### PR TITLE
Add centralised thread configuration module

### DIFF
--- a/linumpy/__init__.py
+++ b/linumpy/__init__.py
@@ -1,15 +1,32 @@
+# Configure thread limits FIRST, before any numerical libraries are imported
+import os as _os
+
+from linumpy._thread_config import (
+    configure_thread_limits,
+    apply_threadpool_limits,
+    configure_all_libraries,
+    configure_sitk,
+)
+
+
 def get_home():
-    import os
     """ Set a user-writeable file-system location to put files. """
-    if 'LINUMPY_HOME' in os.environ:
-        return os.environ['LINUMPY_HOME']
-    return os.path.join(os.path.expanduser('~'), '.linumpy')
+    if 'LINUMPY_HOME' in _os.environ:
+        return _os.environ['LINUMPY_HOME']
+    return _os.path.join(_os.path.expanduser('~'), '.linumpy')
 
 
 def get_root():
-    import os
-    return os.path.realpath(f"{os.path.dirname(os.path.abspath(__file__))}/..")
+    return _os.path.realpath(f"{_os.path.dirname(_os.path.abspath(__file__))}/..")
 
 
 LINUMPY_HOME = get_home()
 LINUMPY_ROOT = get_root()
+
+# Apply runtime thread pool limits (for libraries that don't respect env vars)
+apply_threadpool_limits()
+
+# Note: configure_sitk() must be called after SimpleITK is imported.
+# Scripts that use SimpleITK should call:
+#   from linumpy._thread_config import configure_all_libraries
+#   configure_all_libraries()  # after all imports

--- a/linumpy/_thread_config.py
+++ b/linumpy/_thread_config.py
@@ -47,21 +47,18 @@ def get_max_threads():
     """
     total_cpus = multiprocessing.cpu_count()
 
-    # Check for explicit max CPUs limit
-    max_cpus = os.environ.get('LINUMPY_MAX_CPUS')
-    if max_cpus is not None:
-        try:
+    try:
+        # Check for explicit max CPUs limit
+        max_cpus = os.environ.get('LINUMPY_MAX_CPUS')
+        if max_cpus is not None:
             return max(1, min(int(max_cpus), total_cpus))
-        except ValueError:
-            pass
 
-    # Check for reserved CPUs
-    reserved = os.environ.get('LINUMPY_RESERVED_CPUS')
-    if reserved is not None:
-        try:
+        # Check for reserved CPUs
+        reserved = os.environ.get('LINUMPY_RESERVED_CPUS')
+        if reserved is not None:
             return max(1, total_cpus - int(reserved))
-        except ValueError:
-            pass
+    except ValueError:
+        pass
 
     # Default: use all CPUs
     return total_cpus

--- a/linumpy/_thread_config.py
+++ b/linumpy/_thread_config.py
@@ -1,0 +1,305 @@
+# -*- coding: utf-8 -*-
+"""
+Thread configuration module for linumpy.
+
+This module MUST be imported before numpy, scipy, or other numerical libraries
+to ensure thread limits are respected. It is automatically imported by the
+linumpy package __init__.py and can also be imported directly by scripts.
+
+The module configures thread limits for:
+- OpenMP (OMP_NUM_THREADS)
+- Intel MKL (MKL_NUM_THREADS)
+- OpenBLAS (OPENBLAS_NUM_THREADS)
+- macOS Accelerate (VECLIB_MAXIMUM_THREADS)
+- NumExpr (NUMEXPR_NUM_THREADS)
+- Numba (NUMBA_NUM_THREADS)
+- Dask (via dask.config)
+- SimpleITK (via ProcessObject.SetGlobalDefaultNumberOfThreads)
+
+Environment variables (checked in order of precedence):
+1. OMP_NUM_THREADS - if already set, respects it (user/Nextflow override)
+2. LINUMPY_MAX_CPUS - explicit maximum CPUs
+3. LINUMPY_RESERVED_CPUS - CPUs to reserve for overhead
+
+Known gaps that can cause CPU usage spikes:
+1. SimpleITK spawns its own thread pool - configure_sitk() must be called after import
+2. Subprocess workers (pqdm, multiprocessing.Pool) re-import libraries
+3. Some libraries ignore environment variables set after import
+4. CuPy/GPU operations don't respect CPU thread limits
+
+To ensure proper limiting, scripts should call configure_all_libraries() after imports.
+"""
+
+import multiprocessing
+import os
+import sys
+
+# Track if we've already configured
+_thread_config_applied = False
+
+
+def get_max_threads():
+    """
+    Calculate the maximum number of threads to use based on environment variables.
+
+    Returns:
+        int: Maximum number of threads to use
+    """
+    total_cpus = multiprocessing.cpu_count()
+
+    # Check for explicit max CPUs limit
+    max_cpus = os.environ.get('LINUMPY_MAX_CPUS')
+    if max_cpus is not None:
+        try:
+            return max(1, min(int(max_cpus), total_cpus))
+        except ValueError:
+            pass
+
+    # Check for reserved CPUs
+    reserved = os.environ.get('LINUMPY_RESERVED_CPUS')
+    if reserved is not None:
+        try:
+            return max(1, total_cpus - int(reserved))
+        except ValueError:
+            pass
+
+    # Default: use all CPUs
+    return total_cpus
+
+
+def configure_thread_limits():
+    """
+    Configure thread limits for numerical libraries.
+
+    This function sets environment variables that control threading in
+    numpy, scipy, and other numerical libraries. It must be called
+    BEFORE these libraries are imported to be effective.
+
+    If OMP_NUM_THREADS is already set (e.g., by Nextflow beforeScript),
+    this function will still set the other threading variables to match.
+    """
+    # Calculate the thread limit
+    max_threads = get_max_threads()
+
+    # If OMP_NUM_THREADS is already set, use that value instead
+    if 'OMP_NUM_THREADS' in os.environ:
+        try:
+            max_threads = int(os.environ['OMP_NUM_THREADS'])
+        except ValueError:
+            pass
+
+    # Set environment variables for all common threading libraries
+    # Set ALL of them unconditionally to ensure consistency
+    thread_vars = [
+        'OMP_NUM_THREADS',  # OpenMP (used by numpy, scipy, etc.)
+        'MKL_NUM_THREADS',  # Intel MKL
+        'OPENBLAS_NUM_THREADS',  # OpenBLAS
+        'VECLIB_MAXIMUM_THREADS',  # macOS Accelerate
+        'NUMEXPR_NUM_THREADS',  # NumExpr
+        'NUMBA_NUM_THREADS',  # Numba
+        'GOTO_NUM_THREADS',  # GotoBLAS
+        'BLIS_NUM_THREADS',  # BLIS
+        'ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS',  # SimpleITK/ITK
+        'XLA_FLAGS',  # JAX/XLA thread pool (set below with special format)
+    ]
+
+    for var in thread_vars:
+        if var == 'XLA_FLAGS':
+            # XLA flags use a special format
+            # This limits JAX's XLA thread pool (used by BaSiCPy)
+            xla_flags = os.environ.get('XLA_FLAGS', '')
+            if f'--xla_cpu_multi_thread_eigen=false' not in xla_flags:
+                # Disable multi-threading in XLA's Eigen backend for better control
+                new_flags = f'{xla_flags} --xla_cpu_multi_thread_eigen=false intra_op_parallelism_threads={max_threads}'.strip()
+                os.environ['XLA_FLAGS'] = new_flags
+        else:
+            os.environ[var] = str(max_threads)
+
+    # Also set dask configuration via environment variable
+    # This limits dask's thread pool before dask is imported
+    os.environ['DASK_NUM_WORKERS'] = str(max_threads)
+
+    return max_threads
+
+
+def configure_dask():
+    """
+    Configure dask's thread pool after dask is imported.
+    Call this after dask has been imported.
+    """
+    try:
+        import dask
+        max_threads = int(os.environ.get('OMP_NUM_THREADS', multiprocessing.cpu_count()))
+        dask.config.set(num_workers=max_threads)
+        dask.config.set(scheduler='threads')  # Use thread scheduler, not process
+        dask.config.set({'array.slicing.split_large_chunks': False})
+    except ImportError:
+        pass
+
+
+def configure_sitk():
+    """
+    Configure SimpleITK's global thread pool.
+    Call this after SimpleITK has been imported.
+
+    NOTE: This is a major source of CPU oversubscription! SimpleITK's
+    ImageRegistrationMethod and other filters spawn their own thread pools
+    that ignore environment variables.
+    """
+    try:
+        import SimpleITK as sitk
+        max_threads = int(os.environ.get('OMP_NUM_THREADS', multiprocessing.cpu_count()))
+        sitk.ProcessObject.SetGlobalDefaultNumberOfThreads(max_threads)
+    except ImportError:
+        pass
+
+
+def apply_threadpool_limits():
+    """
+    Apply thread limits using threadpoolctl after libraries are loaded.
+
+    This provides runtime control over thread pools that may not respect
+    environment variables. Call this after numpy/scipy are imported.
+
+    Returns:
+        threadpoolctl.ThreadpoolController context or None if not available
+    """
+    try:
+        from threadpoolctl import threadpool_limits
+
+        # Get the configured thread limit
+        max_threads = int(os.environ.get('OMP_NUM_THREADS', multiprocessing.cpu_count()))
+
+        # Apply limits globally - this returns a context manager but also applies immediately
+        limiter = threadpool_limits(limits=max_threads)
+        return limiter
+    except ImportError:
+        return None
+
+
+def configure_all_libraries():
+    """
+    Configure thread limits for ALL known libraries that have been imported.
+
+    This is the most comprehensive approach - call this after all imports
+    are complete to ensure all libraries respect the thread limits.
+
+    This addresses the following gaps:
+    1. SimpleITK's internal thread pool (major source of CPU spikes)
+    2. Dask's scheduler configuration
+    3. Runtime threadpool limiting via threadpoolctl
+    4. Numba's thread pool
+
+    Returns:
+        int: The configured thread limit
+    """
+    global _thread_config_applied
+
+    max_threads = int(os.environ.get('OMP_NUM_THREADS', multiprocessing.cpu_count()))
+
+    # Configure SimpleITK if imported (CRITICAL - major source of CPU spikes)
+    if 'SimpleITK' in sys.modules:
+        configure_sitk()
+
+    # Configure dask if imported
+    if 'dask' in sys.modules:
+        configure_dask()
+
+    # Configure numba if imported
+    if 'numba' in sys.modules:
+        try:
+            from numba import set_num_threads
+            set_num_threads(max_threads)
+        except (ImportError, Exception):
+            pass
+
+    # Apply threadpoolctl limits (catches numpy, scipy, etc.)
+    apply_threadpool_limits()
+
+    _thread_config_applied = True
+    return max_threads
+
+
+def get_thread_info():
+    """
+    Get diagnostic information about current thread configuration.
+    Useful for debugging CPU usage issues.
+
+    Returns:
+        dict: Thread configuration information
+    """
+    info = {
+        'total_cpus': multiprocessing.cpu_count(),
+        'configured_threads': int(os.environ.get('OMP_NUM_THREADS', multiprocessing.cpu_count())),
+        'env_vars': {},
+        'libraries': {},
+    }
+
+    # Check environment variables
+    for var in ['OMP_NUM_THREADS', 'MKL_NUM_THREADS', 'OPENBLAS_NUM_THREADS',
+                'LINUMPY_MAX_CPUS', 'LINUMPY_RESERVED_CPUS']:
+        info['env_vars'][var] = os.environ.get(var, 'NOT SET')
+
+    # Check SimpleITK
+    if 'SimpleITK' in sys.modules:
+        try:
+            import SimpleITK as sitk
+            info['libraries']['SimpleITK'] = sitk.ProcessObject.GetGlobalDefaultNumberOfThreads()
+        except Exception:
+            info['libraries']['SimpleITK'] = 'ERROR'
+
+    # Check threadpoolctl
+    try:
+        from threadpoolctl import threadpool_info
+        info['libraries']['threadpoolctl'] = threadpool_info()
+    except ImportError:
+        info['libraries']['threadpoolctl'] = 'NOT INSTALLED'
+
+    return info
+
+
+def print_thread_info():
+    """Print thread configuration for debugging."""
+    info = get_thread_info()
+    print(f"CPU cores: {info['total_cpus']}")
+    print(f"Configured threads: {info['configured_threads']}")
+    print("Environment variables:")
+    for var, val in info['env_vars'].items():
+        print(f"  {var}: {val}")
+    print("Library configurations:")
+    for lib, val in info['libraries'].items():
+        print(f"  {lib}: {val}")
+
+
+def worker_initializer():
+    """
+    Initializer function for multiprocessing workers.
+
+    Use this as the `initializer` argument for multiprocessing.Pool or
+    concurrent.futures.ProcessPoolExecutor to ensure worker processes
+    respect thread limits.
+
+    Example:
+        from multiprocessing import Pool
+        from linumpy._thread_config import worker_initializer
+
+        with Pool(n_workers, initializer=worker_initializer) as pool:
+            results = pool.map(my_function, data)
+
+    This is crucial because:
+    1. Child processes inherit environment variables but re-import libraries
+    2. Libraries like SimpleITK need explicit configuration after import
+    3. threadpoolctl limits need to be reapplied in each worker
+    """
+    # Re-run the initial configuration
+    configure_thread_limits()
+
+    # Apply runtime limits
+    apply_threadpool_limits()
+
+    # Configure any imported libraries in this worker
+    configure_all_libraries()
+
+
+# Configure thread limits immediately when this module is imported
+_configured_threads = configure_thread_limits()

--- a/linumpy/io/zarr.py
+++ b/linumpy/io/zarr.py
@@ -359,9 +359,12 @@ class OmeZarrWriter:
         self.shape = shape
         self.downscale_factor = downscale_factor
 
-        if os.path.exists(store_path):
+        if os.path.exists(store_path) or os.path.islink(store_path):
             if overwrite:
-                shutil.rmtree(store_path)
+                if os.path.islink(store_path):
+                    os.unlink(store_path)
+                else:
+                    shutil.rmtree(store_path)
             else:
                 raise ValueError(f"Overwrite set to False and {store_path} non-empty.")
 

--- a/linumpy/io/zarr.py
+++ b/linumpy/io/zarr.py
@@ -15,6 +15,11 @@ from ome_zarr.scale import Scaler
 from ome_zarr.writer import write_image, write_multiscales_metadata
 from skimage.transform import resize
 
+# Configure dask thread pool based on environment variables
+from linumpy._thread_config import configure_dask
+
+configure_dask()
+
 """
     This file contains functions for working with zarr files
 """
@@ -168,7 +173,17 @@ def generate_axes_dict(ndims=3, unit="millimeter"):
 
 def create_directory(store_path, overwrite=False):
     directory = Path(store_path)
-    if directory.exists():
+    # Check for symlink first: is_symlink() is True even for dangling symlinks,
+    # while exists() follows the link and returns False for dangling ones.
+    # shutil.rmtree raises OSError on symlinks, so handle them separately.
+    if directory.is_symlink():
+        if overwrite:
+            directory.unlink()  # Remove the symlink only; target is NOT deleted
+        else:
+            raise FileExistsError('Path {} already exists as a symlink. '
+                                  'Set overwrite=True to overwrite.'
+                                  .format(directory.as_posix()))
+    elif directory.exists():
         if overwrite:
             shutil.rmtree(directory)
         else:
@@ -193,6 +208,7 @@ def validate_n_levels(n_levels, shape, downscale_factor=2):
     :type adjusted_n_levels: int
     :return adjusted_n_levels: Adjusted n_levels such that we don't exceed volume shape.
     """
+
     def logn(arr, n):
         return np.log2(arr) / np.log2(n)
 
@@ -424,6 +440,16 @@ class OmeZarrWriter:
         return self.zarray.dtype
 
     def finalize(self, res, n_levels=5):
+        """
+        Finalize the OME-Zarr with traditional power-of-2 pyramid levels.
+        
+        Parameters
+        ----------
+        res : list of float
+            Resolution in mm for each axis (e.g., [0.01, 0.01, 0.01] for 10 µm isotropic)
+        n_levels : int
+            Number of pyramid levels (default: 5). Each level is 2x downsampled.
+        """
         n_levels = validate_n_levels(n_levels, self.shape, self.downscale_factor)
         paths = [f"{i}" for i in range(n_levels + 1)]
         self._downsample_pyramid_on_disk(self.root, paths)
@@ -441,6 +467,211 @@ class OmeZarrWriter:
             "method": "ome_zarr.scale.Scaler",
             "version": ome_zarr_version,
             "args": pyramid_kw
+        }
+
+        write_multiscales_metadata(self.root, datasets, axes=self.axes, metadata=metadata)
+
+
+class AnalysisOmeZarrWriter(OmeZarrWriter):
+    """
+    OmeZarrWriter subclass that supports custom analysis-friendly resolution pyramids.
+    
+    This class extends OmeZarrWriter to create pyramid levels at specific target
+    resolutions (e.g., 10, 25, 50, 100 µm) instead of traditional power-of-2
+    downsampling. This is useful for creating output volumes optimized for
+    downstream analysis at specific scales.
+    
+    Example
+    -------
+    >>> writer = AnalysisOmeZarrWriter("output.ome.zarr", shape, chunks, dtype=np.float32)
+    >>> writer[:] = data  # Write data at full resolution
+    >>> writer.finalize(base_res, [10, 25, 50, 100])
+    
+    Notes
+    -----
+    - Use `finalize()` for traditional power-of-2 pyramids (inherited from OmeZarrWriter)
+    - Use `finalize_with_resolutions()` for custom analysis-friendly resolutions
+    """
+
+    def _downsample_to_resolution(self, parent, source_path, target_path, target_shape):
+        """
+        Downsample from source_path to target_path with specific target shape.
+        """
+        group_path = str(parent.store_path)
+        # Remove file:// prefix if present (from zarr URL format)
+        if group_path.startswith("file://"):
+            group_path = group_path[7:]
+        img_path = parent.store_path / parent.path
+        image_path = os.path.join(group_path, parent.path)
+
+        full_target_path = os.path.join(image_path, target_path)
+        if os.path.exists(full_target_path):
+            print(f"Path exists: {full_target_path}")
+            return
+
+        # Open source from disk via dask
+        path_to_array = os.path.join(image_path, source_path)
+        dask_image = da.from_zarr(path_to_array)
+
+        output = da_resize(
+            dask_image, tuple(target_shape), preserve_range=True, anti_aliasing=True
+        )
+
+        options = {}
+        if self.fmt.zarr_format == 2:
+            options["dimension_separator"] = "/"
+        else:
+            options["chunk_key_encoding"] = self.fmt.chunk_key_encoding
+            options["dimension_names"] = [axis["name"] for axis in self.axes]
+
+        da.to_zarr(
+            arr=output, url=img_path, component=target_path,
+            zarr_format=self.fmt.zarr_format, **options
+        )
+
+    def finalize(self, res, target_resolutions_um=(10, 25, 50, 100), n_levels=None,
+                 make_isotropic=True):
+        """
+        Finalize the OME-Zarr with pyramid levels.
+        
+        Parameters
+        ----------
+        res : list of float
+            Base resolution in mm (e.g., [0.01, 0.01, 0.01] for 10 µm isotropic,
+            or [0.0015, 0.01, 0.01] for anisotropic z=1.5µm, xy=10µm)
+        target_resolutions_um : list of float, optional
+            Target resolutions in microns (default: [10, 25, 50, 100]).
+            Ignored if n_levels is specified.
+        n_levels : int, optional
+            If specified, uses traditional power-of-2 downsampling instead of
+            custom resolutions (backward compatible with OmeZarrWriter).
+        make_isotropic : bool, optional
+            If True (default), resamples anisotropic data to produce isotropic
+            voxels at each target resolution. Each dimension is scaled independently
+            to achieve the target resolution.
+            If False, preserves the original aspect ratio by scaling all dimensions
+            uniformly based on the finest (smallest) base resolution.
+            
+        Notes
+        -----
+        By default, creates pyramid levels at specific analysis-friendly
+        resolutions (e.g., 10, 25, 50, 100 µm). If n_levels is provided,
+        falls back to traditional power-of-2 downsampling for backward
+        compatibility.
+        
+        Examples
+        --------
+        For anisotropic data with base resolution [1.5, 10, 10] µm targeting 25 µm:
+        
+        With make_isotropic=True (default):
+            - Scale factors: [16.67, 2.5, 2.5] (per-dimension)
+            - Output: isotropic 25 µm voxels
+            - Shape aspect ratio changes
+            
+        With make_isotropic=False:
+            - Scale factor: 16.67 (uniform, based on finest dimension 1.5 µm)
+            - Output: anisotropic [25, 167, 167] µm voxels
+            - Shape aspect ratio preserved
+        """
+        # Backward compatibility: if n_levels is specified, use parent's power-of-2 method
+        if n_levels is not None:
+            super().finalize(res, n_levels)
+            return
+        # Convert base resolution to microns
+        base_res_um = [r * 1000 for r in res]  # mm to µm
+        min_base_res_um = min(base_res_um)
+
+        # Filter target resolutions to only include those >= finest base resolution
+        valid_targets = sorted([t for t in target_resolutions_um if t >= min_base_res_um])
+
+        if not valid_targets:
+            print(f"WARNING: No valid target resolutions. Base resolution is {base_res_um} µm")
+            # Fall back to parent's power-of-2 finalize with no levels
+            super().finalize(res, n_levels=0)
+            return
+
+        # Inform user about anisotropic handling
+        is_anisotropic = max(base_res_um) / min_base_res_um > 1.1  # 10% threshold
+        if is_anisotropic:
+            if make_isotropic:
+                print(f"Creating ISOTROPIC pyramid from anisotropic data")
+                print(f"  Base resolution: {base_res_um} µm (anisotropic)")
+                print(f"  Output: isotropic voxels at {valid_targets} µm")
+            else:
+                print(f"Creating pyramid PRESERVING ASPECT RATIO")
+                print(f"  Base resolution: {base_res_um} µm (anisotropic)")
+                print(f"  Scaling uniformly based on finest dimension ({min_base_res_um} µm)")
+        else:
+            print(f"Creating pyramid with target resolutions: {valid_targets} µm")
+
+        paths = []
+        resolutions = []
+
+        # Get the path to level 0 (base resolution) for downsampling source
+        # Remove file:// prefix if present (from zarr URL format)
+        group_path = str(self.root.store_path)
+        if group_path.startswith("file://"):
+            group_path = group_path[7:]  # Remove "file://" prefix
+
+        for i, target_um in enumerate(valid_targets):
+            path = f"{i}"
+            paths.append(path)
+
+            if make_isotropic:
+                # Per-dimension scaling to achieve isotropic target resolution
+                # Each dimension scales independently to reach the target resolution
+                scale_factors = [target_um / base_res_um_d for base_res_um_d in base_res_um]
+            else:
+                # Uniform scaling to preserve aspect ratio
+                # All dimensions scale by the same factor based on finest resolution
+                uniform_scale = target_um / min_base_res_um
+                scale_factors = [uniform_scale] * len(base_res_um)
+
+            # Calculate target shape using scale factors
+            target_shape = [max(1, int(s / sf)) for s, sf in zip(self.shape, scale_factors)]
+
+            # Calculate target resolution per-dimension
+            target_res_mm = [r * sf for r, sf in zip(res, scale_factors)]
+            resolutions.append(target_res_mm)
+
+            # Display resolution info
+            target_res_um = [r * 1000 for r in target_res_mm]
+            if make_isotropic or not is_anisotropic:
+                print(f"  Level {i}: {target_um} µm -> shape {target_shape}")
+            else:
+                print(f"  Level {i}: {target_res_um} µm -> shape {target_shape}")
+
+            if i == 0:
+                # For level 0, we need to replace the base resolution data
+                # First downsample to a temp location, then replace
+                temp_path = f"_temp_{i}"
+                self._downsample_to_resolution(self.root, "0", temp_path, target_shape)
+
+                # Remove original level 0 and rename temp
+                original_path = os.path.join(group_path, self.root.path, "0")
+                temp_full_path = os.path.join(group_path, self.root.path, temp_path)
+
+                if os.path.exists(original_path):
+                    shutil.rmtree(original_path)
+                shutil.move(temp_full_path, original_path)
+            else:
+                # For other levels, downsample from the new level 0
+                self._downsample_to_resolution(self.root, "0", path, target_shape)
+
+        # Create transformation metadata
+        datasets = []
+        for path, res_mm in zip(paths, resolutions):
+            transforms = [{"type": "scale", "scale": res_mm}]
+            datasets.append({"path": path, "coordinateTransformations": transforms})
+
+        ome_zarr_version = version("ome-zarr")
+        metadata = {
+            "method": "custom_resolution_pyramid",
+            "version": ome_zarr_version,
+            "args": {
+                "target_resolutions_um": valid_targets,
+                "make_isotropic": make_isotropic
+            }
         }
 
         write_multiscales_metadata(self.root, datasets, axes=self.axes, metadata=metadata)

--- a/scripts/linum_aip.py
+++ b/scripts/linum_aip.py
@@ -3,6 +3,9 @@
 
 """Compute the average intensity projection of a 3D zarr volume."""
 
+# Configure thread limits before numpy/scipy imports
+import linumpy._thread_config  # noqa: F401
+
 import argparse
 from pathlib import Path
 import dask.array as da

--- a/scripts/linum_apply_slices_transforms.py
+++ b/scripts/linum_apply_slices_transforms.py
@@ -2,6 +2,9 @@
 """
 Apply corrections from linum_estimate_slices_transforms_gui.py to volume.
 """
+# Configure thread limits before numpy/scipy imports
+import linumpy._thread_config  # noqa: F401
+
 import argparse
 import zarr
 import numpy as np

--- a/scripts/linum_axis_XYZ_to_ZYX.py
+++ b/scripts/linum_axis_XYZ_to_ZYX.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
+# Configure thread limits before numpy/scipy imports
+import linumpy._thread_config  # noqa: F401
+
 import nibabel as nib
 import numpy as np
 import argparse

--- a/scripts/linum_clip_percentile.py
+++ b/scripts/linum_clip_percentile.py
@@ -3,6 +3,9 @@
 """
 Clip .ome.zarr volume intensities between lower and upper percentile.
 """
+# Configure thread limits before numpy/scipy imports
+import linumpy._thread_config  # noqa: F401
+
 import argparse
 import numpy as np
 

--- a/scripts/linum_compensate_attenuation.py
+++ b/scripts/linum_compensate_attenuation.py
@@ -5,6 +5,9 @@ Compensate the tissue attenuation using a precomputed attenuation
 bias field.
 """
 
+# Configure thread limits before numpy/scipy imports
+import linumpy._thread_config  # noqa: F401
+
 import argparse
 import dask.array as da
 

--- a/scripts/linum_compensate_illumination.py
+++ b/scripts/linum_compensate_illumination.py
@@ -3,6 +3,9 @@
 
 """Uses the BaSiC algorithm to estimate and compensate illumination inhomogeneities in a mosaic grid"""
 
+# Configure thread limits before numpy/scipy imports
+import linumpy._thread_config  # noqa: F401
+
 import argparse
 from pathlib import Path
 

--- a/scripts/linum_compensate_psf_from_model.py
+++ b/scripts/linum_compensate_psf_from_model.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# Configure thread limits before numpy/scipy imports
+import linumpy._thread_config  # noqa: F401
+
 import argparse
 import numpy as np
 from linumpy.io.zarr import read_omezarr, save_omezarr

--- a/scripts/linum_compute_attenuation.py
+++ b/scripts/linum_compute_attenuation.py
@@ -5,6 +5,9 @@
 and then use the average attenuation to compensate its effect in
 the OCT reflectivity data.
 """
+# Configure thread limits before numpy/scipy imports
+import linumpy._thread_config  # noqa: F401
+
 # TODO: Keep the OCT pixel format (which is float32 ?)
 import argparse
 

--- a/scripts/linum_compute_attenuation_bias_field.py
+++ b/scripts/linum_compute_attenuation_bias_field.py
@@ -3,6 +3,9 @@
 
 """Compute the tissue attenuation compensation bias field"""
 
+# Configure thread limits before numpy/scipy imports
+import linumpy._thread_config  # noqa: F401
+
 import argparse
 
 import numpy as np

--- a/scripts/linum_convert_bin_to_nii.py
+++ b/scripts/linum_convert_bin_to_nii.py
@@ -5,6 +5,9 @@
 Convert OCT raw binary data to nifti
 """
 
+# Configure thread limits before numpy/scipy imports
+import linumpy._thread_config  # noqa: F401
+
 import argparse
 from pathlib import Path
 

--- a/scripts/linum_convert_nifti_to_nrrd.py
+++ b/scripts/linum_convert_nifti_to_nrrd.py
@@ -3,6 +3,9 @@
 
 """Convert a nifti volume into a nrrd volume"""
 
+# Configure thread limits before numpy/scipy imports
+import linumpy._thread_config  # noqa: F401
+
 import argparse
 
 import dask.array as da

--- a/scripts/linum_convert_nifti_to_zarr.py
+++ b/scripts/linum_convert_nifti_to_zarr.py
@@ -3,6 +3,9 @@
 
 """Convert a nifti volume into a .zarr volume"""
 
+# Configure thread limits before numpy/scipy imports
+import linumpy._thread_config  # noqa: F401
+
 import argparse
 
 import dask.array as da

--- a/scripts/linum_convert_omezarr_to_nifti.py
+++ b/scripts/linum_convert_omezarr_to_nifti.py
@@ -3,6 +3,9 @@
 
 """Convert an ome-zarr volume into a nifti volume at a given resolution."""
 
+# Configure thread limits before numpy/scipy imports
+import linumpy._thread_config  # noqa: F401
+
 import argparse
 from pathlib import Path
 

--- a/scripts/linum_convert_tiff_to_nifti.py
+++ b/scripts/linum_convert_tiff_to_nifti.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
+# Configure thread limits before numpy/scipy imports
+import linumpy._thread_config  # noqa: F401
+
 import os
 import argparse
 import SimpleITK as sitk

--- a/scripts/linum_convert_tiff_to_omezarr.py
+++ b/scripts/linum_convert_tiff_to_omezarr.py
@@ -17,6 +17,9 @@ If there are more than one channel, file structure should be
     │   └── ...
     └── ...
 """
+# Configure thread limits before numpy/scipy imports
+import linumpy._thread_config  # noqa: F401
+
 import argparse
 from glob import glob
 import logging

--- a/scripts/linum_convert_zarr_to_omezarr.py
+++ b/scripts/linum_convert_zarr_to_omezarr.py
@@ -3,6 +3,9 @@
 
 """Convert a zarr file to an ome-zarr file"""
 
+# Configure thread limits before numpy/scipy imports
+import linumpy._thread_config  # noqa: F401
+
 import argparse
 
 import zarr

--- a/scripts/linum_create_all_mosaic_grids_2d.py
+++ b/scripts/linum_create_all_mosaic_grids_2d.py
@@ -3,6 +3,9 @@
 
 """Convert all 3D OCT tiles in a directory to 2D mosaic grids"""
 
+# Configure thread limits before numpy/scipy imports
+import linumpy._thread_config  # noqa: F401
+
 import argparse
 import subprocess
 from tqdm.auto import tqdm

--- a/scripts/linum_crop_tiles.py
+++ b/scripts/linum_crop_tiles.py
@@ -3,6 +3,9 @@
 
 """Crop the tiles given a 2D mosaic grid."""
 
+# Configure thread limits before numpy/scipy imports
+import linumpy._thread_config  # noqa: F401
+
 import argparse
 from pathlib import Path
 import SimpleITK as sitk

--- a/scripts/linum_detect_focal_curvature.py
+++ b/scripts/linum_detect_focal_curvature.py
@@ -3,6 +3,9 @@
 
 """Detect and fix the focal curvature in a 3D mosaic grid"""
 
+# Configure thread limits before numpy/scipy imports
+import linumpy._thread_config  # noqa: F401
+
 import argparse
 
 import numpy as np

--- a/scripts/linum_estimate_illumination.py
+++ b/scripts/linum_estimate_illumination.py
@@ -3,6 +3,9 @@
 
 """Uses the BaSiC algorithm to estimate the illumination inhomogeneities in a mosaic grid"""
 
+# Configure thread limits before numpy/scipy imports
+import linumpy._thread_config  # noqa: F401
+
 import argparse
 import random
 

--- a/scripts/linum_estimate_slices_transforms_gui.py
+++ b/scripts/linum_estimate_slices_transforms_gui.py
@@ -8,6 +8,9 @@ minimum and maximum values to the range [0, 1]. When launched, a matplotlib
 window opens, enabling the user to manipulate the slices as they wish. The
 resulting transformations are saved as soon as the window is closed.
 """
+# Configure thread limits before numpy/scipy imports
+import linumpy._thread_config  # noqa: F401
+
 import argparse
 import zarr
 import numpy as np

--- a/scripts/linum_estimate_xy_shift_from_metadata.py
+++ b/scripts/linum_estimate_xy_shift_from_metadata.py
@@ -3,6 +3,9 @@
 
 """Estimate the mosaic grid positions from the tiles metadata"""
 
+# Configure thread limits before numpy/scipy imports
+import linumpy._thread_config  # noqa: F401
+
 import argparse
 import csv
 from pathlib import Path

--- a/scripts/linum_intensity_normalization.py
+++ b/scripts/linum_intensity_normalization.py
@@ -3,6 +3,9 @@
 
 """Normalize the intensity in a given nifty image"""
 
+# Configure thread limits before numpy/scipy imports
+import linumpy._thread_config  # noqa: F401
+
 import nibabel as nib
 import numpy as np
 import numpy as np

--- a/scripts/linum_merge_slices_into_folders.py
+++ b/scripts/linum_merge_slices_into_folders.py
@@ -3,6 +3,9 @@
 """
 Move slices from a flat directory into subdirectories based on their names.
 """
+# Configure thread limits before numpy/scipy imports
+import linumpy._thread_config  # noqa: F401
+
 import argparse
 import filecmp
 import re

--- a/scripts/linum_reorient_nifti_to_ras.py
+++ b/scripts/linum_reorient_nifti_to_ras.py
@@ -7,6 +7,9 @@
  The script will estimate the main axis of the volume and reorient it to RAS+. Currently, the script only
  performs 90° rotations and flips."""
 
+# Configure thread limits before numpy/scipy imports
+import linumpy._thread_config  # noqa: F401
+
 import argparse
 from pathlib import Path
 

--- a/scripts/linum_resample.py
+++ b/scripts/linum_resample.py
@@ -3,6 +3,9 @@
 
 """Resample a nifti volume to a given resolution."""
 
+# Configure thread limits before numpy/scipy imports
+import linumpy._thread_config  # noqa: F401
+
 from pathlib import Path
 
 import argparse

--- a/scripts/linum_segment_brain_3d.py
+++ b/scripts/linum_segment_brain_3d.py
@@ -3,6 +3,9 @@
 
 """Segment the brain from a 3D volume using a threshold and morphological operations."""
 
+# Configure thread limits before numpy/scipy imports
+import linumpy._thread_config  # noqa: F401
+
 import argparse
 from pathlib import Path
 

--- a/scripts/linum_stack_slices.py
+++ b/scripts/linum_stack_slices.py
@@ -3,6 +3,9 @@
 
 """Stack 2D mosaics into a single volume."""
 
+# Configure thread limits before numpy/scipy imports
+import linumpy._thread_config  # noqa: F401
+
 import argparse
 import re
 import shutil

--- a/scripts/linum_stitch_2d.py
+++ b/scripts/linum_stitch_2d.py
@@ -4,6 +4,9 @@
 """Stitch a 2D mosaic grid.
 """
 
+# Configure thread limits before numpy/scipy imports
+import linumpy._thread_config  # noqa: F401
+
 import argparse
 from pathlib import Path
 

--- a/scripts/linum_view_oct_raw_tile.py
+++ b/scripts/linum_view_oct_raw_tile.py
@@ -3,6 +3,9 @@
 
 """View an OCT tile in 3D using napari."""
 
+# Configure thread limits before numpy/scipy imports
+import linumpy._thread_config  # noqa: F401
+
 import argparse
 
 import napari

--- a/scripts/linum_view_omezarr.py
+++ b/scripts/linum_view_omezarr.py
@@ -3,6 +3,9 @@
 
 """View an ome-zarr file with napari."""
 
+# Configure thread limits before numpy/scipy imports
+import linumpy._thread_config  # noqa: F401
+
 import argparse
 from ome_zarr.io import parse_url
 from ome_zarr.reader import Reader

--- a/scripts/linum_view_zarr.py
+++ b/scripts/linum_view_zarr.py
@@ -3,6 +3,9 @@
 
 """View a Zarr file with napari."""
 
+# Configure thread limits before numpy/scipy imports
+import linumpy._thread_config  # noqa: F401
+
 import argparse
 
 import napari


### PR DESCRIPTION
## Summary

Many numerical libraries (NumPy, SciPy, Dask, SimpleITK, JAX) spawn their own thread pools and do not respect each other's limits, causing resource contention on shared HPC nodes.

This PR introduces `linumpy/_thread_config.py`, a single module that reads `OMP_NUM_THREADS`, `LINUMPY_MAX_CPUS`, and `LINUMPY_RESERVED_CPUS` from the environment and applies consistent thread limits across all supported libraries at import time.

## Changes

- New `linumpy/_thread_config.py` — thread limit management with `configure_thread_limits()`, `apply_threadpool_limits()`, `configure_sitk()`, `configure_dask()`, `configure_all_libraries()`
- `linumpy/__init__.py` — imports and calls `apply_threadpool_limits()` at package init
- `linumpy/io/zarr.py` — calls `configure_dask()` at module load
- ~30 existing scripts — each gains the 3-line guard:
  ```python
  # Configure thread limits before numpy/scipy imports
  import linumpy._thread_config  # noqa: F401
  ```

## Testing

Existing tests pass. Thread limits can be verified by setting `LINUMPY_MAX_CPUS=2` before running any script.

---

> **Merge order:** This PR must be merged **first** — all other PRs in this series depend on this module.