### PR TITLE
Changes to facilitate quick data reconstruction during S-OCT acquisition

### DIFF
--- a/linumpy/microscope/oct.py
+++ b/linumpy/microscope/oct.py
@@ -1,3 +1,4 @@
+import warnings
 from pathlib import Path
 from typing import Union
 
@@ -91,8 +92,11 @@ class OCT:
 
         # Estimate the galvo shift
         if isinstance(fix_shift, bool) and fix_shift is True:
-            shift = xyzcorr.detect_galvo_shift(vol.mean(axis=0), n_pixel_return=n_extra)
-            vol = xyzcorr.fix_galvo_shift(vol, shift=shift)
+            if n_extra == 0:
+                warnings.warn("Cannot estimate the shift correction as there are no extra a-lines in the file.")
+            else:
+                shift = xyzcorr.detect_galvo_shift(vol.mean(axis=0), n_pixel_return=n_extra)
+                vol = xyzcorr.fix_galvo_shift(vol, shift=shift)
         elif isinstance(fix_shift, int):
             vol = xyzcorr.fix_galvo_shift(vol, shift=fix_shift)
 

--- a/linumpy/microscope/oct.py
+++ b/linumpy/microscope/oct.py
@@ -53,7 +53,7 @@ class OCT:
                 val = int(val)
             self.info[key] = val
 
-    def load_image(self, crop: bool = True, fix_shift: Union[bool, int] = False) -> np.ndarray:
+    def load_image(self, crop: bool = True, fix_shift: Union[bool, int] = True) -> np.ndarray:
         """ Load an image dataset
         Parameters
         ----------

--- a/linumpy/reconstruction.py
+++ b/linumpy/reconstruction.py
@@ -257,7 +257,7 @@ def quick_stitch(directory, z: int, overlap_fraction: float = 0.2, n_rot: int = 
     return mosaic
 
 
-def detect_mosaic(directory: str, z: int, margin: float = 0.5, display: bool = False, image_file: str = None,
+def detect_mosaic(directory: str, z: int, img: np.ndarray=None,  margin: float = 0.5, display: bool = False, image_file: str = None,
                   roi_file: str = None, keep_largest_island: bool = False):
     """Detect the tissue in the mosaic and compute the limits of the tissue.
     Parameters
@@ -295,7 +295,8 @@ def detect_mosaic(directory: str, z: int, margin: float = 0.5, display: bool = F
     ymax = np.max([p[1] for p in info["tiles_pos_mm"]]) + info["tile_shape_mm"][1] / 2
 
     # Stitch the image using the tile position
-    img = quick_stitch(directory, z=z, use_stage_positions=True)
+    if img is None:
+        img = quick_stitch(directory, z=z, use_stage_positions=True)
 
     # Save the quick stitch image
     if image_file is not None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ ome-zarr>=0.9.0
 napari[all]
 napari-ome-zarr
 pynrrd==1.1.3
+numcodecs<0.16

--- a/scripts/linum_create_mosaic_grid_2d.py
+++ b/scripts/linum_create_mosaic_grid_2d.py
@@ -67,8 +67,8 @@ def get_volume(filename: str, config: dict = None) -> np.ndarray:
     # Get the loading options
     if config is None:
         config = {}
-    crop = config.get("crop", False)
-    fix_shift = config.get("fix_shift", False)
+    crop = config.get("crop", True)
+    fix_shift = config.get("fix_shift", True)
     if fix_shift:
         fix_shift = config.get("shift",
                                True)  # Either a precomputed shift, or a True value to compute it during loading.

--- a/scripts/linum_create_mosaic_grid_2d.py
+++ b/scripts/linum_create_mosaic_grid_2d.py
@@ -1,7 +1,12 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-"""Convert 3D OCT tiles to a 2D mosaic grid"""
+"""Convert 3D OCT tiles to a 2D mosaic grid
+
+Notes
+-----
+- jpg output should only be used for visualization purposes due to loss of data from the 8bit conversion.
+"""
 
 import argparse
 import multiprocessing
@@ -24,7 +29,7 @@ def _build_arg_parser():
     p.add_argument("tiles_directory",
                    help="Full path to a directory containing the tiles to process")
     p.add_argument("output_file",
-                   help="Full path to the output file (tiff or zarr)")
+                   help="Full path to the output file (jpg, tiff, or zarr)")
     p.add_argument("-r", "--resolution", type=float, default=-1,
                    help="Output isotropic resolution in micron per pixel. (Use -1 to keep the original resolution). (default=%(default)s)")
     p.add_argument("-z", "--slice", type=int, default=0,
@@ -77,7 +82,7 @@ def main():
     # Parameters
     tiles_directory = Path(args.tiles_directory)
     output_file = Path(args.output_file)
-    assert output_file.suffix in [".tiff", ".zarr"], "The output file must be a .tiff or .zarr file."
+    assert output_file.suffix in [".jpg", ".tiff", ".zarr"], "The output file must be .jpg, .tiff, or .zarr file."
     if output_file.suffix == ".zarr":
         zarr_file = output_file
     else:
@@ -164,6 +169,16 @@ def main():
         io.imsave(output_file, img)
         shutil.rmtree(zarr_file)
 
+    if output_file.suffix == ".jpg":
+        imin = np.min(mosaic)
+        imax = np.percentile(mosaic, args.saturation)
+        mosaic = (mosaic - imin) / (imax - imin)
+        mosaic[mosaic < 0] = 0
+        mosaic[mosaic > 1] = 1
+        mosaic = (mosaic * 255).astype(np.uint8)
+        img = mosaic[:]
+        io.imsave(output_file, img)
+        shutil.rmtree(zarr_file)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This pull request introduces improvements to the mosaic grid creation workflow and image loading defaults, with a particular focus on supporting `.jpg` output for visualization and updating default behaviors for image processing. The most important changes are grouped below:

**Image Loading Defaults**

* Changed the default value of the `fix_shift` parameter in `OCT.load_image` and related functions to `True`, ensuring image shifts are corrected by default during loading. [[1]](diffhunk://#diff-6f5786b70915eb709e8fe66ebadfa2a96bad53edec8113284834db0615d3f114L56-R56) [[2]](diffhunk://#diff-5d21587c3fe48bd951c548c653d46168d6ae4de3ad6c60cc4e46821774e4a237L67-R71). This is due to a random shift that sometimes occurs between the galvos and the camera. My setting the `fix_shift` parameter to `True` we ensure that this shift is corrected when loading the data. That is a temporary solution while we fix this issue on the hardware side.

**Mosaic Detection and Stitching**

* Updated `detect_mosaic` in `linumpy/reconstruction.py` to accept an optional `img` parameter, allowing pre-stitched images to be passed in and improving flexibility in mosaic generation. [[1]](diffhunk://#diff-28d940828848938a676ef5cc1302f10b65e0aafdd03d7ea1e88ad1674d3d9757L260-R260) [[2]](diffhunk://#diff-28d940828848938a676ef5cc1302f10b65e0aafdd03d7ea1e88ad1674d3d9757R298)

**Script Enhancements and Output Options**

* Added support for `.jpg` output in the mosaic creation script, including normalization and saturation adjustment for visualization purposes, and updated output validation to allow `.jpg` files. [[1]](diffhunk://#diff-5d21587c3fe48bd951c548c653d46168d6ae4de3ad6c60cc4e46821774e4a237L126-R129) [[2]](diffhunk://#diff-5d21587c3fe48bd951c548c653d46168d6ae4de3ad6c60cc4e46821774e4a237R215-R224)
* Clarified documentation in `scripts/linum_create_mosaic_grid_2d.py` to note that `.jpg` output is intended for visualization only and may result in data loss due to 8-bit conversion.
* Updated argument parsing in the mosaic grid script to reflect the new `.jpg` output option.