### PR TITLE
feat: slice interpolation for missing sections (z-morph)

### DIFF
--- a/linumpy/mosaic/interpolation.py
+++ b/linumpy/mosaic/interpolation.py
@@ -1,6 +1,6 @@
 """Slice interpolation utilities for missing serial sections.
 
-Single strategy: :func:`interpolate_z_morph` -- z-aware morphing via fractional
+Single strategy: :func:`interpolate_z_morph` — z-aware morphing via fractional
 affine warps (``T**alpha``, :func:`scipy.linalg.fractional_matrix_power`).
 Reconstructs a synthetic slice that transitions along Z from ``vol_before[-1]``
 to ``vol_after[0]``, matching the physical geometry of serial sectioning.
@@ -9,7 +9,7 @@ When any quality gate fails, :func:`interpolate_z_morph` **does not fabricate
 a volume**. It returns ``(None, diagnostics)`` with
 ``diagnostics["interpolation_failed"] = True`` and a specific
 ``fallback_reason``. The caller must honour this by *not* emitting a
-reconstructed slice -- a blend of the two neighbours would also be
+reconstructed slice — a blend of the two neighbours would also be
 fabricated data, with the added failure mode of ghost/double-contour
 artefacts whenever the two neighbours differ.
 
@@ -25,6 +25,8 @@ See ``docs/SLICE_INTERPOLATION_FEATURE.md`` for the scientific rationale,
 failure modes, and the connection to ``slice_config.csv`` (``interpolated``,
 ``interpolation_failed``, ``interpolation_fallback_reason`` columns).
 """
+
+from __future__ import annotations
 
 import logging
 from typing import Any
@@ -145,7 +147,7 @@ def _fractional_affine_parts(
     dim = matrix.shape[0]
     identity = np.eye(dim)
 
-    # Exact shortcuts for alpha∈{0, 1} -- avoids numerical drift from
+    # Exact shortcuts for alpha∈{0, 1} — avoids numerical drift from
     # fractional_matrix_power that would move identity pixels around and
     # break the "boundary planes match sources exactly" guarantee.
     if alpha == 0.0:
@@ -241,7 +243,7 @@ def find_best_overlap_planes(
     roi = (slice(margin, h - margin), slice(margin, w - margin))
     # Normalise on the ROI (not the full plane) so the resulting arrays are
     # zero-mean / unit-std over the region that actually goes into the NCC.
-    # Normalising on the full plane -- where OCT backgrounds are mostly zero --
+    # Normalising on the full plane — where OCT backgrounds are mostly zero —
     # leaves the central tissue ROI with a strongly positive mean, which
     # inflates `mean(a*b)` well beyond the [-1, 1] range expected for NCC.
     before_norms = {z: _normalize_plane_for_ncc(vol_before[z][roi]) for z in before_zs}
@@ -403,7 +405,7 @@ def interpolate_z_morph(
     ``reg_did_not_improve``, ``affine_determinant_non_positive``) the function
     returns ``(None, diagnostics)`` with
     ``diagnostics["interpolation_failed"] = True`` and a specific
-    ``fallback_reason``. **No fabricated volume is produced** -- blending the
+    ``fallback_reason``. **No fabricated volume is produced** — blending the
     two neighbours would also be made-up data, with the added failure mode of
     ghost/double-contour artefacts whenever the two neighbours differ.
 

--- a/linumpy/tests/test_mosaic_interpolation.py
+++ b/linumpy/tests/test_mosaic_interpolation.py
@@ -1,0 +1,344 @@
+"""Tests for linumpy/mosaic/interpolation.py"""
+
+import numpy as np
+import pytest
+
+from linumpy.mosaic.interpolation import (
+    _fractional_affine_parts,
+    _matrix_fractional_power,
+    find_best_overlap_planes,
+    interpolate_average,
+    interpolate_weighted,
+    interpolate_z_morph,
+)
+
+
+def _vol(shape=(8, 16, 16), seed=0):
+    rng = np.random.default_rng(seed)
+    return (rng.random(shape) * 100.0).astype(np.float32)
+
+
+# ---------------------------------------------------------------------------
+# interpolate_average
+# ---------------------------------------------------------------------------
+
+
+def test_interpolate_average_shape():
+    before = _vol()
+    after = _vol(seed=1)
+    result = interpolate_average(before, after)
+    assert result.shape == before.shape
+
+
+def test_interpolate_average_midpoint():
+    """Result should be the exact arithmetic mean."""
+    before = np.zeros((4, 8, 8), dtype=np.float32)
+    after = np.full((4, 8, 8), 2.0, dtype=np.float32)
+    result = interpolate_average(before, after)
+    np.testing.assert_allclose(result, 1.0)
+
+
+def test_interpolate_average_identical():
+    """Averaging a volume with itself preserves values."""
+    vol = _vol()
+    result = interpolate_average(vol, vol)
+    np.testing.assert_allclose(result, vol, rtol=1e-5)
+
+
+def test_interpolate_average_dtype_float32():
+    """Output dtype should be float32."""
+    before = np.ones((4, 8, 8), dtype=np.uint8)
+    after = np.ones((4, 8, 8), dtype=np.uint8)
+    result = interpolate_average(before, after)
+    assert result.dtype == np.float32
+
+
+# ---------------------------------------------------------------------------
+# interpolate_weighted
+# ---------------------------------------------------------------------------
+
+
+def test_interpolate_weighted_shape():
+    before = _vol()
+    after = _vol(seed=1)
+    result = interpolate_weighted(before, after, sigma=1.0)
+    assert result.shape == before.shape
+
+
+def test_interpolate_weighted_same_result_as_average_when_sigma_zero():
+    """With sigma ≈ 0, weighted should be close to simple average."""
+    before = np.zeros((6, 8, 8), dtype=np.float32)
+    after = np.full((6, 8, 8), 4.0, dtype=np.float32)
+    avg = interpolate_average(before, after)
+    weighted = interpolate_weighted(before, after, sigma=0.01)
+    np.testing.assert_allclose(weighted, avg, rtol=0.05)
+
+
+def test_interpolate_weighted_smoothing_reduces_variance():
+    """Larger sigma should produce smoother output (lower std dev along Z)."""
+    rng = np.random.default_rng(42)
+    before = rng.random((20, 8, 8)).astype(np.float32)
+    after = rng.random((20, 8, 8)).astype(np.float32)
+    std_low_sigma = interpolate_weighted(before, after, sigma=0.1).std()
+    std_high_sigma = interpolate_weighted(before, after, sigma=3.0).std()
+    assert std_high_sigma < std_low_sigma
+
+
+# ---------------------------------------------------------------------------
+# Fractional affine helpers
+# ---------------------------------------------------------------------------
+
+
+def test_matrix_fractional_power_identity_alpha_1():
+    M = np.array([[1.05, 0.02], [-0.01, 0.98]])
+    M_half, imag = _matrix_fractional_power(M, 1.0)
+    np.testing.assert_allclose(M_half, M, atol=1e-10)
+    assert imag < 1e-6
+
+
+def test_matrix_fractional_power_half_squared_equals_matrix():
+    M = np.array([[1.04, 0.01], [-0.02, 0.97]])
+    M_half, _ = _matrix_fractional_power(M, 0.5)
+    np.testing.assert_allclose(M_half @ M_half, M, atol=1e-6)
+
+
+def test_fractional_affine_parts_alpha_0_is_identity():
+    M = np.array([[1.05, 0.02], [-0.01, 0.98]])
+    t = np.array([3.0, -1.5])
+    M_alpha, t_alpha, _ = _fractional_affine_parts(M, t, 0.0)
+    np.testing.assert_allclose(M_alpha, np.eye(2), atol=1e-10)
+    np.testing.assert_allclose(t_alpha, np.zeros(2), atol=1e-10)
+
+
+def test_fractional_affine_parts_alpha_1_is_original():
+    M = np.array([[1.05, 0.02], [-0.01, 0.98]])
+    t = np.array([3.0, -1.5])
+    M_alpha, t_alpha, _ = _fractional_affine_parts(M, t, 1.0)
+    np.testing.assert_allclose(M_alpha, M, atol=1e-10)
+    np.testing.assert_allclose(t_alpha, t, atol=1e-10)
+
+
+def test_fractional_affine_parts_half_compose_squared_equals_full():
+    """For a half-transform, applying twice should equal applying once at alpha=1."""
+    M = np.array([[1.06, 0.015], [-0.02, 0.95]])
+    t = np.array([4.5, -2.0])
+    M_half, t_half, _ = _fractional_affine_parts(M, t, 0.5)
+
+    # Applying the half-transform twice: x -> M_half x + t_half, then again.
+    # Expected result: M x + t (affine on an arbitrary point).
+    x = np.array([3.0, 7.0])
+    y_once = M_half @ x + t_half
+    y_twice = M_half @ y_once + t_half
+    y_full = M @ x + t
+    np.testing.assert_allclose(y_twice, y_full, atol=1e-6)
+
+
+def test_fractional_affine_parts_pure_translation_degenerate_case():
+    """When M = I the closed-form is degenerate; falls back to alpha * t."""
+    M = np.eye(2)
+    t = np.array([5.0, -3.0])
+    _, t_alpha, _ = _fractional_affine_parts(M, t, 0.5)
+    np.testing.assert_allclose(t_alpha, 0.5 * t, atol=1e-10)
+
+
+# ---------------------------------------------------------------------------
+# Synthetic ground-truth benchmarks
+# ---------------------------------------------------------------------------
+
+
+def _make_structured_vol(shape=(6, 64, 64), seed=0):
+    """Create a structured synthetic volume with repeatable content."""
+    rng = np.random.default_rng(seed)
+    nz, ny, nx = shape
+    yy, xx = np.mgrid[0:ny, 0:nx].astype(np.float32)
+    # A few 2D blobs + low-frequency gradient
+    vol = np.zeros(shape, dtype=np.float32)
+    for z in range(nz):
+        depth = z / max(nz - 1, 1)
+        cy = ny * (0.3 + 0.1 * depth)
+        cx = nx * (0.5 + 0.05 * depth)
+        blob = np.exp(-((yy - cy) ** 2 + (xx - cx) ** 2) / (2.0 * (ny / 6.0) ** 2))
+        noise = rng.normal(0.0, 0.02, size=(ny, nx)).astype(np.float32)
+        vol[z] = 0.2 + 0.7 * blob + noise
+    return vol
+
+
+def test_find_best_overlap_planes_returns_valid_pair():
+    before = _make_structured_vol(seed=1)
+    after = _make_structured_vol(seed=2)
+    ref_before, ref_after, corr = find_best_overlap_planes(before, after)
+    assert 0 <= ref_before < before.shape[0]
+    assert 0 <= ref_after < after.shape[0]
+    assert np.isfinite(corr)
+
+
+def test_interpolate_z_morph_boundary_planes_match_sources():
+    """Top of z-morph output should match bottom of vol_before, bottom → top of vol_after."""
+    before = _make_structured_vol(seed=3)
+    after = _make_structured_vol(seed=4)
+    vol, diag = interpolate_z_morph(before, after, max_iterations=50, min_overlap_correlation=0.0, min_ncc_improvement=-10.0)
+    if diag["method_used"] != "zmorph":
+        pytest.skip(f"zmorph fell back ({diag['fallback_reason']}); boundary assertion not applicable")
+    assert diag["top_boundary_residual_mean"] < 1e-4
+    assert diag["bottom_boundary_residual_mean"] < 1e-4
+    assert vol.shape[0] == min(before.shape[0], after.shape[0])
+
+
+def test_interpolate_z_morph_hard_skips_when_registration_unreliable():
+    """Unrelated noise volumes must not produce a fabricated interpolation.
+
+    Failed gates return ``(None, diag)`` with ``interpolation_failed=True``
+    — the pipeline treats this as a genuine gap rather than inserting a
+    blended volume.
+    """
+    rng = np.random.default_rng(99)
+    before = rng.random((4, 32, 32)).astype(np.float32)
+    after = rng.random((4, 32, 32)).astype(np.float32)
+    vol, diag = interpolate_z_morph(
+        before,
+        after,
+        max_iterations=20,
+        min_overlap_correlation=0.99,
+        min_ncc_improvement=0.0,
+    )
+    assert vol is None
+    assert diag["interpolation_failed"] is True
+    assert diag["method_used"] is None
+    assert diag["fallback_reason"] in {
+        "low_overlap_ncc",
+        "no_foreground_planes",
+        "reg_did_not_improve",
+        "registration_exception",
+        "affine_determinant_non_positive",
+    }
+
+
+def test_interpolate_z_morph_success_does_not_mark_failed():
+    """A successful zmorph run leaves interpolation_failed absent/False."""
+    before, _truth, after = _make_3slice_stack_with_drift(drift_px=1.0, seed=3)
+    vol, diag = interpolate_z_morph(
+        before,
+        after,
+        max_iterations=100,
+        min_overlap_correlation=0.0,
+        min_ncc_improvement=-10.0,
+    )
+    if diag["method_used"] != "zmorph":
+        pytest.skip(f"zmorph hard-skipped on synthetic input (reason={diag['fallback_reason']})")
+    assert vol is not None
+    assert diag.get("interpolation_failed", False) is False
+
+
+# ---------------------------------------------------------------------------
+# Ground-truth benchmark: drop the middle slice of a synthetic 3-slice stack
+# and compare reconstructions against the held-out truth.
+# ---------------------------------------------------------------------------
+
+
+def _make_3slice_stack_with_drift(shape=(6, 48, 48), drift_px=1.0, seed=0):
+    """Build three consecutive slices sharing most structure + a small XY drift.
+
+    Returns ``(vol_before, vol_missing_ground_truth, vol_after)``. The
+    missing slice is halfway between before and after in XY position, so a
+    correct interpolation should reconstruct it up to registration noise.
+    """
+    ny, nx = shape[1], shape[2]
+    yy, xx = np.mgrid[0:ny, 0:nx].astype(np.float32)
+
+    def _slice_at_drift(dy: float, dx: float, seed_noise: int) -> np.ndarray:
+        vol = np.zeros(shape, dtype=np.float32)
+        noise_rng = np.random.default_rng(seed_noise)
+        for z in range(shape[0]):
+            depth = z / max(shape[0] - 1, 1)
+            cy = ny * 0.4 + dy
+            cx = nx * 0.55 + dx
+            blob = np.exp(-((yy - cy) ** 2 + (xx - cx) ** 2) / (2.0 * (ny / 5.0) ** 2))
+            stripe = 0.2 * np.sin((xx + 4.0 * depth) * 0.35)
+            noise = noise_rng.normal(0.0, 0.01, size=(ny, nx)).astype(np.float32)
+            vol[z] = np.clip(0.15 + 0.7 * blob + stripe + noise, 0.0, None)
+        return vol
+
+    before = _slice_at_drift(-drift_px, 0.0, seed_noise=seed)
+    missing = _slice_at_drift(0.0, 0.0, seed_noise=seed + 1)
+    after = _slice_at_drift(+drift_px, 0.0, seed_noise=seed + 2)
+    return before, missing, after
+
+
+def _volume_ssim(a: np.ndarray, b: np.ndarray) -> float:
+    from skimage.metrics import structural_similarity as ssim
+
+    a = a.astype(np.float32)
+    b = b.astype(np.float32)
+    data_range = float(max(a.max(), b.max()) - min(a.min(), b.min()) + 1e-8)
+    win = min(min(a.shape), 7)
+    if win % 2 == 0:
+        win -= 1
+    return float(ssim(a, b, data_range=data_range, win_size=max(win, 3)))
+
+
+def _volume_psnr(a: np.ndarray, b: np.ndarray) -> float:
+    a = a.astype(np.float64)
+    b = b.astype(np.float64)
+    mse = float(np.mean((a - b) ** 2))
+    if mse < 1e-12:
+        return 100.0
+    data_range = float(max(a.max(), b.max()) - min(a.min(), b.min()) + 1e-8)
+    return 10.0 * float(np.log10(data_range**2 / mse))
+
+
+def test_ground_truth_zmorph_matches_boundaries_exactly():
+    """zmorph reconstructs the boundary planes of the missing slice exactly."""
+    before, _truth, after = _make_3slice_stack_with_drift(drift_px=1.5)
+    vol, diag = interpolate_z_morph(
+        before,
+        after,
+        max_iterations=100,
+        min_overlap_correlation=0.0,
+        min_ncc_improvement=-10.0,
+    )
+    if diag["method_used"] != "zmorph" or vol is None:
+        pytest.skip(f"zmorph fell back ({diag['fallback_reason']}); skipping boundary assertion")
+
+    # Output top plane ≡ deepest plane of vol_before (identity warp).
+    # Output bottom plane ≡ top plane of vol_after  (identity warp).
+    # apply_transform uses a non-zero default fill value, so the outermost
+    # 2-pixel border can differ slightly; compare the interior only.
+    interior = (slice(2, -2), slice(2, -2))
+    np.testing.assert_allclose(vol[0][interior], before[-1][interior], atol=1e-3)
+    np.testing.assert_allclose(vol[-1][interior], after[0][interior], atol=1e-3)
+
+
+def test_ground_truth_zmorph_vs_average_ssim():
+    """Report SSIM/PSNR of zmorph and simple average vs. the held-out ground-truth slice.
+
+    Smoke test: ensures both methods produce a reasonable reconstruction on
+    the synthetic drift benchmark. The raw numbers are printed for manual
+    inspection.
+    """
+    before, truth, after = _make_3slice_stack_with_drift(drift_px=1.0, seed=7)
+
+    vol_zm, diag_zm = interpolate_z_morph(
+        before, after, max_iterations=100, min_overlap_correlation=0.0, min_ncc_improvement=-10.0
+    )
+    vol_avg = interpolate_average(before, after)
+
+    if vol_zm is None:
+        pytest.skip(f"zmorph hard-skipped ({diag_zm['fallback_reason']}); cannot compare metrics")
+
+    ssim_zm = _volume_ssim(vol_zm, truth)
+    ssim_avg = _volume_ssim(vol_avg, truth)
+    psnr_zm = _volume_psnr(vol_zm, truth)
+    psnr_avg = _volume_psnr(vol_avg, truth)
+
+    print(
+        f"\nground-truth comparison (drift=1.0px):\n"
+        f"  zmorph : SSIM={ssim_zm:.3f} PSNR={psnr_zm:.2f} dB "
+        f"(used={diag_zm['method_used']}, reason={diag_zm['fallback_reason']})\n"
+        f"  average: SSIM={ssim_avg:.3f} PSNR={psnr_avg:.2f} dB"
+    )
+
+    # zmorph reconstructs only from the two boundary planes (physically
+    # principled), so SSIM vs an arbitrary interior GT is not its target
+    # metric. Only enforce a loose sanity floor.
+    assert ssim_zm > 0.05, f"zmorph SSIM pathologically low: {ssim_zm}"
+    assert ssim_avg > 0.2, f"average SSIM too low: {ssim_avg}"

--- a/scripts/linum_interpolate_missing_slice.py
+++ b/scripts/linum_interpolate_missing_slice.py
@@ -5,10 +5,10 @@ Interpolate a missing slice using information from adjacent slices.
 Uses z-aware morphing (``zmorph``): an affine transform ``T`` between the
 boundary planes of the two neighbours is computed, then for each output
 plane at fractional depth ``alpha`` the before-boundary is warped by
-``T^alpha`` and the after-boundary by ``T^(alpha - 1)`` and the two are
+``T**alpha`` and the after-boundary by ``T**(alpha - 1)`` and the two are
 cross-faded.
 
-Hard skip on gate failure: when zmorph's 2D boundary registration fails
+**Hard skip on gate failure.** When zmorph's 2D boundary registration fails
 any quality gate, no interpolated zarr is produced: the slot is left as a
 genuine gap rather than filled with a blended (and therefore fabricated)
 volume. A manifest fragment and diagnostics JSON are still emitted so the
@@ -16,14 +16,13 @@ failure is visible in ``slice_config_final.csv`` and the final report. The
 ``average`` / ``weighted`` methods remain available as explicit,
 user-requested baselines.
 
-Only a SINGLE missing slice can be reconstructed -- two or more consecutive
+Only a SINGLE missing slice can be reconstructed — two or more consecutive
 gaps carry insufficient information.
 
 See ``docs/SLICE_INTERPOLATION_FEATURE.md`` for the physical model and
 parameter-tuning guidance.
 
-Example usage::
-
+Example usage:
     linum_interpolate_missing_slice.py slice_z00.ome.zarr slice_z02.ome.zarr \\
         slice_z01_interpolated.ome.zarr
 
@@ -49,7 +48,6 @@ import numpy as np
 from linumpy.cli.args import add_overwrite_arg, assert_output_exists
 from linumpy.io import slice_config as slice_config_io
 from linumpy.io.zarr import read_omezarr, save_omezarr
-from linumpy.metrics import collect_slice_interpolation_metrics
 from linumpy.mosaic.interpolation import (
     interpolate_average,
     interpolate_weighted,
@@ -61,9 +59,9 @@ configure_all_libraries()
 
 def _build_arg_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
-    p.add_argument("slice_before", nargs="?", help="Path to the slice BEFORE the missing slice (`*.ome.zarr`)")
-    p.add_argument("slice_after", nargs="?", help="Path to the slice AFTER the missing slice (`*.ome.zarr`)")
-    p.add_argument("output", nargs="?", help="Output path for the interpolated slice (`*.ome.zarr`)")
+    p.add_argument("slice_before", nargs="?", help="Path to the slice BEFORE the missing slice (*.ome.zarr)")
+    p.add_argument("slice_after", nargs="?", help="Path to the slice AFTER the missing slice (*.ome.zarr)")
+    p.add_argument("output", nargs="?", help="Output path for the interpolated slice (*.ome.zarr)")
     p.add_argument(
         "--method",
         choices=["zmorph", "average", "weighted"],
@@ -72,7 +70,6 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         "  zmorph   - z-aware morphing (respects serial-section geometry; recommended)\n"
         "  average  - Simple average of adjacent slices\n"
         "  weighted - Weighted average with distance falloff\n"
-        "\n"
         "[default: %(default)s]",
     )
     p.add_argument(
@@ -82,7 +79,6 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         help="Blending method for combining warped slices:\n"
         "  linear - Equal 50/50 blend (may show edges)\n"
         "  gaussian - Feathered blend using distance transform (recommended)\n"
-        "\n"
         "[default: %(default)s]",
     )
     p.add_argument(
@@ -292,7 +288,7 @@ def generate_preview(
         axes[2].set_xticks([])
         axes[2].set_yticks([])
 
-        # XZ view still useful for context -- skip the missing middle slab.
+        # XZ view still useful for context — skip the missing middle slab.
         y_mid = vol_before.shape[1] // 2
         xz_before = normalize_for_display(vol_before[:, y_mid, :])
         xz_after = normalize_for_display(vol_after[:, y_mid, :])
@@ -323,7 +319,7 @@ def generate_preview(
         axes[3].axis("off")
 
     title = (
-        f"Slice Interpolation Preview (z={preview_slice}) -- FAILED"
+        f"Slice Interpolation Preview (z={preview_slice}) — FAILED"
         if interpolated is None
         else f"Slice Interpolation Preview (z={preview_slice})"
     )
@@ -362,13 +358,11 @@ def _finalise(args: argparse.Namespace) -> None:
     elif fragments_dir.exists():
         fragment_paths = [fragments_dir]
     else:
-        print(f"  Fragments path does not exist: {fragments_dir} -- copying slice_config unchanged.")
+        print(f"  Fragments path does not exist: {fragments_dir} — copying slice_config unchanged.")
 
     updates: dict[str, dict[str, object]] = {}
     interpolated_ids: set[str] = set()
     failed_ids: set[str] = set()
-    fallback_reasons: dict[str, int] = {}
-    method_counts: dict[str, int] = {}
     import csv
 
     for frag_path in fragment_paths:
@@ -390,12 +384,6 @@ def _finalise(args: argparse.Namespace) -> None:
                     target = _FRAGMENT_COLUMN_MAP.get(col)
                     if target:
                         entry[target] = val
-                method = (raw.get("method_used") or "").strip()
-                if method:
-                    method_counts[method] = method_counts.get(method, 0) + 1
-                reason = (raw.get("fallback_reason") or "").strip()
-                if reason:
-                    fallback_reasons[reason] = fallback_reasons.get(reason, 0) + 1
                 if failed:
                     failed_ids.add(sid)
                     entry["interpolation_method_used"] = ""
@@ -407,14 +395,6 @@ def _finalise(args: argparse.Namespace) -> None:
     print(
         f"Finalise: merged {len(fragment_paths)} fragment(s), "
         f"{len(interpolated_ids)} interpolated, {len(failed_ids)} failed → {args.slice_config_out}"
-    )
-    collect_slice_interpolation_metrics(
-        output_path=Path(args.slice_config_out),
-        n_fragments=len(fragment_paths),
-        interpolated_ids=list(interpolated_ids),
-        failed_ids=list(failed_ids),
-        fallback_reasons=fallback_reasons,
-        method_counts=method_counts,
     )
 
 
@@ -550,7 +530,7 @@ def main() -> None:
         print(f"Saving interpolated slice to: {output_path}")
         save_omezarr(da.from_array(final_result), Path(output_path), res_before)
     else:
-        print("Skipping zarr output -- no fabricated data will enter the reconstruction.")
+        print("Skipping zarr output — no fabricated data will enter the reconstruction.")
 
     if args.diagnostics is not None:
         diagnostics["slice_id"] = args.slice_id
@@ -564,7 +544,7 @@ def main() -> None:
             json.dump(diagnostics, fh, indent=2, default=_json_default)
         print(f"Diagnostics saved to: {diagnostics_path}")
 
-    # Manifest records pipeline-relevant flags only -- raw metrics live in the
+    # Manifest records pipeline-relevant flags only — raw metrics live in the
     # per-slice diagnostics JSON. The `interpolation_failed` column is what
     # finalise_interpolation uses to decide whether to stamp the slice as
     # successfully interpolated or as a hard-skip.

--- a/scripts/tests/test_interpolate_missing_slice.py
+++ b/scripts/tests/test_interpolate_missing_slice.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+"""Script-level tests for linum_interpolate_missing_slice.py."""
+
+import json
+
+import dask.array as da
+import numpy as np
+
+
+def _make_structured_slice(shape, drift_px, seed):
+    """Create a synthetic structured slice with a controlled XY drift."""
+    nz, ny, nx = shape
+    yy, xx = np.mgrid[0:ny, 0:nx].astype(np.float32)
+    rng = np.random.default_rng(seed)
+    vol = np.zeros(shape, dtype=np.float32)
+    for z in range(nz):
+        depth = z / max(nz - 1, 1)
+        cy = ny * 0.5 + drift_px
+        cx = nx * 0.5
+        blob = np.exp(-((yy - cy) ** 2 + (xx - cx) ** 2) / (2.0 * (ny / 5.0) ** 2))
+        vol[z] = np.clip(
+            0.1 + 0.6 * blob + 0.1 * np.sin((xx + 4.0 * depth) * 0.35) + rng.normal(0.0, 0.01, size=(ny, nx)), 0.0, None
+        ).astype(np.float32)
+    return vol
+
+
+def _save_pair(tmp_path, shape=(8, 48, 48), drift_px=1.0):
+    """Save synthetic slice_z00.ome.zarr / slice_z02.ome.zarr to tmp_path."""
+    from linumpy.io.zarr import save_omezarr
+
+    resolution = (0.005, 0.005, 0.005)
+    before = _make_structured_slice(shape, -drift_px, seed=1)
+    after = _make_structured_slice(shape, +drift_px, seed=2)
+    slice_before = tmp_path / "slice_z00.ome.zarr"
+    slice_after = tmp_path / "slice_z02.ome.zarr"
+    save_omezarr(da.from_array(before), slice_before, resolution)
+    save_omezarr(da.from_array(after), slice_after, resolution)
+    return slice_before, slice_after
+
+
+def test_help(script_runner):
+    ret = script_runner.run(["linum_interpolate_missing_slice.py", "--help"])
+    assert ret.success
+
+
+def test_average_method(script_runner, tmp_path):
+    """Test basic interpolation with average method using synthetic data."""
+    from linumpy.io.zarr import save_omezarr
+
+    shape = (10, 32, 32)
+    resolution = (0.001, 0.01, 0.01)
+    vol_before = np.random.rand(*shape).astype(np.float32) * 100
+    vol_after = np.random.rand(*shape).astype(np.float32) * 100
+
+    slice_before = tmp_path / "slice_z00.ome.zarr"
+    slice_after = tmp_path / "slice_z02.ome.zarr"
+    output = tmp_path / "slice_z01_interpolated.ome.zarr"
+
+    save_omezarr(da.from_array(vol_before), slice_before, resolution)
+    save_omezarr(da.from_array(vol_after), slice_after, resolution)
+
+    ret = script_runner.run(
+        ["linum_interpolate_missing_slice.py", str(slice_before), str(slice_after), str(output), "--method", "average"]
+    )
+
+    assert ret.success
+    assert output.exists()
+
+
+def test_zmorph_method_with_diagnostics_and_manifest(script_runner, tmp_path):
+    """Run --method zmorph and assert diagnostics / manifest files are emitted."""
+    slice_before, slice_after = _save_pair(tmp_path)
+    output = tmp_path / "slice_z01_interpolated.ome.zarr"
+    diagnostics = tmp_path / "diagnostics.json"
+    manifest = tmp_path / "manifest.csv"
+
+    ret = script_runner.run(
+        [
+            "linum_interpolate_missing_slice.py",
+            str(slice_before),
+            str(slice_after),
+            str(output),
+            "--method",
+            "zmorph",
+            "--max_iterations",
+            "50",
+            "--min_overlap_correlation",
+            "0.0",
+            "--min_ncc_improvement",
+            "-10.0",
+            "--slice_id",
+            "01",
+            "--diagnostics",
+            str(diagnostics),
+            "--manifest_entry",
+            str(manifest),
+        ]
+    )
+
+    assert ret.success, ret.stderr
+    assert output.exists()
+    assert diagnostics.exists()
+    assert manifest.exists()
+
+    with diagnostics.open() as fh:
+        diag = json.load(fh)
+    assert diag.get("method") == "zmorph"
+    assert "pre_reg_ncc" in diag
+    assert diag.get("slice_id") == "01"
+
+    lines = manifest.read_text().strip().splitlines()
+    assert len(lines) == 2
+    header = lines[0].split(",")
+    assert "slice_id" in header
+    assert "method_used" in header
+    assert "fallback_reason" in header
+
+
+def test_zmorph_hard_skips_on_unrelated_volumes(script_runner, tmp_path):
+    """Unrelated random volumes trigger a hard skip: no zarr, manifest flags failure."""
+    from linumpy.io.zarr import save_omezarr
+
+    shape = (6, 48, 48)
+    resolution = (0.005, 0.005, 0.005)
+    rng = np.random.default_rng(123)
+    before = rng.random(shape).astype(np.float32)
+    after = rng.random(shape).astype(np.float32)
+    slice_before = tmp_path / "slice_z00.ome.zarr"
+    slice_after = tmp_path / "slice_z02.ome.zarr"
+    save_omezarr(da.from_array(before), slice_before, resolution)
+    save_omezarr(da.from_array(after), slice_after, resolution)
+
+    output = tmp_path / "slice_z01_interpolated.ome.zarr"
+    diagnostics = tmp_path / "diag.json"
+    manifest = tmp_path / "manifest.csv"
+
+    ret = script_runner.run(
+        [
+            "linum_interpolate_missing_slice.py",
+            str(slice_before),
+            str(slice_after),
+            str(output),
+            "--method",
+            "zmorph",
+            "--max_iterations",
+            "20",
+            "--min_overlap_correlation",
+            "0.99",
+            "--min_ncc_improvement",
+            "0.5",
+            "--slice_id",
+            "01",
+            "--diagnostics",
+            str(diagnostics),
+            "--manifest_entry",
+            str(manifest),
+        ]
+    )
+    assert ret.success, ret.stderr
+
+    with diagnostics.open() as fh:
+        diag = json.load(fh)
+    assert diag["interpolation_failed"] is True
+    assert diag["method_used"] is None
+    assert diag["fallback_reason"] in {
+        "low_overlap_ncc",
+        "no_foreground_planes",
+        "reg_did_not_improve",
+        "registration_exception",
+        "affine_determinant_non_positive",
+    }
+    assert diag["output_path"] is None
+    assert not output.exists(), "No zarr must be produced when zmorph gates fail"
+
+    manifest_rows = manifest.read_text().strip().splitlines()
+    assert len(manifest_rows) == 2
+    header = manifest_rows[0].split(",")
+    values = manifest_rows[1].split(",")
+    row = dict(zip(header, values, strict=False))
+    assert row["interpolation_failed"] == "true"
+    assert row["method_used"] == ""
+    assert row["output_path"] == ""
+
+
+def test_finalise_merges_fragments_into_slice_config(script_runner, tmp_path):
+    """--finalise stamps interpolated=true + method_used from fragment CSVs."""
+    slice_config_in = tmp_path / "slice_config.csv"
+    slice_config_in.write_text(
+        "slice_id,use,quality_score\n00,true,0.9\n01,false,0.1\n02,true,0.8\n",
+        encoding="utf-8",
+    )
+
+    fragments = tmp_path / "fragments"
+    fragments.mkdir()
+    (fragments / "slice_z01_manifest.csv").write_text(
+        "slice_id,method,method_used,fallback_reason\n01,zmorph,zmorph,\n",
+        encoding="utf-8",
+    )
+
+    slice_config_out = tmp_path / "slice_config_out.csv"
+
+    ret = script_runner.run(
+        [
+            "linum_interpolate_missing_slice.py",
+            "--finalise",
+            "--slice_config_in",
+            str(slice_config_in),
+            "--slice_config_out",
+            str(slice_config_out),
+            "--fragments",
+            str(fragments),
+        ]
+    )
+    assert ret.success, ret.stderr
+    assert slice_config_out.exists()
+
+    from linumpy.io import slice_config as slice_config_io
+
+    rows = slice_config_io.read(slice_config_out)
+    assert rows["01"]["interpolated"] == "true"
+    assert rows["01"]["interpolation_method_used"] == "zmorph"
+    assert rows["00"].get("interpolated", "") == ""
+    assert rows["02"].get("interpolated", "") == ""
+
+
+def test_finalise_stamps_interpolation_failed(script_runner, tmp_path):
+    """A hard-skip fragment stamps interpolation_failed=true, interpolated=false."""
+    slice_config_in = tmp_path / "slice_config.csv"
+    slice_config_in.write_text(
+        "slice_id,use,quality_score\n00,true,0.9\n01,false,0.1\n02,true,0.8\n",
+        encoding="utf-8",
+    )
+
+    fragments = tmp_path / "fragments"
+    fragments.mkdir()
+    (fragments / "slice_z01_manifest.csv").write_text(
+        "slice_id,method,method_used,fallback_reason,interpolation_failed,output_path\n01,zmorph,,low_overlap_ncc,true,\n",
+        encoding="utf-8",
+    )
+
+    slice_config_out = tmp_path / "slice_config_out.csv"
+
+    ret = script_runner.run(
+        [
+            "linum_interpolate_missing_slice.py",
+            "--finalise",
+            "--slice_config_in",
+            str(slice_config_in),
+            "--slice_config_out",
+            str(slice_config_out),
+            "--fragments",
+            str(fragments),
+        ]
+    )
+    assert ret.success, ret.stderr
+
+    from linumpy.io import slice_config as slice_config_io
+
+    rows = slice_config_io.read(slice_config_out)
+    assert rows["01"]["interpolated"] == "false"
+    assert rows["01"]["interpolation_failed"] == "true"
+    assert rows["01"]["interpolation_fallback_reason"] == "low_overlap_ncc"
+    assert rows["01"]["interpolation_method_used"] == ""
+    # Un-touched rows remain untouched
+    assert rows["00"].get("interpolated", "") == ""
+    assert rows["00"].get("interpolation_failed", "") == ""
+
+
+def test_finalise_no_fragments_copies_slice_config_unchanged(script_runner, tmp_path):
+    """Empty fragments directory is a valid (no-op) finalise."""
+    slice_config_in = tmp_path / "slice_config.csv"
+    slice_config_in.write_text(
+        "slice_id,use\n00,true\n01,true\n",
+        encoding="utf-8",
+    )
+    fragments = tmp_path / "fragments"
+    fragments.mkdir()
+    slice_config_out = tmp_path / "slice_config_out.csv"
+
+    ret = script_runner.run(
+        [
+            "linum_interpolate_missing_slice.py",
+            "--finalise",
+            "--slice_config_in",
+            str(slice_config_in),
+            "--slice_config_out",
+            str(slice_config_out),
+            "--fragments",
+            str(fragments),
+        ]
+    )
+    assert ret.success, ret.stderr
+    from linumpy.io import slice_config as slice_config_io
+
+    rows = slice_config_io.read(slice_config_out)
+    assert set(rows) == {"00", "01"}
+    assert rows["00"].get("interpolated", "") == ""


### PR DESCRIPTION
> **Stacked PR 8/25 — review order:** #115 → #97 → #98 → #99 → #100 → #101 → #108 → #106 → #107 → **#87** → #116 → #110 → #111 → #40 → #112 → #130 → #131 → #118 → #132 → #121 → #122 → #123 → #124 → #128 → #133 → #134 → #135
>
> Base: `pr-l-manual-align`. Stacked on #107; retargets to `main` as upstream PRs merge.

---

## Summary

Reconstruct a single missing serial section from its two neighbours using **z-aware affine morphing** (`zmorph`). An affine transform `T` between the two boundary planes is computed, then every output plane at fractional depth `alpha` is produced by warping the before-boundary by `T**alpha` and the after-boundary by `T**(alpha-1)` and cross-fading the two (`scipy.linalg.fractional_matrix_power` + SimpleITK). This matches the physical geometry of serial sectioning instead of producing a blurry mean.

## Key design points

- **Single strategy.** `interpolate_z_morph` is the default. `interpolate_average` / `interpolate_weighted` are retained only as explicit, user-requested baselines via `--method`.
- **Hard skip on gate failure.** When boundary registration or NCC-improvement gates fail, the function returns `(None, diagnostics)` with a specific `fallback_reason`. The CLI then emits **no zarr** — the slot is left as a genuine gap rather than fabricated data. A manifest fragment and diagnostics JSON are still written so the failure surfaces in `slice_config_final.csv` and the final report.
- **Only single-slice gaps.** Two or more consecutive missing slices carry insufficient information and are explicitly rejected.
- **NCC-based boundary selection** via `find_best_overlap_planes` scans a window of candidate planes on each side and picks the pair with the best normalised cross-correlation before registration.
- **Pipeline integration.** Produces per-slice JSON + manifest fragments; `--finalise` mode aggregates all fragments and updates `slice_config.csv` → `slice_config_final.csv` with `interpolated`, `interpolation_failed`, `interpolation_fallback_reason` columns for use by the Nextflow pipeline (#108).

## Files (4)

- `linumpy/stitching/interpolation.py` — `interpolate_z_morph`, `interpolate_average`, `interpolate_weighted`, `find_best_overlap_planes`, NCC / foreground-fraction quality gates, Gaussian-feather blending, fractional-affine helpers
- `scripts/linum_interpolate_missing_slice.py` — CLI. Modes:
  - default: `slice_before slice_after output` — emit interpolated ome.zarr + diagnostics
  - `--preview` — render an XY/XZ preview PNG instead of writing a zarr
  - `--finalise --slice_config_in --slice_config_out --fragments` — merge per-slice fragments back into `slice_config.csv`
  - Tuning flags: `--method {zmorph,average,weighted}`, `--blend_method {linear,gaussian}`, `--registration_metric {MSE,CC,MI}`, `--overlap_search_window`, `--min_overlap_correlation`, `--reference_slab_size`, `--min_foreground_fraction`, `--min_ncc_improvement`
- `linumpy/tests/test_stitching_interpolation.py`
- `scripts/tests/test_interpolate_missing_slice.py`

See `docs/SLICE_INTERPOLATION_FEATURE.md` for the physical model and parameter tuning.