### PR TITLE
Bug fix for the zarr viewer resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ To install the tool for development, clone the repository and then install them 
 pip install -e .
 ```
 
+To use the Napari viewer, you will need to install the following dependencies:
+
+```
+pip install napari[all]
+``` 
 
 We highly recommend working in a [Python Virtual Environment].
 

--- a/scripts/linum_view_zarr.py
+++ b/scripts/linum_view_zarr.py
@@ -14,7 +14,7 @@ def _build_arg_parser():
         description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
     p.add_argument("input_zarr",
                    help="Full path to the Zarr file.")
-    p.add_argument("-r", "--resolution",  nargs=3, type=float, default=[1.0]*3, metavar=('res_z', 'res_x', 'res_y'),
+    p.add_argument("-r", "--resolution",  nargs=3, type=float, default=[1.0]*3, metavar=('z', 'x', 'y'),
                    help="Resolution in micrometer in the Z, X, Y order. For an isotropic resolution, provide a single value. (default=%(default)s)")
 
     return p

--- a/scripts/linum_view_zarr.py
+++ b/scripts/linum_view_zarr.py
@@ -14,7 +14,7 @@ def _build_arg_parser():
         description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
     p.add_argument("input_zarr",
                    help="Full path to the Zarr file.")
-    p.add_argument("-r", "--resolution",  nargs="+", type=float, default=[1.0],
+    p.add_argument("-r", "--resolution",  nargs=3, type=float, default=[1.0]*3, metavar=('res_z', 'res_x', 'res_y'),
                    help="Resolution in micrometer in the Z, X, Y order. For an isotropic resolution, provide a single value. (default=%(default)s)")
 
     return p


### PR DESCRIPTION
The old version of the viewer script needed to be called with the zarr_input followed by the resolution. We can now give the resolution before the zarr_input. We also added instructions in the readme to install napari.