### PR TITLE
Develop refactor allen download

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-allensdk==2.15.1
 nibabel==5.1.0
 numpy==1.24.3
 scipy==1.10.1
 SimpleITK==2.2.1
+tqdm==4.65.0

--- a/scripts/linum_download_allen.py
+++ b/scripts/linum_download_allen.py
@@ -7,25 +7,26 @@ Download the Allen mouse brain template, and setting the correct RAS+ direction 
 
 import argparse
 from pathlib import Path
+
 import SimpleITK as sitk
+
 from linumpy.io import allen
 
 
 def _build_arg_parser():
     p = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
-    p.add_argument("output", 
+    p.add_argument("output",
                    help="Output nifti filename")
     p.add_argument("-r", "--resolution", default=100, type=int, choices=allen.AVAILABLE_RESOLUTIONS,
                    help="Template resolution in micron. Default=%(default)s")
-    p.add_argument("--apply_transform", action="store_true", 
-                    help="Apply the transform to align the volume to RAS+ instead of relying only on the volume metadata")
 
     return p
 
+
 def main():
     parser = _build_arg_parser()
-    args = parser.parse_args()  
+    args = parser.parse_args()
 
     # Prepare the output directory
     output = Path(args.output)
@@ -38,18 +39,20 @@ def main():
     output.absolute()
     output.parent.mkdir(exist_ok=True, parents=True)
 
-    vol = allen.download_template(args.resolution, cache=False)
+    vol = allen.download_template(args.resolution, cache=True)
 
     # Preparing the affine to align the template in the RAS+
-    r_mm = args.resolution / 1e3 # Convert the resolution from micron to mm
-    vol.SetSpacing([r_mm]*3) # Set the spacing in mm
-    if args.apply_transform:
-        vol = sitk.PermuteAxes(vol, (2,0,1))
-        vol = sitk.Flip(vol, (False, False, True))
-        vol.SetDirection([1,0,0, 0,1,0, 0,0,1])
-    else:
-        vol.SetDirection([0,0,-1, 1,0,0, 0,-1,0]) # Set the correct axes directions.
+    r_mm = args.resolution / 1e3  # Convert the resolution from micron to mm
+    vol.SetSpacing([r_mm] * 3)  # Set the spacing in mm
+
+    # Apply the transform to RAS
+    vol = sitk.PermuteAxes(vol, (2, 0, 1))
+    vol = sitk.Flip(vol, (False, False, True))
+    vol.SetDirection([1, 0, 0, 0, 1, 0, 0, 0, 1])
+
+    # Save the volume
     sitk.WriteImage(vol, str(output))
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Removing the allensdk requirement by using python `requests` to download the template.