### PR TITLE
Fix for creating all mosaic grids

### DIFF
--- a/scripts/linum_create_all_mosaicgrids.py
+++ b/scripts/linum_create_all_mosaicgrids.py
@@ -43,7 +43,7 @@ def main():
 
     for z in tqdm(slices, desc="Creating mosaic grids", unit="slice", leave=True):
         output_file = f"{output_directory}/mosaic_grid_z{z:02d}{extension}"
-        cmd = f"linum_create_mosaic_grid {input_directory} {output_file} --slice {z} --resolution {resolution} --n_cpus {n_cpus}"
+        cmd = f"linum_create_mosaic_grid.py {input_directory} {output_file} --slice {z} --resolution {resolution} --n_cpus {n_cpus}"
         subprocess.run(cmd, shell=True)
 
 if __name__ == "__main__":


### PR DESCRIPTION
When executing the linum_create_all_mosaicgrids.py from the command line, it crashed for me with the exception that it couldn't execute linum_create_mosaic_grid. I needed to add the extension to get it to work. This might need some testing to confirm this is the new intended behaviour.