### PR TITLE
Add motor-position stacking and stitching pipeline

### DIFF
--- a/linumpy/stitching/motor.py
+++ b/linumpy/stitching/motor.py
@@ -1,0 +1,296 @@
+# -*- coding: utf-8 -*-
+"""
+Motor-position-based tile placement for mosaic stitching.
+
+Consolidated from linum_stitch_3d_refined.py and linum_stitch_motor_only.py.
+"""
+import logging
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+
+def compute_motor_positions(nx: int, ny: int, tile_shape: tuple,
+                            overlap_fraction: float,
+                            scale_factor: float = 1.0,
+                            rotation_deg: float = 0.0):
+    """Compute tile positions based on motor grid (ideal positions).
+
+    Assumes a regular grid where tiles are spaced by (1 - overlap) * tile_size.
+    Optionally applies scale factor and rotation to test hypotheses about
+    stage calibration issues.
+
+    Parameters
+    ----------
+    nx, ny : int
+        Number of tiles in each direction.
+    tile_shape : tuple
+        Tile dimensions (z, height, width).
+    overlap_fraction : float
+        Expected overlap between tiles (0-1).
+    scale_factor : float
+        Scale applied to step size (default 1.0 = no scaling).
+    rotation_deg : float
+        Global grid rotation in degrees (default 0.0).
+
+    Returns
+    -------
+    positions : list
+        List of (row_pos, col_pos) pixel positions for each tile.
+    step_y : int
+        Y step in pixels.
+    step_x : int
+        X step in pixels.
+    """
+    tile_height, tile_width = tile_shape[1], tile_shape[2]
+
+    step_y = int(tile_height * (1.0 - overlap_fraction))
+    step_x = int(tile_width * (1.0 - overlap_fraction))
+
+    step_y = int(step_y * scale_factor)
+    step_x = int(step_x * scale_factor)
+
+    if rotation_deg != 0.0:
+        theta = np.radians(rotation_deg)
+        cos_t, sin_t = np.cos(theta), np.sin(theta)
+        rotation_matrix = np.array([[cos_t, -sin_t], [sin_t, cos_t]])
+
+    positions = []
+    for i in range(nx):
+        for j in range(ny):
+            pos = np.array([i * step_y, j * step_x])
+            if rotation_deg != 0.0:
+                pos = np.dot(rotation_matrix, pos)
+            positions.append(pos.astype(int) if rotation_deg != 0.0 else (int(pos[0]), int(pos[1])))
+
+    return positions, step_y, step_x
+
+
+def compute_registration_refinements(volume: np.ndarray,
+                                     tile_shape: tuple,
+                                     nx: int, ny: int,
+                                     overlap_fraction: float,
+                                     max_refinement_px: float = 10.0) -> dict:
+    """Compute sub-pixel refinements by phase-correlating overlapping tile regions.
+
+    Does not change tile positions — computes how much the blending transition
+    should be adjusted for smoother seams at tile boundaries.
+
+    Parameters
+    ----------
+    volume : np.ndarray
+        The mosaic grid volume (Z, nx*tile_h, ny*tile_w).
+    tile_shape : tuple
+        Tile dimensions (z, height, width).
+    nx, ny : int
+        Number of tiles in each direction.
+    overlap_fraction : float
+        Expected overlap fraction (0-1).
+    max_refinement_px : float
+        Maximum allowed refinement shift. Larger shifts are clamped.
+
+    Returns
+    -------
+    dict with keys 'horizontal', 'vertical', 'stats'.
+    """
+    from linumpy.stitching.registration import pairWisePhaseCorrelation
+
+    tile_height, tile_width = tile_shape[1], tile_shape[2]
+    overlap_y = int(tile_height * overlap_fraction)
+    overlap_x = int(tile_width * overlap_fraction)
+
+    refinements = {
+        'horizontal': {},
+        'vertical': {},
+        'stats': {
+            'total_pairs': 0,
+            'valid_pairs': 0,
+            'clamped_pairs': 0,
+            'mean_refinement': 0.0,
+            'max_refinement': 0.0
+        }
+    }
+
+    all_shifts = []
+    z_mid = volume.shape[0] // 2
+
+    # Horizontal refinements (between columns)
+    for i in range(nx):
+        for j in range(ny - 1):
+            r1_start = i * tile_height
+            r1_end = (i + 1) * tile_height
+            c1_end = (j + 1) * tile_width
+            c2_start = (j + 1) * tile_width
+
+            overlap1 = volume[z_mid, r1_start:r1_end, c1_end - overlap_x:c1_end]
+            overlap2 = volume[z_mid, r1_start:r1_end, c2_start:c2_start + overlap_x]
+
+            if np.mean(overlap1 > 0) < 0.1 or np.mean(overlap2 > 0) < 0.1:
+                continue
+
+            refinements['stats']['total_pairs'] += 1
+            try:
+                dy, dx = pairWisePhaseCorrelation(overlap1, overlap2)
+                magnitude = np.sqrt(dx**2 + dy**2)
+                if magnitude > max_refinement_px:
+                    scale = max_refinement_px / magnitude
+                    dx *= scale
+                    dy *= scale
+                    refinements['stats']['clamped_pairs'] += 1
+
+                refinements['horizontal'][(i, j)] = {'dx': float(dx), 'dy': float(dy)}
+                refinements['stats']['valid_pairs'] += 1
+                all_shifts.append(magnitude)
+            except Exception as e:
+                logger.debug(f"Registration failed for h-pair ({i},{j})-({i},{j+1}): {e}")
+
+    # Vertical refinements (between rows)
+    for i in range(nx - 1):
+        for j in range(ny):
+            r1_end = (i + 1) * tile_height
+            r2_start = (i + 1) * tile_height
+            c_start = j * tile_width
+            c_end = (j + 1) * tile_width
+
+            overlap1 = volume[z_mid, r1_end - overlap_y:r1_end, c_start:c_end]
+            overlap2 = volume[z_mid, r2_start:r2_start + overlap_y, c_start:c_end]
+
+            if np.mean(overlap1 > 0) < 0.1 or np.mean(overlap2 > 0) < 0.1:
+                continue
+
+            refinements['stats']['total_pairs'] += 1
+            try:
+                dy, dx = pairWisePhaseCorrelation(overlap1, overlap2)
+                magnitude = np.sqrt(dx**2 + dy**2)
+                if magnitude > max_refinement_px:
+                    scale = max_refinement_px / magnitude
+                    dx *= scale
+                    dy *= scale
+                    refinements['stats']['clamped_pairs'] += 1
+
+                refinements['vertical'][(i, j)] = {'dx': float(dx), 'dy': float(dy)}
+                refinements['stats']['valid_pairs'] += 1
+                all_shifts.append(magnitude)
+            except Exception as e:
+                logger.debug(f"Registration failed for v-pair ({i},{j})-({i+1},{j}): {e}")
+
+    if all_shifts:
+        refinements['stats']['mean_refinement'] = float(np.mean(all_shifts))
+        refinements['stats']['max_refinement'] = float(np.max(all_shifts))
+
+    return refinements
+
+
+def apply_blend_shift_refinement(tile: np.ndarray,
+                                 refinements_for_tile: list,
+                                 overlap_fraction: float) -> np.ndarray:
+    """Apply registration refinement by shifting tile data in overlap regions.
+
+    Applies a small sub-pixel shift (averaged from all neighbors) to improve
+    blending quality without changing the tile's position in the mosaic.
+
+    Parameters
+    ----------
+    tile : np.ndarray
+        3D tile data (Z, Y, X).
+    refinements_for_tile : list
+        List of dicts with 'dx', 'dy' refinements from neighbors.
+    overlap_fraction : float
+        Tile overlap fraction (used for context; shift applies to whole tile).
+
+    Returns
+    -------
+    np.ndarray
+        Shifted tile (or unmodified if shift is negligible).
+    """
+    from scipy.ndimage import shift as ndi_shift
+
+    if not refinements_for_tile:
+        return tile
+
+    total_dy = sum(ref.get('dy', 0) for ref in refinements_for_tile)
+    total_dx = sum(ref.get('dx', 0) for ref in refinements_for_tile)
+    count = len(refinements_for_tile)
+
+    avg_dy = total_dy / count / 2
+    avg_dx = total_dx / count / 2
+
+    if abs(avg_dy) < 0.1 and abs(avg_dx) < 0.1:
+        return tile
+
+    nonzero_vals = tile[tile > 0]
+    cval = float(np.percentile(nonzero_vals, 1)) if len(nonzero_vals) > 0 else 0.0
+    shifted = ndi_shift(tile, (0, avg_dy, avg_dx), order=1, mode='constant', cval=cval)
+    return shifted
+
+
+def compare_motor_vs_registration(motor_positions: list,
+                                  reg_positions: list,
+                                  output_path: str = None) -> dict:
+    """Compare motor-based positions with registration-based positions.
+
+    Used diagnostically to identify stage calibration issues (systematic offset,
+    dilation/scaling) and registration drift.
+
+    Parameters
+    ----------
+    motor_positions : list
+        List of (row, col) positions from motor grid.
+    reg_positions : list
+        List of (row, col) positions from image registration.
+    output_path : str or None
+        If provided, save comparison JSON to this path.
+
+    Returns
+    -------
+    dict
+        Statistics including mean/std/max differences and diagnostic flags.
+    """
+    import json
+
+    motor_arr = np.array(motor_positions)
+    reg_arr = np.array(reg_positions)
+    diff = reg_arr - motor_arr
+
+    comparison = {
+        'n_tiles': len(motor_positions),
+        'mean_diff_y': float(np.mean(diff[:, 0])),
+        'mean_diff_x': float(np.mean(diff[:, 1])),
+        'std_diff_y': float(np.std(diff[:, 0])),
+        'std_diff_x': float(np.std(diff[:, 1])),
+        'max_diff_y': float(np.max(np.abs(diff[:, 0]))),
+        'max_diff_x': float(np.max(np.abs(diff[:, 1]))),
+        'mean_magnitude': float(np.mean(np.sqrt(diff[:, 0]**2 + diff[:, 1]**2))),
+        'max_magnitude': float(np.max(np.sqrt(diff[:, 0]**2 + diff[:, 1]**2))),
+    }
+
+    if abs(comparison['mean_diff_y']) > 5 or abs(comparison['mean_diff_x']) > 5:
+        comparison['systematic_offset'] = True
+        comparison['offset_warning'] = (
+            f"Systematic offset detected: "
+            f"({comparison['mean_diff_y']:.1f}, {comparison['mean_diff_x']:.1f}) pixels"
+        )
+    else:
+        comparison['systematic_offset'] = False
+
+    tile_indices = np.arange(len(motor_positions))
+    diff_magnitude = np.sqrt(diff[:, 0]**2 + diff[:, 1]**2)
+    if len(tile_indices) > 10:
+        correlation = np.corrcoef(tile_indices, diff_magnitude)[0, 1]
+        comparison['index_error_correlation'] = float(correlation)
+        if abs(correlation) > 0.5:
+            comparison['dilation_indicator'] = True
+            comparison['dilation_warning'] = (
+                f"Error increases with tile index (r={correlation:.2f}), "
+                f"suggesting dilation/scaling"
+            )
+        else:
+            comparison['dilation_indicator'] = False
+
+    if output_path:
+        with open(output_path, 'w') as f:
+            json.dump(comparison, f, indent=2)
+
+    return comparison

--- a/linumpy/stitching/stacking.py
+++ b/linumpy/stitching/stacking.py
@@ -373,5 +373,5 @@ def refine_z_blend_overlap(existing: np.ndarray,
         return moving_overlap, 0.0
 
     refined = ndi_shift(moving_overlap.astype(np.float32), [0, dy, dx],
-                        order=1, mode='constant', cval=0)
+                        order=1, mode='nearest')
     return refined, magnitude

--- a/linumpy/stitching/stacking.py
+++ b/linumpy/stitching/stacking.py
@@ -1,0 +1,377 @@
+# -*- coding: utf-8 -*-
+"""
+3D slice stacking utilities.
+
+Consolidated from linum_stack_slices_motor.py and linum_stack_motor_only.py.
+"""
+import logging
+from typing import Optional, Tuple
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+
+def find_z_overlap(fixed_vol: np.ndarray,
+                   moving_vol: np.ndarray,
+                   slicing_interval_mm: float,
+                   search_range_mm: float,
+                   resolution_um: float) -> Tuple[int, float]:
+    """Find optimal Z-overlap between consecutive slices using cross-correlation.
+
+    Searches around the expected overlap for the best normalized
+    cross-correlation score, using the center XY region for speed.
+
+    Parameters
+    ----------
+    fixed_vol : np.ndarray
+        Bottom (fixed) slice volume (Z, Y, X).
+    moving_vol : np.ndarray
+        Top (moving) slice volume (Z, Y, X).
+    slicing_interval_mm : float
+        Expected physical slice thickness in mm.
+    search_range_mm : float
+        Search range around expected position in mm.
+    resolution_um : float
+        Z resolution in microns per voxel.
+
+    Returns
+    -------
+    best_overlap : int
+        Optimal overlap in Z voxels.
+    best_corr : float
+        Correlation score at optimal overlap.
+    """
+    interval_vox = int((slicing_interval_mm * 1000) / resolution_um)
+    expected_overlap_vox = min(fixed_vol.shape[0], moving_vol.shape[0]) - interval_vox
+    search_range_vox = int((search_range_mm * 1000) / resolution_um)
+
+    min_overlap = max(1, expected_overlap_vox - search_range_vox)
+    max_overlap = min(fixed_vol.shape[0], moving_vol.shape[0],
+                      expected_overlap_vox + search_range_vox)
+
+    if min_overlap >= max_overlap:
+        return expected_overlap_vox, 0.0
+
+    h, w = fixed_vol.shape[1], fixed_vol.shape[2]
+    margin = min(h, w) // 4
+    y_slice = slice(margin, h - margin)
+    x_slice = slice(margin, w - margin)
+
+    best_overlap = expected_overlap_vox
+    best_corr = -np.inf
+
+    for overlap in range(min_overlap, max_overlap + 1):
+        fixed_region = fixed_vol[-overlap:, y_slice, x_slice]
+        moving_region = moving_vol[:overlap, y_slice, x_slice]
+
+        fixed_norm = (fixed_region - fixed_region.mean()) / (fixed_region.std() + 1e-8)
+        moving_norm = (moving_region - moving_region.mean()) / (moving_region.std() + 1e-8)
+
+        corr = np.mean(fixed_norm * moving_norm)
+        if corr > best_corr:
+            best_corr = corr
+            best_overlap = overlap
+
+    return best_overlap, best_corr
+
+
+def apply_2d_transform(image_2d: np.ndarray,
+                       transform,
+                       rotation_only: bool = False,
+                       max_rotation_deg: float = 1.0,
+                       override_rotation=None) -> np.ndarray:
+    """Apply a SimpleITK 2D/3D transform to a single 2D image (Z-slice).
+
+    Parameters
+    ----------
+    image_2d : np.ndarray
+        2D image to transform.
+    transform : sitk.Transform
+        SimpleITK transform (extracts 2D rotation/translation from 3D Euler).
+    rotation_only : bool
+        If True, apply only rotation, ignore translation.
+    max_rotation_deg : float
+        Maximum rotation in degrees; larger values are clamped. 0 = no clamping.
+    override_rotation : float or None
+        Use this rotation angle (radians) instead of extracting from transform.
+
+    Returns
+    -------
+    np.ndarray
+        Transformed 2D image.
+    """
+    import SimpleITK as sitk
+
+    sitk_img = sitk.GetImageFromArray(image_2d.astype(np.float32))
+
+    if transform.GetDimension() == 3:
+        if isinstance(transform, sitk.Euler3DTransform) or transform.GetName() == 'Euler3DTransform':
+            params = transform.GetParameters()
+            angle = params[2] if len(params) > 2 else 0
+            tx = params[3] if len(params) > 3 else 0
+            ty = params[4] if len(params) > 4 else 0
+
+            if override_rotation is not None:
+                angle = override_rotation
+            elif max_rotation_deg > 0:
+                max_angle_rad = np.radians(max_rotation_deg)
+                if abs(angle) > max_angle_rad:
+                    angle = np.clip(angle, -max_angle_rad, max_angle_rad)
+
+            center = transform.GetCenter()
+            center_2d = [center[0], center[1]]
+            tfm_2d = sitk.Euler2DTransform()
+            tfm_2d.SetCenter(center_2d)
+            tfm_2d.SetAngle(angle)
+            if rotation_only:
+                tfm_2d.SetTranslation([0, 0])
+            else:
+                tfm_2d.SetTranslation([tx, ty])
+        else:
+            tfm_2d = sitk.Euler2DTransform()
+            angle = 0
+            tx, ty = 0, 0
+    else:
+        tfm_2d = transform
+        if rotation_only and hasattr(tfm_2d, 'SetTranslation'):
+            tfm_2d.SetTranslation([0, 0])
+        angle = 0
+        tx, ty = 0, 0
+
+    tx_final = 0 if rotation_only else tx
+    ty_final = 0 if rotation_only else ty
+    if abs(angle) < 0.00175 and abs(tx_final) < 1.0 and abs(ty_final) < 1.0:
+        return image_2d.copy()
+
+    resampler = sitk.ResampleImageFilter()
+    resampler.SetReferenceImage(sitk_img)
+    resampler.SetTransform(tfm_2d)
+    resampler.SetInterpolator(sitk.sitkLinear)
+
+    nonzero_vals = image_2d[image_2d > 0]
+    default_val = float(np.percentile(nonzero_vals, 1)) if len(nonzero_vals) > 0 else 0.0
+    resampler.SetDefaultPixelValue(default_val)
+
+    result = resampler.Execute(sitk_img)
+    return sitk.GetArrayFromImage(result)
+
+
+def apply_transform_to_volume(vol: np.ndarray,
+                               transform,
+                               rotation_only: bool = False,
+                               max_rotation_deg: float = 1.0,
+                               override_rotation=None) -> np.ndarray:
+    """Apply a 2D transform to each Z-slice of a volume.
+
+    Parameters
+    ----------
+    vol : np.ndarray
+        3D volume (Z, Y, X).
+    transform : sitk.Transform
+        Transform to apply to each slice.
+    rotation_only : bool
+        If True, apply only rotation.
+    max_rotation_deg : float
+        Maximum rotation in degrees.
+    override_rotation : float or None
+        If provided, use this rotation for all slices.
+
+    Returns
+    -------
+    np.ndarray
+        Transformed volume.
+    """
+    result = np.zeros_like(vol)
+    for z in range(vol.shape[0]):
+        result[z] = apply_2d_transform(vol[z], transform, rotation_only,
+                                       max_rotation_deg, override_rotation)
+    return result
+
+
+def apply_xy_shift(vol: np.ndarray,
+                   dx_px: float,
+                   dy_px: float,
+                   output_shape: Tuple[int, int]):
+    """Compute destination region for placing a shifted volume.
+
+    Returns the (possibly cropped) volume data and destination coordinates
+    without allocating a full-size output array.
+
+    Parameters
+    ----------
+    vol : np.ndarray
+        3D volume (Z, Y, X).
+    dx_px, dy_px : float
+        Shift in pixels (X and Y directions).
+    output_shape : tuple
+        (out_ny, out_nx) output canvas size.
+
+    Returns
+    -------
+    cropped_vol : np.ndarray or None
+        Cropped volume data to write.
+    dst_coords : tuple or None
+        (y_start, y_end, x_start, x_end) in output coordinates.
+    """
+    out_ny, out_nx = output_shape
+    dx_int, dy_int = int(round(dx_px)), int(round(dy_px))
+
+    dst_y_start = dy_int
+    dst_x_start = dx_int
+    dst_y_end = dst_y_start + vol.shape[1]
+    dst_x_end = dst_x_start + vol.shape[2]
+
+    src_y_start = max(0, -dst_y_start)
+    src_y_end = vol.shape[1] - max(0, dst_y_end - out_ny)
+    src_x_start = max(0, -dst_x_start)
+    src_x_end = vol.shape[2] - max(0, dst_x_end - out_nx)
+
+    dst_y_start = max(0, dst_y_start)
+    dst_y_end = min(out_ny, dst_y_end)
+    dst_x_start = max(0, dst_x_start)
+    dst_x_end = min(out_nx, dst_x_end)
+
+    if src_y_end > src_y_start and src_x_end > src_x_start:
+        cropped = vol[:, src_y_start:src_y_end, src_x_start:src_x_end]
+        return cropped, (dst_y_start, dst_y_end, dst_x_start, dst_x_end)
+    return None, None
+
+
+def blend_overlap_z(fixed_region: np.ndarray,
+                    moving_region: np.ndarray) -> np.ndarray:
+    """Blend overlapping Z-region using a cosine (Hann) ramp along Z-axis.
+
+    The weight ramp has zero slope at both endpoints, so there is no abrupt
+    intensity change at either boundary of the overlap zone.  At tissue
+    boundaries where only one slice has data the full intensity of that slice
+    is used unchanged.
+
+    Parameters
+    ----------
+    fixed_region : np.ndarray
+        3D array (Z, Y, X) from the existing stack (bottom portion).
+    moving_region : np.ndarray
+        3D array (Z, Y, X) from the new slice (top portion).
+
+    Returns
+    -------
+    np.ndarray
+        Blended region with smooth Z-transition.
+    """
+    nz = fixed_region.shape[0]
+
+    if nz <= 1:
+        return moving_region if np.sum(moving_region > 0) >= np.sum(fixed_region > 0) else fixed_region
+
+    # Cosine (Hann) ramp: 0 → 1 with zero slope at both ends
+    t = np.linspace(0, np.pi, nz)
+    z_weights = 0.5 * (1 - np.cos(t))
+    alphas = np.broadcast_to(z_weights[:, np.newaxis, np.newaxis], fixed_region.shape).copy()
+
+    fixed_valid = fixed_region > 0
+    moving_valid = moving_region > 0
+    both_valid = fixed_valid & moving_valid
+    fixed_only = fixed_valid & ~moving_valid
+    moving_only = moving_valid & ~fixed_valid
+
+    blended = np.zeros_like(moving_region, dtype=np.float32)
+    if np.any(both_valid):
+        blended[both_valid] = ((1 - alphas) * fixed_region + alphas * moving_region)[both_valid]
+    if np.any(fixed_only):
+        blended[fixed_only] = fixed_region[fixed_only]
+    if np.any(moving_only):
+        blended[moving_only] = moving_region[moving_only]
+
+    return blended
+
+
+def blend_overlap_xy(existing: np.ndarray,
+                     new_data: np.ndarray,
+                     method: str = 'none') -> np.ndarray:
+    """Blend overlapping XY regions for motor-only stacking.
+
+    Parameters
+    ----------
+    existing : np.ndarray
+        Existing data in the output region.
+    new_data : np.ndarray
+        Incoming data to blend.
+    method : str
+        'none' (overwrite), 'average', 'max', or 'feather'.
+
+    Returns
+    -------
+    np.ndarray
+        Blended result.
+    """
+    if method == 'none':
+        mask = new_data != 0
+        existing[mask] = new_data[mask]
+        return existing
+    elif method == 'average':
+        both_valid = (existing != 0) & (new_data != 0)
+        only_new = (existing == 0) & (new_data != 0)
+        existing[both_valid] = (existing[both_valid] + new_data[both_valid]) / 2
+        existing[only_new] = new_data[only_new]
+        return existing
+    elif method == 'max':
+        return np.maximum(existing, new_data)
+    elif method == 'feather':
+        return blend_overlap_xy(existing, new_data, 'average')
+    return existing
+
+
+def refine_z_blend_overlap(existing: np.ndarray,
+                            moving_overlap: np.ndarray,
+                            max_refinement_px: float) -> Tuple[np.ndarray, float]:
+    """Find and apply a small XY shift to align moving_overlap with existing before blending.
+
+    Uses 2D phase correlation on Z-projected overlap regions to detect residual
+    XY misalignment at slice boundaries.
+
+    Parameters
+    ----------
+    existing : np.ndarray
+        3D array (Z, Y, X) from current stack at the overlap zone.
+    moving_overlap : np.ndarray
+        3D array (Z, Y, X) from incoming slice at the overlap zone.
+    max_refinement_px : float
+        Maximum allowed shift magnitude in pixels.
+
+    Returns
+    -------
+    refined : np.ndarray
+        Shifted moving_overlap with residual XY misalignment corrected.
+    magnitude : float
+        Shift magnitude applied (pixels), or 0.0 if not applied.
+    """
+    from scipy.ndimage import shift as ndi_shift
+    from linumpy.stitching.registration import pairWisePhaseCorrelation
+
+    fixed_2d = np.mean(existing, axis=0).astype(np.float32)
+    moving_2d = np.mean(moving_overlap, axis=0).astype(np.float32)
+
+    valid = (fixed_2d > 0) & (moving_2d > 0)
+    if np.sum(valid) < 1000:
+        return moving_overlap, 0.0
+
+    try:
+        shift = pairWisePhaseCorrelation(fixed_2d, moving_2d)
+        dy, dx = float(shift[0]), float(shift[1])
+    except Exception as e:
+        logger.debug(f"Z-blend phase correlation failed: {e}")
+        return moving_overlap, 0.0
+
+    magnitude = np.sqrt(dy**2 + dx**2)
+
+    if magnitude < 0.1:
+        return moving_overlap, 0.0
+
+    if magnitude > max_refinement_px:
+        logger.debug(f"Z-blend refinement rejected: {magnitude:.2f} px > max {max_refinement_px} px")
+        return moving_overlap, 0.0
+
+    refined = ndi_shift(moving_overlap.astype(np.float32), [0, dy, dx],
+                        order=1, mode='constant', cval=0)
+    return refined, magnitude

--- a/linumpy/stitching/stacking.py
+++ b/linumpy/stitching/stacking.py
@@ -373,5 +373,5 @@ def refine_z_blend_overlap(existing: np.ndarray,
         return moving_overlap, 0.0
 
     refined = ndi_shift(moving_overlap.astype(np.float32), [0, dy, dx],
-                        order=1, mode='nearest')
+                        order=0, mode='nearest')
     return refined, magnitude

--- a/linumpy/tests/test_stitching_motor.py
+++ b/linumpy/tests/test_stitching_motor.py
@@ -1,0 +1,132 @@
+# -*- coding: utf-8 -*-
+"""Tests for linumpy/stitching/motor.py"""
+import json
+
+import numpy as np
+import pytest
+
+from linumpy.stitching.motor import (
+    apply_blend_shift_refinement,
+    compare_motor_vs_registration,
+    compute_motor_positions,
+)
+
+
+# ---------------------------------------------------------------------------
+# compute_motor_positions
+# ---------------------------------------------------------------------------
+
+def test_compute_motor_positions_count():
+    positions, step_y, step_x = compute_motor_positions(
+        nx=3, ny=4, tile_shape=(10, 64, 64), overlap_fraction=0.1)
+    assert len(positions) == 12   # 3 × 4
+
+
+def test_compute_motor_positions_step_sizes():
+    tile_shape = (10, 100, 80)
+    overlap = 0.2
+    positions, step_y, step_x = compute_motor_positions(
+        nx=2, ny=2, tile_shape=tile_shape, overlap_fraction=overlap)
+    expected_step_y = int(100 * (1 - overlap))  # 80
+    expected_step_x = int(80 * (1 - overlap))   # 64
+    assert step_y == expected_step_y
+    assert step_x == expected_step_x
+
+
+def test_compute_motor_positions_first_is_origin():
+    positions, _, _ = compute_motor_positions(
+        nx=2, ny=3, tile_shape=(5, 50, 50), overlap_fraction=0.1)
+    first = positions[0]
+    assert first[0] == 0
+    assert first[1] == 0
+
+
+def test_compute_motor_positions_scale_factor():
+    tile_shape = (10, 100, 100)
+    positions_1x, step_y_1x, _ = compute_motor_positions(
+        nx=2, ny=1, tile_shape=tile_shape, overlap_fraction=0.0, scale_factor=1.0)
+    positions_2x, step_y_2x, _ = compute_motor_positions(
+        nx=2, ny=1, tile_shape=tile_shape, overlap_fraction=0.0, scale_factor=2.0)
+    assert step_y_2x == 2 * step_y_1x
+
+
+# ---------------------------------------------------------------------------
+# apply_blend_shift_refinement
+# ---------------------------------------------------------------------------
+
+def test_apply_blend_shift_refinement_empty_refinements():
+    """No refinements → tile returned unchanged."""
+    tile = np.ones((5, 16, 16), dtype=np.float32)
+    result = apply_blend_shift_refinement(tile, [], overlap_fraction=0.1)
+    np.testing.assert_array_equal(result, tile)
+
+
+def test_apply_blend_shift_refinement_negligible_shift():
+    """Sub-threshold shifts (< 0.1 px) → tile returned unchanged."""
+    tile = np.ones((5, 16, 16), dtype=np.float32)
+    refinements = [{'dx': 0.05, 'dy': 0.05}]
+    result = apply_blend_shift_refinement(tile, refinements, overlap_fraction=0.1)
+    np.testing.assert_array_equal(result, tile)
+
+
+def test_apply_blend_shift_refinement_applies_shift():
+    """Large shift is applied, changing the tile data."""
+    rng = np.random.default_rng(7)
+    tile = (rng.random((5, 32, 32)) * 100.0).astype(np.float32)
+    refinements = [{'dx': 3.0, 'dy': 3.0}]
+    result = apply_blend_shift_refinement(tile, refinements, overlap_fraction=0.2)
+    # Shape must be preserved
+    assert result.shape == tile.shape
+    # Content must have changed
+    assert not np.array_equal(result, tile)
+
+
+def test_apply_blend_shift_refinement_averages_multiple():
+    """Multiple refinements are averaged before application."""
+    tile = (np.ones((5, 32, 32)) * 50.0).astype(np.float32)
+    # Two opposite shifts → average ≈ 0 → no change (may not be exact due to shift)
+    refinements = [{'dx': 0.0, 'dy': 4.0}, {'dx': 0.0, 'dy': -4.0}]
+    result = apply_blend_shift_refinement(tile, refinements, overlap_fraction=0.1)
+    # Average dy = 0 / 2 / 2 = 0 → negligible → should be unchanged
+    np.testing.assert_array_equal(result, tile)
+
+
+# ---------------------------------------------------------------------------
+# compare_motor_vs_registration
+# ---------------------------------------------------------------------------
+
+def test_compare_motor_vs_registration_basic():
+    motor = [(0, 0), (10, 0), (0, 10), (10, 10)]
+    reg = [(1, 1), (11, 1), (1, 11), (11, 11)]
+    result = compare_motor_vs_registration(motor, reg)
+    assert result['n_tiles'] == 4
+    assert abs(result['mean_diff_y'] - 1.0) < 1e-9
+    assert abs(result['mean_diff_x'] - 1.0) < 1e-9
+    assert result['systematic_offset'] is False   # only 1 px offset, threshold is 5
+
+
+def test_compare_motor_vs_registration_systematic_offset():
+    motor = [(0, 0)] * 5
+    reg = [(10, 10)] * 5     # 10 px systematic offset
+    result = compare_motor_vs_registration(motor, reg)
+    assert result['systematic_offset'] is True
+    assert 'offset_warning' in result
+
+
+def test_compare_motor_vs_registration_writes_json(tmp_path):
+    motor = [(0, 0), (10, 0)]
+    reg = [(1, 0), (11, 0)]
+    out_path = str(tmp_path / "comparison.json")
+    result = compare_motor_vs_registration(motor, reg, output_path=out_path)
+    with open(out_path) as f:
+        loaded = json.load(f)
+    assert loaded['n_tiles'] == 2
+    assert abs(loaded['mean_diff_y'] - 1.0) < 1e-9
+
+
+def test_compare_motor_vs_registration_no_dilation_flag():
+    """Fewer than 10 tiles: no dilation_indicator key."""
+    motor = [(0, 0), (10, 0)]
+    reg = [(0, 0), (10, 0)]
+    result = compare_motor_vs_registration(motor, reg)
+    assert 'dilation_indicator' not in result

--- a/linumpy/tests/test_stitching_stacking.py
+++ b/linumpy/tests/test_stitching_stacking.py
@@ -1,0 +1,169 @@
+# -*- coding: utf-8 -*-
+"""Tests for linumpy/stitching/stacking.py"""
+import numpy as np
+import pytest
+
+from linumpy.stitching.stacking import (
+    apply_xy_shift,
+    blend_overlap_xy,
+    blend_overlap_z,
+    find_z_overlap,
+)
+
+
+def _make_vol(shape=(10, 32, 32), fill=1.0):
+    return (np.ones(shape) * fill).astype(np.float32)
+
+
+# ---------------------------------------------------------------------------
+# find_z_overlap
+# ---------------------------------------------------------------------------
+
+def test_find_z_overlap_returns_tuple():
+    fixed = _make_vol((20, 16, 16))
+    moving = _make_vol((20, 16, 16))
+    overlap, corr = find_z_overlap(fixed, moving,
+                                   slicing_interval_mm=0.1,
+                                   search_range_mm=0.05,
+                                   resolution_um=5.0)
+    assert isinstance(overlap, int)
+    assert isinstance(corr, (float, np.floating))
+
+
+def test_find_z_overlap_identical_volumes():
+    """Identical volumes have perfect correlation at some overlap."""
+    rng = np.random.default_rng(0)
+    vol = rng.random((20, 16, 16)).astype(np.float32)
+    overlap, corr = find_z_overlap(vol, vol,
+                                   slicing_interval_mm=0.05,
+                                   search_range_mm=0.1,
+                                   resolution_um=5.0)
+    # Correlation should be high (>= 0.0 at minimum)
+    assert corr >= 0.0
+    assert 1 <= overlap <= 20
+
+
+def test_find_z_overlap_min_max_degenerate():
+    """When search range collapses, falls back to expected overlap."""
+    fixed = _make_vol((10, 8, 8))
+    moving = _make_vol((10, 8, 8))
+    # Very large interval → expected overlap < 0 → min >= max edge case
+    overlap, corr = find_z_overlap(fixed, moving,
+                                   slicing_interval_mm=10.0,
+                                   search_range_mm=0.0,
+                                   resolution_um=5.0)
+    assert isinstance(overlap, int)
+
+
+# ---------------------------------------------------------------------------
+# apply_xy_shift
+# ---------------------------------------------------------------------------
+
+def test_apply_xy_shift_zero_shift():
+    vol = _make_vol((4, 10, 10))
+    cropped, dst = apply_xy_shift(vol, 0.0, 0.0, output_shape=(10, 10))
+    assert cropped is not None
+    assert dst == (0, 10, 0, 10)
+
+
+def test_apply_xy_shift_positive():
+    vol = _make_vol((4, 8, 8))
+    cropped, dst = apply_xy_shift(vol, 2.0, 3.0, output_shape=(12, 12))
+    # dest starts at (dy=3, dx=2) in (y_start, y_end, x_start, x_end)
+    assert dst[0] == 3                # y_start
+    assert dst[2] == 2                # x_start
+    assert cropped.shape[1] == 8
+    assert cropped.shape[2] == 8
+
+
+def test_apply_xy_shift_negative_clips_src():
+    vol = _make_vol((4, 10, 10))
+    # Shift by -2 in both dims: source crops 2 from start
+    cropped, dst = apply_xy_shift(vol, -2.0, -2.0, output_shape=(10, 10))
+    assert cropped is not None
+    assert dst[0] == 0   # clamped to canvas start
+    assert cropped.shape[1] == 8   # 2 rows clipped
+
+
+def test_apply_xy_shift_fully_outside_canvas():
+    vol = _make_vol((4, 8, 8))
+    cropped, dst = apply_xy_shift(vol, 100.0, 100.0, output_shape=(10, 10))
+    assert cropped is None
+    assert dst is None
+
+
+# ---------------------------------------------------------------------------
+# blend_overlap_z
+# ---------------------------------------------------------------------------
+
+def test_blend_overlap_z_output_shape():
+    fixed = _make_vol((5, 8, 8), fill=1.0)
+    moving = _make_vol((5, 8, 8), fill=2.0)
+    result = blend_overlap_z(fixed, moving)
+    assert result.shape == fixed.shape
+
+
+def test_blend_overlap_z_both_valid():
+    """With both regions non-zero, result is between fixed and moving."""
+    fixed = np.ones((6, 8, 8), dtype=np.float32)
+    moving = np.full((6, 8, 8), 3.0, dtype=np.float32)
+    result = blend_overlap_z(fixed, moving)
+    assert float(result.min()) >= 1.0
+    assert float(result.max()) <= 3.0
+
+
+def test_blend_overlap_z_one_sided_fixed_only():
+    """When moving is zero, fixed values are preserved."""
+    fixed = np.ones((6, 8, 8), dtype=np.float32)
+    moving = np.zeros((6, 8, 8), dtype=np.float32)
+    result = blend_overlap_z(fixed, moving)
+    np.testing.assert_allclose(result[fixed > 0], 1.0)
+
+
+def test_blend_overlap_z_one_sided_moving_only():
+    """When fixed is zero, moving values are preserved."""
+    fixed = np.zeros((6, 8, 8), dtype=np.float32)
+    moving = np.ones((6, 8, 8), dtype=np.float32)
+    result = blend_overlap_z(fixed, moving)
+    np.testing.assert_allclose(result[moving > 0], 1.0)
+
+
+def test_blend_overlap_z_single_slice():
+    """Single z-slice edge case: picks the region with more non-zero voxels."""
+    fixed = np.ones((1, 8, 8), dtype=np.float32)
+    moving = np.zeros((1, 8, 8), dtype=np.float32)
+    result = blend_overlap_z(fixed, moving)
+    assert result.shape == (1, 8, 8)
+
+
+# ---------------------------------------------------------------------------
+# blend_overlap_xy
+# ---------------------------------------------------------------------------
+
+def test_blend_overlap_xy_none_overwrites():
+    existing = np.ones((4, 8, 8), dtype=np.float32)
+    new_data = np.full((4, 8, 8), 5.0, dtype=np.float32)
+    result = blend_overlap_xy(existing.copy(), new_data, method='none')
+    np.testing.assert_allclose(result, 5.0)
+
+
+def test_blend_overlap_xy_average():
+    existing = np.ones((4, 8, 8), dtype=np.float32)
+    new_data = np.full((4, 8, 8), 3.0, dtype=np.float32)
+    result = blend_overlap_xy(existing.copy(), new_data, method='average')
+    np.testing.assert_allclose(result, 2.0)
+
+
+def test_blend_overlap_xy_max():
+    existing = np.ones((4, 8, 8), dtype=np.float32)
+    new_data = np.full((4, 8, 8), 3.0, dtype=np.float32)
+    result = blend_overlap_xy(existing.copy(), new_data, method='max')
+    np.testing.assert_allclose(result, 3.0)
+
+
+def test_blend_overlap_xy_average_respects_zeros():
+    """Pixels zero in existing (no data) should take new_data value."""
+    existing = np.zeros((4, 8, 8), dtype=np.float32)
+    new_data = np.full((4, 8, 8), 2.0, dtype=np.float32)
+    result = blend_overlap_xy(existing.copy(), new_data, method='average')
+    np.testing.assert_allclose(result, 2.0)

--- a/scripts/linum_stack_motor_only.py
+++ b/scripts/linum_stack_motor_only.py
@@ -1,0 +1,381 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Stack slices into a 3D volume using only motor positions (no pairwise registration).
+
+This diagnostic tool creates a 3D stack using ONLY the XY shifts from the shifts_xy.csv
+file (motor/stage positions recorded during acquisition). By comparing this "motor-only"
+stack against the fully-registered stack, you can:
+
+1. **Validate motor positions**: Check if motor positions alone provide good alignment
+2. **Identify registration artifacts**: See if pairwise registration introduces errors
+3. **Debug dilation issues**: Verify if XY drift is the main cause of misalignment
+
+The script reads the shifts file and positions each slice according to its cumulative
+XY shift, without any image-based registration refinement.
+"""
+import linumpy._thread_config  # noqa: F401
+
+import argparse
+import logging
+import re
+from pathlib import Path
+
+import numpy as np
+
+from linumpy.io.zarr import read_omezarr, AnalysisOmeZarrWriter
+from linumpy.stitching.stacking import apply_xy_shift, blend_overlap_xy
+from linumpy.utils.io import add_overwrite_arg, assert_output_exists
+from linumpy.utils.shifts import center_shifts, convert_shifts_to_pixels, load_shifts_csv
+
+logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
+logger = logging.getLogger(__name__)
+
+
+def _build_arg_parser():
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter)
+    p.add_argument('in_slices_dir',
+                   help='Directory containing slice volumes (.ome.zarr)')
+    p.add_argument('in_shifts',
+                   help='CSV file with XY shifts (shifts_xy.csv)')
+    p.add_argument('out_volume',
+                   help='Output stacked volume (.ome.zarr)')
+
+    p.add_argument('--blending', type=str, default='none',
+                   choices=['none', 'average', 'max', 'feather'],
+                   help='Blending method for overlapping regions [%(default)s]\n'
+                        '  none: No blending, later slices overwrite earlier ones\n'
+                        '  average: Average overlapping voxels\n'
+                        '  max: Take maximum of overlapping voxels\n'
+                        '  feather: Feathered blending based on distance from edge')
+    p.add_argument('--overlap_slices', type=int, default=0,
+                   help='Number of z-slices to overlap between consecutive slices [%(default)s]\n'
+                        'Set to 0 to stack without z-overlap (just XY alignment)')
+    p.add_argument('--z_spacing_um', type=float, default=None,
+                   help='Z spacing between slices in microns.\n'
+                        'If not provided, uses spacing from first slice metadata.')
+    p.add_argument('--center_drift', action='store_true', default=True,
+                   help='Center cumulative drift around middle slice [%(default)s]')
+    p.add_argument('--no_center_drift', action='store_false', dest='center_drift',
+                   help='Do not center drift')
+    p.add_argument('--slice_pattern', type=str, default=r'slice_z(\d+)',
+                   help='Regex pattern to extract slice ID from filename [%(default)s]')
+    p.add_argument('--preview', type=str, default=None,
+                   help='Output path for preview image (.png)')
+    p.add_argument('--max_slices', type=int, default=None,
+                   help='Maximum number of slices to stack (for testing)')
+
+    add_overwrite_arg(p)
+    return p
+
+
+def compute_output_shape(slice_files, cumsum_px, overlap_slices=0):
+    """Compute the output volume shape to fit all slices."""
+    xmin, xmax, ymin, ymax = [], [], [], []
+    total_z = 0
+
+    for slice_id, slice_file in slice_files.items():
+        vol, _ = read_omezarr(str(slice_file), level=0)
+        dx, dy = cumsum_px.get(slice_id, (0, 0))
+
+        z_depth = vol.shape[0]
+        height = vol.shape[1]  # Y
+        width = vol.shape[2]   # X
+
+        xmin.append(dx)
+        xmax.append(dx + width)
+        ymin.append(dy)
+        ymax.append(dy + height)
+        total_z += z_depth
+
+    # Account for overlap
+    n_slices = len(slice_files)
+    if overlap_slices > 0 and n_slices > 1:
+        total_z -= overlap_slices * (n_slices - 1)
+
+    x0 = min(xmin)
+    y0 = min(ymin)
+    nx = int(np.ceil(max(xmax) - x0))
+    ny = int(np.ceil(max(ymax) - y0))
+
+    return (total_z, ny, nx), (x0, y0)
+
+
+def generate_preview(volume, output_path):
+    """Generate a preview image of the stacked volume."""
+    try:
+        import matplotlib.pyplot as plt
+
+        fig, axes = plt.subplots(1, 3, figsize=(15, 5))
+
+        # Middle slices in each dimension
+        z_mid = volume.shape[0] // 2
+        y_mid = volume.shape[1] // 2
+        x_mid = volume.shape[2] // 2
+
+        # XY slice (axial)
+        axes[0].imshow(volume[z_mid, :, :], cmap='gray')
+        axes[0].set_title(f'XY (z={z_mid})')
+        axes[0].axis('off')
+
+        # XZ slice (coronal)
+        axes[1].imshow(volume[:, y_mid, :], cmap='gray', aspect='auto')
+        axes[1].set_title(f'XZ (y={y_mid})')
+        axes[1].axis('off')
+
+        # YZ slice (sagittal)
+        axes[2].imshow(volume[:, :, x_mid], cmap='gray', aspect='auto')
+        axes[2].set_title(f'YZ (x={x_mid})')
+        axes[2].axis('off')
+
+        plt.suptitle('Motor-Only Stack Preview')
+        plt.tight_layout()
+        plt.savefig(output_path, dpi=150)
+        plt.close()
+
+        logger.info(f"Preview saved to {output_path}")
+    except Exception as e:
+        logger.warning(f"Could not generate preview: {e}")
+
+
+def generate_preview_from_slice(slice_2d, output_path):
+    """Generate a preview image from a single 2D slice."""
+    try:
+        import matplotlib.pyplot as plt
+
+        fig, ax = plt.subplots(1, 1, figsize=(10, 10))
+
+        # Normalize for display
+        vmin = np.percentile(slice_2d[slice_2d > 0], 1) if np.any(slice_2d > 0) else 0
+        vmax = np.percentile(slice_2d, 99)
+
+        ax.imshow(slice_2d, cmap='gray', vmin=vmin, vmax=vmax)
+        ax.set_title('Motor-Only Stack (middle Z slice)')
+        ax.axis('off')
+
+        plt.tight_layout()
+        plt.savefig(output_path, dpi=150, bbox_inches='tight')
+        plt.close()
+
+        logger.info(f"Preview saved to {output_path}")
+    except Exception as e:
+        logger.warning(f"Could not generate preview: {e}")
+
+
+def generate_preview_from_zarr(zarr_output, output_path):
+    """Generate a 3-panel preview (XY, XZ, YZ) from a zarr output without loading full volume."""
+    try:
+        import matplotlib.pyplot as plt
+
+        # Get shape from zarr
+        shape = zarr_output.shape  # (Z, Y, X)
+        z_mid = shape[0] // 2
+        y_mid = shape[1] // 2
+        x_mid = shape[2] // 2
+
+        # Read only the slices we need
+        xy_slice = np.array(zarr_output[z_mid, :, :])  # XY at middle Z
+        xz_slice = np.array(zarr_output[:, y_mid, :])  # XZ at middle Y
+        yz_slice = np.array(zarr_output[:, :, x_mid])  # YZ at middle X
+
+        fig, axes = plt.subplots(1, 3, figsize=(18, 6))
+
+        # Normalize each slice for display
+        def normalize_slice(s):
+            valid = s > 0
+            if np.any(valid):
+                vmin = np.percentile(s[valid], 1)
+                vmax = np.percentile(s, 99)
+            else:
+                vmin, vmax = 0, 1
+            return vmin, vmax
+
+        # XY slice (axial)
+        vmin, vmax = normalize_slice(xy_slice)
+        axes[0].imshow(xy_slice, cmap='gray', vmin=vmin, vmax=vmax)
+        axes[0].set_title(f'XY (z={z_mid})')
+        axes[0].axis('off')
+
+        # XZ slice (coronal)
+        vmin, vmax = normalize_slice(xz_slice)
+        axes[1].imshow(xz_slice, cmap='gray', vmin=vmin, vmax=vmax, aspect='auto')
+        axes[1].set_title(f'XZ (y={y_mid})')
+        axes[1].axis('off')
+
+        # YZ slice (sagittal)
+        vmin, vmax = normalize_slice(yz_slice)
+        axes[2].imshow(yz_slice, cmap='gray', vmin=vmin, vmax=vmax, aspect='auto')
+        axes[2].set_title(f'YZ (x={x_mid})')
+        axes[2].axis('off')
+
+        plt.suptitle(f'Motor-Only Stack Preview ({shape[0]} x {shape[1]} x {shape[2]})')
+        plt.tight_layout()
+        plt.savefig(output_path, dpi=150, bbox_inches='tight')
+        plt.close()
+
+        logger.info(f"3-panel preview saved to {output_path}")
+    except Exception as e:
+        logger.warning(f"Could not generate preview: {e}")
+
+
+def main():
+    p = _build_arg_parser()
+    args = p.parse_args()
+
+    slices_dir = Path(args.in_slices_dir)
+    shifts_path = Path(args.in_shifts)
+    output_path = Path(args.out_volume)
+
+    assert_output_exists(output_path, p, args)
+
+    # Find slice files
+    slice_files_list = sorted(slices_dir.glob('*.ome.zarr'))
+    if not slice_files_list:
+        p.error(f"No .ome.zarr files found in {slices_dir}")
+
+    # Extract slice IDs and build mapping
+    pattern = re.compile(args.slice_pattern)
+    slice_files = {}
+    for f in slice_files_list:
+        match = pattern.search(f.name)
+        if match:
+            slice_id = int(match.group(1))
+            slice_files[slice_id] = f
+
+    if not slice_files:
+        p.error(f"No files matched pattern '{args.slice_pattern}' in {slices_dir}")
+
+    logger.info(f"Found {len(slice_files)} slice files")
+
+    # Limit slices for testing
+    if args.max_slices:
+        slice_ids = sorted(slice_files.keys())[:args.max_slices]
+        slice_files = {k: slice_files[k] for k in slice_ids}
+        logger.info(f"Limited to {len(slice_files)} slices for testing")
+
+    # Load shifts
+    logger.info(f"Loading shifts from {shifts_path}")
+    cumsum_mm, all_shift_ids = load_shifts_csv(shifts_path)
+
+    # Get resolution from first slice
+    # NOTE: read_omezarr returns resolution in MILLIMETERS (OME-NGFF standard)
+    first_slice_id = sorted(slice_files.keys())[0]
+    first_vol, first_res = read_omezarr(str(slice_files[first_slice_id]), level=0)
+
+    # Resolution: res is [z, y, x] in mm from OME-NGFF, convert to µm
+    res_x_mm = first_res[-1] if len(first_res) >= 3 else first_res[0]
+    res_y_mm = first_res[-2] if len(first_res) >= 3 else first_res[0]
+    res_z_mm = first_res[0] if len(first_res) >= 3 else 0.200  # default 200 µm
+
+    # Convert to µm for display and calculations
+    res_x_um = res_x_mm * 1000
+    res_y_um = res_y_mm * 1000
+    res_z_um = res_z_mm * 1000
+
+    if args.z_spacing_um:
+        res_z_um = args.z_spacing_um
+
+    logger.info(f"Resolution: Z={res_z_um:.2f} µm, Y={res_y_um:.2f} µm, X={res_x_um:.2f} µm")
+
+    # Convert shifts to pixels (use X resolution for both X and Y for simplicity)
+    cumsum_px = convert_shifts_to_pixels(cumsum_mm, res_x_um)
+
+    # Filter to only slices we have files for
+    available_ids = sorted(slice_files.keys())
+    cumsum_px = {k: v for k, v in cumsum_px.items() if k in available_ids}
+
+    # Fill in missing shifts with zero
+    for slice_id in available_ids:
+        if slice_id not in cumsum_px:
+            logger.warning(f"No shift for slice {slice_id}, using (0, 0)")
+            cumsum_px[slice_id] = (0.0, 0.0)
+
+    # Center drift if requested
+    if args.center_drift:
+        cumsum_px = center_shifts(cumsum_px, available_ids)
+        logger.info("Centered drift around middle slice")
+
+    # Compute output shape
+    logger.info("Computing output shape...")
+    output_shape, (x0, y0) = compute_output_shape(slice_files, cumsum_px, args.overlap_slices)
+    logger.info(f"Output shape: {output_shape} (Z, Y, X)")
+    logger.info(f"Origin offset: ({x0:.1f}, {y0:.1f}) px")
+
+    # Adjust shifts by origin
+    cumsum_px = {
+        slice_id: (dx - x0, dy - y0)
+        for slice_id, (dx, dy) in cumsum_px.items()
+    }
+
+    # Stack slices
+    logger.info(f"Stacking {len(slice_files)} slices (blending: {args.blending})...")
+
+    # Use chunked writer to avoid memory issues
+    output = AnalysisOmeZarrWriter(
+        str(output_path), output_shape,
+        chunk_shape=(min(100, output_shape[0]), min(512, output_shape[1]), min(512, output_shape[2])),
+        dtype=np.float32
+    )
+
+    z_cursor = 0
+    for i, slice_id in enumerate(available_ids):
+        slice_file = slice_files[slice_id]
+        vol, _ = read_omezarr(str(slice_file), level=0)
+        vol_data = np.array(vol[:]).astype(np.float32)
+
+        dx, dy = cumsum_px[slice_id]
+
+        # Get the cropped slice and destination coordinates
+        shifted, dst_coords = apply_xy_shift(vol_data, dx, dy, (output_shape[1], output_shape[2]))
+
+        if shifted is None:
+            logger.warning(f"Slice {slice_id} is entirely outside output bounds, skipping")
+            continue
+
+        dst_y_start, dst_y_end, dst_x_start, dst_x_end = dst_coords
+
+        # Determine Z range for this slice
+        z_start = z_cursor
+        z_end = z_start + shifted.shape[0]
+
+        # Handle overlap
+        if args.overlap_slices > 0 and i > 0:
+            z_start -= args.overlap_slices
+
+        # Ensure we don't exceed output bounds
+        if z_end > output_shape[0]:
+            z_end = output_shape[0]
+            shifted = shifted[:z_end - z_start]
+
+        # Place/blend into output at the correct XY position
+        if z_start < z_end:
+            if args.blending == 'none' or i == 0:
+                # No blending - just write to the specific region
+                output[z_start:z_end, dst_y_start:dst_y_end, dst_x_start:dst_x_end] = shifted
+            else:
+                # Read existing region, blend, write back
+                existing = np.array(output[z_start:z_end, dst_y_start:dst_y_end, dst_x_start:dst_x_end])
+                blended = blend_overlap_xy(existing, shifted, args.blending)
+                output[z_start:z_end, dst_y_start:dst_y_end, dst_x_start:dst_x_end] = blended
+
+        z_cursor = z_end
+
+        logger.info(f"  Slice {slice_id:02d}: shift=({dx:.1f}, {dy:.1f}) px, z=[{z_start}:{z_end}], "
+                    f"xy=[{dst_y_start}:{dst_y_end}, {dst_x_start}:{dst_x_end}]")
+
+    # Finalize with pyramid
+    logger.info("Finalizing and generating pyramid levels...")
+    resolution = [res_z_um, res_y_um, res_x_um]
+    output.finalize(resolution, n_levels=3)
+
+    # Generate preview if requested
+    if args.preview:
+        # Generate 3-panel preview from zarr output
+        generate_preview_from_zarr(output, args.preview)
+
+    logger.info("Done!")
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/linum_stack_slices_motor.py
+++ b/scripts/linum_stack_slices_motor.py
@@ -1,0 +1,729 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Stack 3D slices using motor positions for XY alignment and simplified Z-matching.
+
+This script implements motor-position-based 3D reconstruction:
+1. XY ALIGNMENT: Uses shifts_xy.csv (motor positions) - precise and consistent
+2. Z-MATCHING: Finds optimal overlap depth using correlation - simplified
+
+This replaces the complex pairwise registration approach when motor positions
+are reliable. The XY shifts from the microscope stage are more precise than
+image-based registration for positioning.
+
+The Z-matching finds where consecutive slices should overlap by correlating
+the bottom of one slice with the top of the next.
+"""
+
+import linumpy._thread_config  # noqa: F401
+
+import argparse
+import logging
+import re
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import SimpleITK as sitk
+from tqdm import tqdm
+
+from linumpy.io.zarr import read_omezarr, AnalysisOmeZarrWriter
+from linumpy.stitching.stacking import (
+    find_z_overlap, apply_2d_transform, apply_transform_to_volume,
+    apply_xy_shift, blend_overlap_z, refine_z_blend_overlap
+)
+from linumpy.utils.io import add_overwrite_arg, assert_output_exists
+from linumpy.utils.metrics import collect_stack_metrics
+from linumpy.utils.shifts import load_shifts_csv
+
+logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
+logger = logging.getLogger(__name__)
+
+
+def _build_arg_parser():
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter)
+    p.add_argument('in_slices_dir',
+                   help='Directory containing slice volumes (.ome.zarr)')
+    p.add_argument('in_shifts',
+                   help='CSV file with XY shifts (shifts_xy.csv)')
+    p.add_argument('out_stack',
+                   help='Output stacked volume (.ome.zarr)')
+
+    # Registration refinements (optional)
+    p.add_argument('--transforms_dir', type=str, default=None,
+                   help='Directory containing pairwise registration outputs.\n'
+                        'If provided, applies rotation/translation refinements.')
+    p.add_argument('--rotation_only', action='store_true',
+                   help='Apply only rotation from registration transforms, ignore translation.\n'
+                        'Use this to prevent XY drift when motor positions are trusted.')
+    p.add_argument('--max_rotation_deg', type=float, default=1.0,
+                   help='Maximum rotation to apply per slice (degrees). Larger rotations\n'
+                        'are clamped to prevent registration errors from causing drift. [%(default)s]')
+    p.add_argument('--accumulate_translations', action='store_true',
+                   help='Accumulate pairwise translations cumulatively across slices.\n'
+                        'Each slice gets the sum of all preceding pairwise translations.\n'
+                        'This propagates corrections through the stack, fixing cumulative\n'
+                        'drift and motor position errors. Rotation stays per-slice.')
+    p.add_argument('--max_pairwise_translation', type=float, default=0,
+                   help='Maximum reliable pairwise translation magnitude (pixels).\n'
+                        'Translations at or above this value are assumed to be registration\n'
+                        'failures (hitting the optimizer boundary) and excluded from\n'
+                        'accumulation. Set to registration_max_translation. 0 = disabled.\n'
+                        '[%(default)s]')
+    p.add_argument('--smooth_window', type=int, default=0,
+                   help='Smooth cumulative translations with a moving average of this window\n'
+                        'size (in slices). Reduces XY jitter between consecutive slices,\n'
+                        'improving blend quality. 0 disables smoothing. [%(default)s]')
+    p.add_argument('--skip_error_transforms', action='store_true',
+                   help='Skip registration transforms flagged as overall_status="error"\n'
+                        'in pairwise_registration_metrics.json.  Error-status registrations\n'
+                        'are typically spurious (e.g. registered against an interpolated\n'
+                        'slice) and applying them introduces large rotation/translation\n'
+                        'artifacts at those slice boundaries.')
+    p.add_argument('--skip_warning_transforms', action='store_true',
+                   help='Also skip transforms with overall_status="warning".\n'
+                        'Warning-status registrations hit the optimizer boundary (e.g. large\n'
+                        'translation clamped at max_translation_px), making their fixed_z/\n'
+                        'moving_z Z-offsets unreliable. Discarding them falls back to the\n'
+                        'default moving_z_first_index, preventing Z gaps caused by bad\n'
+                        'Z-overlap estimates from failed registrations.')
+    p.add_argument('--no_xy_shift', action='store_true',
+                   help='Skip XY shifting from motor positions.\n'
+                        'Use when slices are already in common space (e.g., from bring_to_common_space).')
+    # Z-matching parameters
+    p.add_argument('--slicing_interval_mm', type=float, default=0.200,
+                   help='Physical slice thickness in mm [%(default)s]')
+    p.add_argument('--search_range_mm', type=float, default=0.100,
+                   help='Search range for Z-matching in mm [%(default)s]')
+    p.add_argument('--use_expected_overlap', action='store_true',
+                   help='Use expected overlap from slicing_interval instead of correlation')
+    p.add_argument('--moving_z_first_index', type=int, default=8,
+                   help='Starting Z-index in moving volume to skip noisy data [%(default)s]')
+
+    # Blending
+    p.add_argument('--blend', action='store_true',
+                   help='Blend overlapping regions using a cosine (Hann) ramp')
+    p.add_argument('--blend_depth', type=int, default=None,
+                   help='Number of z-slices to blend (default: auto from overlap)')
+    p.add_argument('--blend_refinement_px', type=float, default=0,
+                   help='Enable Z-blend refinement: phase-correlation-based XY shift\n'
+                        'correction applied in the overlap zone before blending, analogous\n'
+                        'to stitch_3d_with_refinement for tiles. Set to the maximum\n'
+                        'allowed shift in pixels (e.g. 10). 0 disables. [%(default)s]')
+
+    # Output options
+    p.add_argument('--pyramid_resolutions', type=float, nargs='+',
+                   default=[10, 25, 50, 100],
+                   help='Target resolutions for pyramid levels in microns')
+    p.add_argument('--make_isotropic', action='store_true', default=True,
+                   help='Resample to isotropic voxels')
+    p.add_argument('--no_isotropic', dest='make_isotropic', action='store_false')
+
+    # Debug
+    p.add_argument('--max_slices', type=int, default=None,
+                   help='Maximum slices to process (for testing)')
+    p.add_argument('--output_z_matches', type=str, default=None,
+                   help='Output CSV with Z-matching results')
+
+    add_overwrite_arg(p)
+    return p
+
+
+def load_registration_transforms(transforms_dir, slice_ids,
+                                 skip_error_status=False,
+                                 skip_warning_status=False):
+    """
+    Load pairwise registration transforms from directory.
+
+    Parameters
+    ----------
+    transforms_dir : Path
+        Directory containing registration outputs (subdirs per slice)
+    slice_ids : list
+        List of slice IDs to load transforms for
+    skip_error_status : bool
+        If True, discard transforms whose pairwise_registration_metrics.json
+        reports overall_status == 'error'.  These are typically registrations
+        that failed (e.g. registered against an interpolated/synthetic slice)
+        and would introduce spurious rotations into the stack.
+    skip_warning_status : bool
+        If True, also discard transforms with overall_status == 'warning'.
+        Warning-status registrations hit the optimizer boundary (e.g. large
+        translation or rotation) and their Z-offsets (fixed_z/moving_z) are
+        unreliable, causing incorrect Z-overlap computation during stacking.
+        Discarding them falls back to the default moving_z_first_index.
+
+    Returns
+    -------
+    dict
+        Mapping from slice_id to (transform, z_offset) tuple
+    """
+    import json
+
+    transforms_dir = Path(transforms_dir)
+    transforms = {}
+
+    for slice_id in slice_ids[1:]:  # First slice has no transform
+        # Find transform directory for this slice
+        # Pattern: slice_z{id}_* or similar
+        matching_dirs = list(transforms_dir.glob(f"*z{slice_id:02d}*")) + \
+                       list(transforms_dir.glob(f"*z{slice_id}*"))
+
+        if not matching_dirs:
+            logger.warning(f"No transform found for slice {slice_id}")
+            transforms[slice_id] = None
+            continue
+
+        transform_dir = matching_dirs[0]
+
+        # Load transform file
+        tfm_files = list(transform_dir.glob("*.tfm"))
+        offset_files = list(transform_dir.glob("*.txt"))
+
+        if not tfm_files:
+            logger.warning(f"No .tfm file in {transform_dir}")
+            transforms[slice_id] = None
+            continue
+
+        try:
+            # Check registration quality status before loading the transform
+            if skip_error_status or skip_warning_status:
+                metrics_files = list(transform_dir.glob("pairwise_registration_metrics.json"))
+                if metrics_files:
+                    with open(metrics_files[0]) as f:
+                        metrics = json.load(f)
+                    status = metrics.get("overall_status", "ok")
+                    should_skip = (status == "error" and skip_error_status) or \
+                                  (status == "warning" and skip_warning_status)
+                    if should_skip:
+                        logger.warning(
+                            f"Slice {slice_id}: skipping transform with "
+                            f"overall_status='{status}' (unreliable registration)"
+                        )
+                        transforms[slice_id] = None
+                        continue
+
+            tfm = sitk.ReadTransform(str(tfm_files[0]))
+
+            # Load z-offsets if available
+            # offsets.txt contains [fixed_z, moving_z]
+            # - fixed_z: Z-index in fixed volume where overlap region starts
+            # - moving_z: Z-index in moving volume where overlap region starts
+            # These indicate WHERE the volumes overlap, not how much.
+            fixed_z = None
+            moving_z = None
+            if offset_files:
+                offsets = np.loadtxt(str(offset_files[0]))
+                if len(offsets) >= 2:
+                    fixed_z = int(offsets[0])
+                    moving_z = int(offsets[1])
+                    logger.debug(f"Slice {slice_id}: fixed_z={fixed_z}, moving_z={moving_z}")
+
+            transforms[slice_id] = (tfm, fixed_z, moving_z)
+            logger.debug(f"Loaded transform for slice {slice_id}")
+
+        except Exception as e:
+            logger.warning(f"Could not load transform for slice {slice_id}: {e}")
+            transforms[slice_id] = None
+
+    return transforms
+
+
+def compute_output_shape(slice_files, cumsum_px, first_vol_shape):
+    """Compute output volume shape to fit all slices."""
+    xmin, xmax, ymin, ymax = [0], [first_vol_shape[2]], [0], [first_vol_shape[1]]
+
+    for slice_id, (dx, dy) in cumsum_px.items():
+        # Assuming all slices have similar XY dimensions
+        xmin.append(dx)
+        xmax.append(dx + first_vol_shape[2])
+        ymin.append(dy)
+        ymax.append(dy + first_vol_shape[1])
+
+    x0 = min(xmin)
+    y0 = min(ymin)
+    nx = int(np.ceil(max(xmax) - x0))
+    ny = int(np.ceil(max(ymax) - y0))
+
+    return ny, nx, x0, y0
+
+
+def main():
+    p = _build_arg_parser()
+    args = p.parse_args()
+
+    slices_dir = Path(args.in_slices_dir)
+    output_path = Path(args.out_stack)
+
+    assert_output_exists(output_path, p, args)
+
+    # Find slice files
+    slice_files_list = sorted(slices_dir.glob('*.ome.zarr'))
+    if not slice_files_list:
+        p.error(f"No .ome.zarr files found in {slices_dir}")
+
+    # Extract slice IDs
+    pattern = re.compile(r'slice_z(\d+)')
+    slice_files = {}
+    for f in slice_files_list:
+        match = pattern.search(f.name)
+        if match:
+            slice_id = int(match.group(1))
+            slice_files[slice_id] = f
+
+    if not slice_files:
+        p.error(f"No files matched slice pattern in {slices_dir}")
+
+    available_ids = sorted(slice_files.keys())
+    if args.max_slices:
+        available_ids = available_ids[:args.max_slices]
+        slice_files = {k: slice_files[k] for k in available_ids}
+
+    logger.info(f"Found {len(slice_files)} slices: {available_ids[0]} to {available_ids[-1]}")
+
+    # Load shifts
+    logger.info(f"Loading shifts from {args.in_shifts}")
+    cumsum_mm, all_shift_ids = load_shifts_csv(args.in_shifts)
+
+    # Get resolution from first slice
+    # NOTE: read_omezarr returns resolution in MILLIMETERS (OME-NGFF standard)
+    first_id = available_ids[0]
+    first_vol, first_res = read_omezarr(str(slice_files[first_id]), level=0)
+    first_vol = np.array(first_vol[:])
+
+    # Resolution in mm (from OME-NGFF metadata)
+    res_z_mm = first_res[0] if len(first_res) >= 1 else 0.010  # default 10 µm
+    res_y_mm = first_res[1] if len(first_res) >= 2 else first_res[0]
+    res_x_mm = first_res[2] if len(first_res) >= 3 else first_res[0]
+
+    logger.info(f"Resolution: Z={res_z_mm*1000:.2f} µm, Y={res_y_mm*1000:.2f} µm, X={res_x_mm*1000:.2f} µm")
+
+    # Handle XY shifts
+    if args.no_xy_shift:
+        # Slices are already in common space, no XY shifting needed
+        logger.info("Skipping XY shifts (--no_xy_shift specified, slices already in common space)")
+        cumsum_px = {slice_id: (0.0, 0.0) for slice_id in available_ids}
+        out_ny, out_nx = first_vol.shape[1], first_vol.shape[2]
+        x0, y0 = 0, 0
+    else:
+        # Convert shifts (in mm) to pixels: shift_mm / res_mm = pixels
+        cumsum_px = {}
+        for slice_id in available_ids:
+            if slice_id in cumsum_mm:
+                dx_mm, dy_mm = cumsum_mm[slice_id]
+            else:
+                logger.warning(f"No shift for slice {slice_id}, using (0, 0)")
+                dx_mm, dy_mm = 0.0, 0.0
+            # mm / mm = pixels
+            cumsum_px[slice_id] = (dx_mm / res_x_mm, dy_mm / res_y_mm)
+
+        # Center shifts
+        middle_id = available_ids[len(available_ids) // 2]
+        center_dx, center_dy = cumsum_px[middle_id]
+        cumsum_px = {k: (dx - center_dx, dy - center_dy) for k, (dx, dy) in cumsum_px.items()}
+
+        # Compute output XY shape
+        out_ny, out_nx, x0, y0 = compute_output_shape(slice_files, cumsum_px, first_vol.shape)
+
+        # Adjust shifts by origin
+        cumsum_px = {k: (dx - x0, dy - y0) for k, (dx, dy) in cumsum_px.items()}
+
+    logger.info(f"Output XY shape: {out_ny} x {out_nx}")
+
+    # Load registration transforms if provided
+    registration_transforms = {}
+    if args.transforms_dir:
+        transforms_dir = Path(args.transforms_dir)
+        if transforms_dir.exists():
+            logger.info(f"Loading registration transforms from {transforms_dir}")
+            registration_transforms = load_registration_transforms(
+                transforms_dir, available_ids,
+                skip_error_status=args.skip_error_transforms,
+                skip_warning_status=args.skip_warning_transforms)
+            n_loaded = sum(1 for v in registration_transforms.values() if v is not None)
+            logger.info(f"Loaded {n_loaded} transforms for refinement")
+        else:
+            logger.warning(f"Transforms directory not found: {transforms_dir}")
+
+    # Accumulate translations cumulatively if requested
+    # Translations are moved from the transforms into cumsum_px so that:
+    # 1. The output canvas is sized to accommodate the cumulative shifts
+    # 2. Transforms only apply rotation (no content lost at slice edges)
+    if args.accumulate_translations and registration_transforms:
+        # First pass: extract all pairwise translations
+        pairwise_translations = {}
+        for slice_id in available_ids[1:]:
+            if slice_id in registration_transforms and registration_transforms[slice_id] is not None:
+                transform, fixed_z, moving_z = registration_transforms[slice_id]
+                params = list(transform.GetParameters())
+                tx = params[3] if len(params) > 3 else 0
+                ty = params[4] if len(params) > 4 else 0
+                pairwise_translations[slice_id] = (tx, ty)
+
+        # Filter unreliable translations before accumulation
+        # Translations at the registration boundary are optimizer failures, not real corrections
+        if pairwise_translations and args.max_pairwise_translation > 0:
+            boundary = args.max_pairwise_translation * 0.95  # 95% of boundary = likely clamped
+            n_excluded = 0
+            for slice_id in list(pairwise_translations.keys()):
+                tx, ty = pairwise_translations[slice_id]
+                mag = np.sqrt(tx**2 + ty**2)
+                if mag >= boundary:
+                    logger.warning(f"Slice {slice_id}: excluding boundary translation "
+                                   f"tx={tx:.1f}, ty={ty:.1f} (mag={mag:.1f} >= {boundary:.1f})")
+                    pairwise_translations[slice_id] = (0.0, 0.0)
+                    n_excluded += 1
+            n_total = len(pairwise_translations)
+            logger.info(f"Translation filter: excluded {n_excluded}/{n_total} pairs "
+                        f"at boundary (>= {boundary:.1f} px)")
+
+        # Second pass: accumulate filtered translations
+        cumulative_tx, cumulative_ty = 0.0, 0.0
+        n_accumulated = 0
+        for slice_id in available_ids[1:]:
+            if slice_id in pairwise_translations:
+                tx, ty = pairwise_translations[slice_id]
+                cumulative_tx += tx
+                cumulative_ty += ty
+                if tx != 0 or ty != 0:
+                    n_accumulated += 1
+                logger.debug(f"Slice {slice_id}: pairwise tx={tx:.2f}, ty={ty:.2f} -> "
+                             f"cumulative tx={cumulative_tx:.2f}, ty={cumulative_ty:.2f}")
+            # Every slice from this point gets the current cumulative correction
+            # Sign is negated: SimpleITK tx=+N shifts content LEFT (fetches from x+N),
+            # but cumsum_px dx=+N places content RIGHT. To achieve the same effect
+            # as the transform, we subtract.
+            prev_dx, prev_dy = cumsum_px[slice_id]
+            cumsum_px[slice_id] = (prev_dx - cumulative_tx, prev_dy - cumulative_ty)
+        logger.info(f"Accumulated translations for {n_accumulated} slices "
+                     f"(final cumulative: tx={cumulative_tx:.2f}, ty={cumulative_ty:.2f})")
+
+        # Smooth cumulative translations to reduce per-slice XY jitter
+        if args.smooth_window > 0:
+            ids_list = sorted(cumsum_px.keys())
+            x_vals = np.array([cumsum_px[sid][0] for sid in ids_list])
+            y_vals = np.array([cumsum_px[sid][1] for sid in ids_list])
+
+            w = args.smooth_window
+            kernel = np.ones(w) / w
+            x_smooth = np.convolve(x_vals, kernel, mode='same')
+            y_smooth = np.convolve(y_vals, kernel, mode='same')
+
+            # Keep original values at edges where the kernel doesn't fully overlap
+            half_w = w // 2
+            x_smooth[:half_w] = x_vals[:half_w]
+            x_smooth[-half_w:] = x_vals[-half_w:]
+            y_smooth[:half_w] = y_vals[:half_w]
+            y_smooth[-half_w:] = y_vals[-half_w:]
+
+            max_correction = 0.0
+            for j, sid in enumerate(ids_list):
+                correction = np.sqrt((x_smooth[j] - x_vals[j])**2 + (y_smooth[j] - y_vals[j])**2)
+                max_correction = max(max_correction, correction)
+                cumsum_px[sid] = (float(x_smooth[j]), float(y_smooth[j]))
+
+            logger.info(f"Smoothed translations with window={w} "
+                        f"(max correction: {max_correction:.1f} px)")
+
+        # Recompute output XY shape to fit the shifted slices
+        out_ny, out_nx, x0, y0 = compute_output_shape(slice_files, cumsum_px, first_vol.shape)
+        cumsum_px = {k: (dx - x0, dy - y0) for k, (dx, dy) in cumsum_px.items()}
+        logger.info(f"Adjusted output XY shape for accumulated translations: {out_ny} x {out_nx}")
+
+    # Smooth per-slice rotations to reduce jitter from isolated correction outliers.
+    # Rotations are applied independently per slice, so alternating ±1-2° corrections
+    # (or a single large outlier like z27 at -2.1° surrounded by ~0° slices) create
+    # visible notching at tissue boundaries throughout the whole volume.
+    # This runs regardless of accumulate_translations.
+    smoothed_rotations = {}
+    if args.smooth_window > 0 and registration_transforms:
+        ids_with_tfm = [sid for sid in available_ids
+                        if sid in registration_transforms
+                        and registration_transforms[sid] is not None]
+        if ids_with_tfm:
+            angle_ids = sorted(ids_with_tfm)
+            raw_angles = []
+            for sid in angle_ids:
+                tfm_tuple = registration_transforms[sid]
+                tfm, _, _ = tfm_tuple
+                params = list(tfm.GetParameters())
+                a = params[2] if len(params) > 2 else 0.0
+                # Clamp before smoothing (same cap as apply_2d_transform)
+                if args.max_rotation_deg > 0:
+                    max_rad = np.radians(args.max_rotation_deg)
+                    a = float(np.clip(a, -max_rad, max_rad))
+                raw_angles.append(a)
+            raw_angles = np.array(raw_angles)
+            w = args.smooth_window
+            kernel = np.ones(w) / w
+            smooth_angles = np.convolve(raw_angles, kernel, mode='same')
+            half_w = w // 2
+            smooth_angles[:half_w] = raw_angles[:half_w]
+            smooth_angles[-half_w:] = raw_angles[-half_w:]
+            max_rot_corr = float(np.max(np.abs(smooth_angles - raw_angles)))
+            logger.info(f"Smoothed rotations with window={w} "
+                        f"(max correction: {np.degrees(max_rot_corr):.3f}°)")
+            for j, sid in enumerate(angle_ids):
+                smoothed_rotations[sid] = float(smooth_angles[j])
+
+    # First pass: find Z overlaps (use registration z-offsets if available)
+    logger.info("Finding Z-overlaps between consecutive slices...")
+    z_matches = []
+    total_z = first_vol.shape[0]
+
+    # Cache volume shapes to avoid re-reading during smoothing
+    volume_shapes = {first_id: first_vol.shape}
+
+    prev_vol = first_vol
+    prev_id = first_id
+
+    for i, slice_id in enumerate(tqdm(available_ids[1:], desc="Z-matching")):
+        vol, _ = read_omezarr(str(slice_files[slice_id]), level=0)
+        vol = np.array(vol[:])
+        volume_shapes[slice_id] = vol.shape  # Cache shape
+
+        # Check if we have registration-derived Z-indices
+        fixed_z = None
+        moving_z = None
+        if slice_id in registration_transforms and registration_transforms[slice_id] is not None:
+            _, fixed_z, moving_z = registration_transforms[slice_id]
+
+        if args.use_expected_overlap:
+            # Expected overlap from known slicing interval and volume depth
+            # overlap = trimmed_volume_depth - slicing_interval_in_voxels
+            # This ensures each slice contributes exactly slicing_interval new voxels
+            moving_z = moving_z if moving_z is not None else args.moving_z_first_index
+            interval_voxels = int(args.slicing_interval_mm / res_z_mm)
+            overlap = vol.shape[0] - (moving_z or 0) - interval_voxels
+            overlap = max(0, overlap)
+            corr = 0.0
+            logger.debug(f"Slice {slice_id}: expected overlap={overlap} voxels "
+                         f"(vol_depth={vol.shape[0]}, moving_z={moving_z}, interval={interval_voxels})")
+        elif fixed_z is not None:
+            # We have registration-derived indices
+            # fixed_z: Z-index in prev_vol where overlap starts
+            # moving_z: Z-index in vol where overlap starts (skipping noisy initial slices)
+            # The overlap depth is: prev_vol.shape[0] - fixed_z
+            prev_nz = prev_vol.shape[0]
+            overlap = max(0, prev_nz - fixed_z)
+            corr = 1.0  # Assume good correlation since registration found it
+            logger.debug(f"Slice {slice_id}: fixed_z={fixed_z}, moving_z={moving_z}, overlap={overlap} voxels")
+        else:
+            # find_z_overlap expects resolution in µm for its internal calculation
+            res_z_um = res_z_mm * 1000
+            overlap, corr = find_z_overlap(
+                prev_vol, vol,
+                args.slicing_interval_mm, args.search_range_mm, res_z_um
+            )
+            moving_z = args.moving_z_first_index  # Use default
+
+        z_matches.append({
+            'fixed_id': prev_id,
+            'moving_id': slice_id,
+            'overlap_voxels': overlap,
+            'moving_z_start': moving_z,  # Z-index in moving volume where to start
+            'correlation': corr
+        })
+
+        # Account for moving_z_start when computing total depth
+        # We add (vol_depth - moving_z - overlap) new voxels
+        moving_z_val = moving_z if moving_z is not None else 0
+        contribution = vol.shape[0] - moving_z_val - overlap
+        total_z += max(0, contribution)
+        prev_vol = vol
+        prev_id = slice_id
+
+    # Save Z-matches if requested
+    if args.output_z_matches:
+        pd.DataFrame(z_matches).to_csv(args.output_z_matches, index=False)
+        logger.info(f"Z-matches saved to {args.output_z_matches}")
+
+    # Smooth Z-overlaps: detect and correct outliers
+    overlaps = np.array([m['overlap_voxels'] for m in z_matches])
+    if len(overlaps) > 3:
+        median_overlap = np.median(overlaps)
+        # Detect outliers (deviates more than 30% from median)
+        # Using 30% to catch more outliers that cause visible jumps
+        outlier_threshold = 0.3 * median_overlap
+        smoothed = False
+        logger.info(f"Z-overlap smoothing: median={median_overlap:.1f}, threshold=±{outlier_threshold:.1f}")
+        for i, match in enumerate(z_matches):
+            deviation = abs(match['overlap_voxels'] - median_overlap)
+            if deviation > outlier_threshold:
+                old_overlap = match['overlap_voxels']
+                # Replace with local median or global median
+                if i > 0 and i < len(z_matches) - 1:
+                    local_median = np.median([z_matches[i-1]['overlap_voxels'],
+                                              z_matches[i+1]['overlap_voxels'] if i+1 < len(z_matches) else median_overlap])
+                    match['overlap_voxels'] = int(local_median)
+                else:
+                    match['overlap_voxels'] = int(median_overlap)
+                logger.warning(f"Slice {match['moving_id']}: corrected outlier overlap {old_overlap} -> {match['overlap_voxels']} voxels (deviation={deviation:.1f})")
+                smoothed = True
+
+        # Recompute total_z after smoothing if any corrections were made
+        if smoothed:
+            # Use cached shapes instead of re-reading volumes
+            total_z = volume_shapes[first_id][0]
+            for match in z_matches:
+                slice_id = match['moving_id']
+                moving_z_val = match.get('moving_z_start', 0) or 0
+                overlap = match['overlap_voxels']
+                vol_nz = volume_shapes[slice_id][0]
+                contribution = vol_nz - moving_z_val - overlap
+                total_z += max(0, contribution)
+            logger.info(f"Recomputed total Z after smoothing: {total_z}")
+
+    # Log Z-match summary
+    overlaps = [m['overlap_voxels'] for m in z_matches]
+    logger.info(f"Z-overlap: mean={np.mean(overlaps):.1f}, std={np.std(overlaps):.1f} voxels")
+
+    # Second pass: assemble volume
+    logger.info(f"Assembling volume: {total_z} x {out_ny} x {out_nx}")
+    output_shape = (total_z, out_ny, out_nx)
+
+    output = AnalysisOmeZarrWriter(
+        str(output_path), output_shape,
+        chunk_shape=(100, 100, 100),
+        dtype=np.float32
+    )
+
+    # Place first slice
+    first_dx, first_dy = cumsum_px[first_id]
+    first_vol_f32 = first_vol.astype(np.float32)
+    shifted_first, first_coords = apply_xy_shift(first_vol_f32, first_dx, first_dy, (out_ny, out_nx))
+
+    if shifted_first is not None:
+        y0, y1, x0, x1 = first_coords
+        output[:first_vol.shape[0], y0:y1, x0:x1] = shifted_first
+        logger.info(f"  First slice: shift=({first_dx:.1f}, {first_dy:.1f}) px, xy=[{y0}:{y1}, {x0}:{x1}]")
+
+    z_cursor = first_vol.shape[0]
+
+    # Stack remaining slices
+    for i, match in enumerate(tqdm(z_matches, desc="Stacking")):
+        slice_id = match['moving_id']
+        overlap = match['overlap_voxels']
+        moving_z_start = match.get('moving_z_start', 0) or 0
+
+        vol, _ = read_omezarr(str(slice_files[slice_id]), level=0)
+        vol = np.array(vol[:]).astype(np.float32)
+
+        # Skip initial noisy z-slices in moving volume
+        if moving_z_start > 0:
+            vol = vol[moving_z_start:]
+            logger.debug(f"Slice {slice_id}: skipped first {moving_z_start} z-slices")
+
+        # Apply registration transform (rotation/small translation refinement) if available
+        if slice_id in registration_transforms and registration_transforms[slice_id] is not None:
+            transform, _, _ = registration_transforms[slice_id]
+            use_rotation_only = args.rotation_only or args.accumulate_translations
+            override_rot = smoothed_rotations.get(slice_id)  # None if no smoothing
+            vol = apply_transform_to_volume(vol, transform,
+                                           rotation_only=use_rotation_only,
+                                           max_rotation_deg=args.max_rotation_deg,
+                                           override_rotation=override_rot)
+            if use_rotation_only:
+                logger.debug(f"Applied rotation-only transform to slice {slice_id} (max_rot={args.max_rotation_deg}°)")
+            else:
+                logger.debug(f"Applied registration transform to slice {slice_id}")
+
+        # Apply XY shift (from motor positions)
+        dx, dy = cumsum_px[slice_id]
+        shifted, dst_coords = apply_xy_shift(vol, dx, dy, (out_ny, out_nx))
+
+        if shifted is None:
+            logger.warning(f"Slice {slice_id} is outside output bounds, skipping")
+            continue
+
+        dst_y0, dst_y1, dst_x0, dst_x1 = dst_coords
+
+        # Determine Z range for this slice
+        z_start = z_cursor - overlap
+        z_end = z_start + shifted.shape[0]
+
+        # Ensure we don't exceed output bounds
+        if z_end > output_shape[0]:
+            z_end = output_shape[0]
+            shifted = shifted[:z_end - z_start]
+
+        if args.blend and overlap > 0 and z_start < z_cursor:
+            # Blend overlap region
+            overlap_z_start = z_start
+            overlap_z_end = min(z_cursor, z_end)
+            overlap_depth = overlap_z_end - overlap_z_start
+
+            if overlap_depth > 0:
+                # Get overlap regions from output and shifted
+                existing = np.array(output[overlap_z_start:overlap_z_end, dst_y0:dst_y1, dst_x0:dst_x1])
+                moving_overlap = shifted[:overlap_depth]
+
+                # Intensity matching: adjust moving slice to match existing in overlap
+                # This reduces visible bands at slice transitions
+                existing_valid = existing > 0
+                moving_valid = moving_overlap > 0
+                both_valid = existing_valid & moving_valid
+
+                if np.sum(both_valid) > 1000:  # Need enough pixels for reliable statistics
+                    existing_median = np.median(existing[both_valid])
+                    moving_median = np.median(moving_overlap[both_valid])
+
+                    if moving_median > 1e-6 and existing_median > 1e-6:
+                        scale = existing_median / moving_median
+                        # Clamp scale to prevent extreme corrections
+                        scale = np.clip(scale, 0.5, 2.0)
+                        if abs(scale - 1.0) > 0.01:
+                            # Apply scaling to the entire shifted volume, not just overlap
+                            shifted = shifted * scale
+                            moving_overlap = shifted[:overlap_depth]
+                            logger.debug(f"Slice {slice_id}: intensity scale={scale:.3f}")
+
+                # Z-blend refinement: correct residual XY misalignment in the overlap zone
+                if args.blend_refinement_px > 0:
+                    moving_overlap, ref_mag = refine_z_blend_overlap(
+                        existing, moving_overlap, args.blend_refinement_px
+                    )
+                    if ref_mag > 0:
+                        logger.debug(f"Slice {slice_id}: z-blend XY refinement {ref_mag:.2f} px")
+
+                # Blend
+                blended = blend_overlap_z(existing, moving_overlap)
+                output[overlap_z_start:overlap_z_end, dst_y0:dst_y1, dst_x0:dst_x1] = blended
+
+                # Add non-overlapping part
+                if z_end > z_cursor:
+                    output[z_cursor:z_end, dst_y0:dst_y1, dst_x0:dst_x1] = shifted[overlap_depth:]
+        else:
+            # No blending - just write to specific region
+            output[z_start:z_end, dst_y0:dst_y1, dst_x0:dst_x1] = shifted
+
+        z_cursor = z_end
+
+        logger.debug(f"  Slice {slice_id}: z=[{z_start}:{z_end}], xy=[{dst_y0}:{dst_y1}, {dst_x0}:{dst_x1}]")
+
+    # Finalize with pyramid
+    logger.info("Generating pyramid levels...")
+    output.finalize(
+        first_res,
+        target_resolutions_um=args.pyramid_resolutions,
+        make_isotropic=args.make_isotropic
+    )
+
+    # Collect metrics
+    z_offsets = np.array([m['overlap_voxels'] for m in z_matches])
+    collect_stack_metrics(
+        output_shape=output_shape,
+        z_offsets=z_offsets,
+        num_slices=len(available_ids),
+        resolution=list(first_res),
+        output_path=str(output_path),
+        blend_enabled=args.blend,
+        normalize_enabled=False
+    )
+
+    logger.info(f"Done! Output saved to {output_path}")
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/linum_stitch_3d_refined.py
+++ b/scripts/linum_stitch_3d_refined.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Stitch a 3D mosaic grid with registration-refined blending.
+
+This script combines the best of both approaches:
+1. Uses MOTOR POSITIONS for tile placement (precise, no systematic drift)
+2. Uses REGISTRATION to refine blending transitions in overlap regions
+
+The registration is only used to compute sub-pixel adjustments for smoother
+blending at tile boundaries, NOT to change where tiles are positioned.
+
+This produces better seam quality while maintaining correct overall geometry.
+"""
+
+# Configure thread limits before numpy/scipy imports
+import linumpy._thread_config  # noqa: F401
+
+import argparse
+import json
+import logging
+from pathlib import Path
+
+import numpy as np
+
+from linumpy.io.zarr import read_omezarr, OmeZarrWriter
+from linumpy.stitching.motor import (compute_motor_positions,
+                                     compute_registration_refinements,
+                                     apply_blend_shift_refinement)
+from linumpy.utils.mosaic_grid import addVolumeToMosaic
+
+logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
+logger = logging.getLogger(__name__)
+
+
+def _build_arg_parser():
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
+    p.add_argument("input_volume",
+                   help="Full path to a 3D mosaic grid volume (.ome.zarr)")
+    p.add_argument("output_volume",
+                   help="Output stitched mosaic filename (.ome.zarr)")
+
+    p.add_argument("--overlap_fraction", type=float, default=0.2,
+                   help="Expected tile overlap fraction (0-1). [%(default)s]")
+    p.add_argument("--blending_method", type=str, default="diffusion",
+                   choices=["none", "average", "diffusion"],
+                   help="Blending method for overlap regions. [%(default)s]")
+    p.add_argument("--refinement_mode", type=str, default="blend_shift",
+                   choices=["none", "blend_shift", "full_shift"],
+                   help="How to apply registration refinements:\n"
+                        "  none: Pure motor positions, no refinement\n"
+                        "  blend_shift: Shift blending weights (recommended)\n"
+                        "  full_shift: Apply sub-pixel shifts to tiles [%(default)s]")
+    p.add_argument("--max_refinement_px", type=float, default=10.0,
+                   help="Maximum allowed refinement shift in pixels. [%(default)s]\n"
+                        "Larger shifts are clamped to prevent bad registrations.")
+    p.add_argument("--output_refinements", type=str, default=None,
+                   help="Output JSON file to save computed refinements for analysis.")
+    p.add_argument("--overwrite", "-f", action="store_true",
+                   help="Overwrite output if it exists.")
+    return p
+
+
+def stitch_with_refinements(volume, tile_shape, overlap_fraction, blending_method,
+                           refinement_mode, refinements, output_shape):
+    """
+    Stitch tiles using motor positions with optional registration refinements.
+    """
+    nz = volume.shape[0]
+    tile_height, tile_width = tile_shape[1], tile_shape[2]
+    nx = volume.shape[1] // tile_height
+    ny = volume.shape[2] // tile_width
+
+    # Compute motor-based positions
+    positions, step_y, step_x = compute_motor_positions(nx, ny, tile_shape, overlap_fraction)
+
+    # Initialize output array
+    output = np.zeros(output_shape, dtype=np.float32)
+
+    for i in range(nx):
+        for j in range(ny):
+            # Extract tile
+            r_start = i * tile_height
+            r_end = (i + 1) * tile_height
+            c_start = j * tile_width
+            c_end = (j + 1) * tile_width
+
+            tile = volume[:, r_start:r_end, c_start:c_end].copy()
+
+            if np.any(tile < 0):
+                tile = tile - tile.min()
+
+            # Get position from motor positions
+            pos = list(positions[i * ny + j])
+
+            # Apply refinements if requested
+            if refinement_mode == 'blend_shift':
+                # Collect refinements for this tile from its neighbors
+                tile_refinements = []
+
+                # From horizontal neighbor to the left
+                if j > 0 and (i, j-1) in refinements.get('horizontal', {}):
+                    ref = refinements['horizontal'][(i, j-1)]
+                    tile_refinements.append({'dy': -ref['dy'], 'dx': -ref['dx']})
+
+                # From horizontal neighbor to the right
+                if (i, j) in refinements.get('horizontal', {}):
+                    ref = refinements['horizontal'][(i, j)]
+                    tile_refinements.append(ref)
+
+                # From vertical neighbor above
+                if i > 0 and (i-1, j) in refinements.get('vertical', {}):
+                    ref = refinements['vertical'][(i-1, j)]
+                    tile_refinements.append({'dy': -ref['dy'], 'dx': -ref['dx']})
+
+                # From vertical neighbor below
+                if (i, j) in refinements.get('vertical', {}):
+                    ref = refinements['vertical'][(i, j)]
+                    tile_refinements.append(ref)
+
+                tile = apply_blend_shift_refinement(tile, tile_refinements, overlap_fraction)
+
+            elif refinement_mode == 'full_shift':
+                # Apply average refinement as position offset (sub-pixel)
+                # This is more aggressive - shifts the entire tile
+                tile_refinements = []
+
+                if j > 0 and (i, j-1) in refinements.get('horizontal', {}):
+                    tile_refinements.append(refinements['horizontal'][(i, j-1)])
+                if (i, j) in refinements.get('horizontal', {}):
+                    tile_refinements.append(refinements['horizontal'][(i, j)])
+                if i > 0 and (i-1, j) in refinements.get('vertical', {}):
+                    tile_refinements.append(refinements['vertical'][(i-1, j)])
+                if (i, j) in refinements.get('vertical', {}):
+                    tile_refinements.append(refinements['vertical'][(i, j)])
+
+                if tile_refinements:
+                    avg_dy = np.mean([r['dy'] for r in tile_refinements]) / 2
+                    avg_dx = np.mean([r['dx'] for r in tile_refinements]) / 2
+                    pos[0] += avg_dy
+                    pos[1] += avg_dx
+
+            # Add tile to mosaic
+            addVolumeToMosaic(tile, pos, output, blendingMethod=blending_method)
+
+    return output
+
+
+def main():
+    p = _build_arg_parser()
+    args = p.parse_args()
+
+    input_file = Path(args.input_volume)
+    output_file = Path(args.output_volume)
+
+    if output_file.exists() and not args.overwrite:
+        raise FileExistsError(f"Output exists: {output_file}. Use -f to overwrite.")
+
+    # Load volume
+    logger.info(f"Loading mosaic grid: {input_file}")
+    volume, resolution = read_omezarr(str(input_file), level=0)
+    volume = np.array(volume[:])
+    tile_shape = volume.shape[0], volume.shape[1] // (volume.shape[1] // 75), volume.shape[2] // (volume.shape[2] // 75)
+
+    # Try to get tile shape from chunks
+    vol_dask, _ = read_omezarr(str(input_file), level=0)
+    if hasattr(vol_dask, 'chunks'):
+        tile_shape = vol_dask.chunks
+
+    logger.info(f"Volume shape: {volume.shape}")
+    logger.info(f"Tile shape: {tile_shape}")
+    logger.info(f"Overlap fraction: {args.overlap_fraction}")
+    logger.info(f"Refinement mode: {args.refinement_mode}")
+
+    nx = volume.shape[1] // tile_shape[1]
+    ny = volume.shape[2] // tile_shape[2]
+    logger.info(f"Grid: {nx} x {ny} tiles")
+
+    # Compute registration refinements
+    refinements = {}
+    if args.refinement_mode != 'none':
+        logger.info("Computing registration refinements...")
+        refinements = compute_registration_refinements(
+            volume, tile_shape, nx, ny,
+            args.overlap_fraction, args.max_refinement_px
+        )
+
+        stats = refinements['stats']
+        logger.info(f"  Total tile pairs: {stats['total_pairs']}")
+        logger.info(f"  Valid registrations: {stats['valid_pairs']}")
+        logger.info(f"  Clamped (large shifts): {stats['clamped_pairs']}")
+        logger.info(f"  Mean refinement: {stats['mean_refinement']:.2f} px")
+        logger.info(f"  Max refinement: {stats['max_refinement']:.2f} px")
+
+        if args.output_refinements:
+            # Convert tuple keys to strings for JSON serialization
+            json_refinements = {
+                'horizontal': {f"{k[0]},{k[1]}": v for k, v in refinements['horizontal'].items()},
+                'vertical': {f"{k[0]},{k[1]}": v for k, v in refinements['vertical'].items()},
+                'stats': refinements['stats'],
+                'parameters': {
+                    'overlap_fraction': args.overlap_fraction,
+                    'max_refinement_px': args.max_refinement_px,
+                    'refinement_mode': args.refinement_mode
+                }
+            }
+            with open(args.output_refinements, 'w') as f:
+                json.dump(json_refinements, f, indent=2)
+            logger.info(f"Refinements saved to: {args.output_refinements}")
+
+    # Compute output shape
+    step_y = int(tile_shape[1] * (1.0 - args.overlap_fraction))
+    step_x = int(tile_shape[2] * (1.0 - args.overlap_fraction))
+    output_height = (nx - 1) * step_y + tile_shape[1]
+    output_width = (ny - 1) * step_x + tile_shape[2]
+    output_shape = (volume.shape[0], output_height, output_width)
+
+    logger.info(f"Output shape: {output_shape}")
+
+    # Stitch with refinements
+    logger.info(f"Stitching with {args.blending_method} blending...")
+    output = stitch_with_refinements(
+        volume, tile_shape, args.overlap_fraction, args.blending_method,
+        args.refinement_mode, refinements, output_shape
+    )
+
+    # Save output
+    logger.info(f"Saving to: {output_file}")
+    from linumpy.io.zarr import save_omezarr
+    import dask.array as da
+    save_omezarr(da.from_array(output), str(output_file), resolution, n_levels=3)
+
+    logger.info("Done!")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/linum_stitch_motor_only.py
+++ b/scripts/linum_stitch_motor_only.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Create a stitched mosaic using only motor positions (bypassing image-based registration).
+
+This diagnostic tool creates stitched mosaics that use ONLY the motor/stage positions
+recorded during acquisition. By comparing this "motor-only" reconstruction against
+the fully-registered reconstruction, you can identify:
+
+1. **Dilation/scaling issues**: If motor positions don't match actual image positions,
+   the motor-only stitch will show systematic offsets or gaps
+2. **Registration drift**: By comparing motor-only vs registered, you can see
+   how much the registration is "correcting" the motor positions
+3. **Stage repeatability**: Systematic patterns in motor-only errors indicate
+   stage calibration issues
+
+For troubleshooting 45° oblique-cut samples where edges don't match up.
+"""
+import linumpy._thread_config  # noqa: F401
+
+import argparse
+import logging
+from pathlib import Path
+
+import numpy as np
+
+from linumpy.io.zarr import read_omezarr, OmeZarrWriter
+from linumpy.utils.mosaic_grid import addVolumeToMosaic
+from linumpy.utils.io import add_overwrite_arg
+from linumpy.utils.metrics import collect_stitch_3d_metrics
+from linumpy.stitching.motor import compute_motor_positions, compare_motor_vs_registration
+
+logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
+logger = logging.getLogger(__name__)
+
+
+def _build_arg_parser():
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter)
+    p.add_argument('input_volume',
+                   help='Full path to a 3D mosaic grid volume (.ome.zarr)')
+    p.add_argument('output_volume',
+                   help='Output stitched mosaic filename (.ome.zarr)')
+
+    p.add_argument('--overlap_fraction', type=float, default=0.1,
+                   help='Expected overlap fraction between tiles [%(default)s]')
+    p.add_argument('--blending_method', type=str, default='diffusion',
+                   choices=['none', 'average', 'diffusion'],
+                   help='Blending method [%(default)s]')
+    p.add_argument('--scale_factor', type=float, default=1.0,
+                   help='Scale factor to apply to motor positions (to test dilation) [%(default)s]')
+    p.add_argument('--rotation_deg', type=float, default=0.0,
+                   help='Global rotation to apply to tile grid (degrees) [%(default)s]')
+    p.add_argument('--compare_transform', type=str, default=None,
+                   help='Path to registration transform .npy file for comparison output')
+    p.add_argument('--output_comparison', type=str, default=None,
+                   help='Output path for comparison metrics JSON')
+
+    add_overwrite_arg(p)
+    return p
+
+
+def compute_registration_positions(nx, ny, transform):
+    """Compute tile positions using registration transform."""
+    positions = []
+    for i in range(nx):
+        for j in range(ny):
+            pos = np.dot(transform, [i, j]).astype(int)
+            positions.append(pos)
+    return positions
+
+
+def main():
+    p = _build_arg_parser()
+    args = p.parse_args()
+
+    input_file = Path(args.input_volume)
+    output_file = Path(args.output_volume)
+
+    assert output_file.name.endswith('.zarr'), "output_volume must be a .zarr file"
+
+    if not args.overwrite and output_file.exists():
+        raise FileExistsError(f"Output file exists: {output_file}. Use --overwrite to replace.")
+
+    # Load the mosaic grid volume
+    logger.info(f"Loading mosaic grid from {input_file}")
+    volume, resolution = read_omezarr(str(input_file), level=0)
+    tile_shape = volume.chunks
+
+    logger.info(f"Volume shape: {volume.shape}")
+    logger.info(f"Tile shape: {tile_shape}")
+    logger.info(f"Resolution: {resolution}")
+
+    # Compute grid dimensions
+    nx = volume.shape[1] // tile_shape[1]
+    ny = volume.shape[2] // tile_shape[2]
+    logger.info(f"Grid: {nx} x {ny} tiles")
+
+    # Compute motor-based positions
+    motor_positions = compute_motor_positions(
+        nx, ny, tile_shape,
+        args.overlap_fraction,
+        args.scale_factor,
+        args.rotation_deg
+    )
+
+    # If comparison transform provided, compare positions
+    if args.compare_transform:
+        transform = np.load(args.compare_transform)
+        reg_positions = compute_registration_positions(nx, ny, transform)
+        comparison = compare_motor_vs_registration(motor_positions, reg_positions, args.output_comparison)
+
+        logger.info("Position comparison summary:")
+        logger.info(f"  Mean offset: ({comparison['mean_diff_y']:.1f}, {comparison['mean_diff_x']:.1f}) px")
+        logger.info(f"  Max offset: {comparison['max_magnitude']:.1f} px")
+        if comparison.get('dilation_indicator'):
+            logger.warning(comparison['dilation_warning'])
+
+    # Compute output mosaic shape
+    posx_min = min([pos[0] for pos in motor_positions])
+    posx_max = max([pos[0] + tile_shape[1] for pos in motor_positions])
+    posy_min = min([pos[1] for pos in motor_positions])
+    posy_max = max([pos[1] + tile_shape[2] for pos in motor_positions])
+    mosaic_shape = (volume.shape[0], int(posx_max - posx_min), int(posy_max - posy_min))
+
+    logger.info(f"Output mosaic shape: {mosaic_shape}")
+
+    # Stitch the mosaic using motor positions only
+    logger.info("Stitching mosaic using motor positions...")
+    writer = OmeZarrWriter(output_file, mosaic_shape, chunk_shape=(100, 100, 100),
+                           dtype=np.float32, overwrite=args.overwrite)
+
+    for i in range(nx):
+        for j in range(ny):
+            # Extract tile from input
+            rmin = i * tile_shape[1]
+            rmax = (i + 1) * tile_shape[1]
+            cmin = j * tile_shape[2]
+            cmax = (j + 1) * tile_shape[2]
+            tile = volume[:, rmin:rmax, cmin:cmax]
+
+            if np.any(tile < 0.0):
+                tile = tile - tile.min()
+
+            # Get motor-based position
+            pos = motor_positions[i * ny + j].copy()
+            pos[0] -= posx_min
+            pos[1] -= posy_min
+
+            addVolumeToMosaic(tile, pos, writer, blendingMethod=args.blending_method)
+
+    writer.finalize(resolution)
+
+    # Collect metrics
+    collect_stitch_3d_metrics(
+        input_shape=volume.shape,
+        output_shape=mosaic_shape,
+        num_tiles=nx * ny,
+        resolution=list(resolution),
+        output_path=str(output_file),
+        input_path=str(input_file),
+        blending_method=args.blending_method
+    )
+
+    logger.info(f"Motor-only stitched mosaic saved to {output_file}")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary

Provides a fast, registration-free stitching and stacking path that uses motor/stage positions recorded during acquisition as the sole source of tile placement — plus an optional refinement step using image registration.

## Key Changes

**New `linumpy/stitching/motor.py`:**
- `compute_motor_positions`: ideal grid positions from scale/rotation parameters
- `compute_registration_refinements`: phase-correlation seam refinement
- `apply_blend_shift_refinement`: blend shift corrections
- `compare_motor_vs_registration`: diagnostic comparison utility

**New `linumpy/stitching/stacking.py`:**
- `find_z_overlap`: cross-correlation Z-overlap search
- `compute_z_offsets`: per-slice Z-offset calculation
- `stack_slices_with_shifts`: full stacking with optional re-homing correction

**New scripts:**
- `linum_stitch_motor_only.py` — fast 2D stitching baseline, no phase correlation
- `linum_stitch_3d_refined.py` — motor initialisation + registration refinement
- `linum_stack_motor_only.py` — stack slices using only motor positions
- `linum_stack_slices_motor.py` — full-featured motor + registration stacking with Z-overlap detection, per-slice normalisation, optional accumulation

**New tests:** `linumpy/tests/test_stitching_motor.py` and `test_stitching_stacking.py`

## Dependencies

Depends on PR #85 (thread config module).

---

> **Merge order:** Merge after PR #85.