### PR TITLE
Add GPU acceleration module (CuPy/JAX) with CPU fallback

### DIFF
--- a/linumpy/gpu/__init__.py
+++ b/linumpy/gpu/__init__.py
@@ -1,0 +1,419 @@
+"""
+GPU acceleration module for linumpy.
+
+This module provides GPU-accelerated versions of compute-intensive operations
+using CuPy. All functions have automatic fallback to CPU (NumPy) if:
+- CuPy is not installed
+- No CUDA-capable GPU is available
+- GPU memory is insufficient
+
+Usage:
+    from linumpy.gpu import GPU_AVAILABLE, get_array_module
+    
+    # Check if GPU is available
+    if GPU_AVAILABLE:
+        print("GPU acceleration enabled")
+    
+    # Get appropriate array module (cupy or numpy)
+    xp = get_array_module(use_gpu=True)
+    
+    # Use GPU-accelerated functions
+    from linumpy.gpu.fft_ops import gpu_phase_correlation
+    from linumpy.gpu.interpolation import gpu_affine_transform
+    from linumpy.gpu.registration import GPUAcceleratedRegistration
+
+Configuration:
+    Set USE_GPU=false environment variable to disable GPU globally.
+"""
+
+import os
+import warnings
+
+# Check for GPU availability
+GPU_AVAILABLE = False
+CUPY_AVAILABLE = False
+GPU_DEVICE_NAME = "N/A"
+GPU_MEMORY_GB = 0
+
+# Allow disabling GPU via environment variable
+_USE_GPU_ENV = os.environ.get("LINUMPY_USE_GPU", "true").lower()
+_GPU_DISABLED_BY_ENV = _USE_GPU_ENV in ("false", "0", "no")
+
+if not _GPU_DISABLED_BY_ENV:
+    try:
+        import cupy as cp
+
+        # Test if CUDA is actually available
+        try:
+            # First, find the GPU with most free memory
+            n_devices = cp.cuda.runtime.getDeviceCount()
+
+            if n_devices > 0:
+                best_gpu_id = 0
+                best_free_memory = 0
+
+                for i in range(n_devices):
+                    with cp.cuda.Device(i):
+                        free, total = cp.cuda.runtime.memGetInfo()
+                        if free > best_free_memory:
+                            best_free_memory = free
+                            best_gpu_id = i
+
+                # Select the best GPU
+                cp.cuda.Device(best_gpu_id).use()
+
+                CUPY_AVAILABLE = True
+                GPU_AVAILABLE = True
+
+                # Get device info for selected GPU
+                device = cp.cuda.Device(best_gpu_id)
+                GPU_DEVICE_NAME = device.name if hasattr(device, 'name') else f"GPU {device.id}"
+                mem_info = device.mem_info
+                GPU_MEMORY_GB = mem_info[1] / (1024 ** 3)  # Total memory in GB
+
+                if n_devices > 1:
+                    # Only show message if there are multiple GPUs
+                    import sys
+
+                    print(f"Auto-selected GPU {best_gpu_id}: {GPU_DEVICE_NAME} "
+                          f"({best_free_memory / (1024 ** 3):.1f} GB free)", file=sys.stderr)
+            else:
+                CUPY_AVAILABLE = True
+                GPU_AVAILABLE = False
+
+        except cp.cuda.runtime.CUDARuntimeError as e:
+            warnings.warn(f"CuPy installed but CUDA not available: {e}")
+            CUPY_AVAILABLE = True
+            GPU_AVAILABLE = False
+
+    except ImportError:
+        pass
+else:
+    warnings.warn("GPU disabled via LINUMPY_USE_GPU environment variable")
+
+
+def get_array_module(use_gpu: bool = True):
+    """
+    Get the appropriate array module (cupy or numpy).
+    
+    Parameters
+    ----------
+    use_gpu : bool
+        Whether to use GPU if available.
+        
+    Returns
+    -------
+    module
+        cupy if GPU available and use_gpu=True, else numpy
+    """
+    if use_gpu and GPU_AVAILABLE:
+        import cupy as cp
+        return cp
+    else:
+        import numpy as np
+        return np
+
+
+def to_gpu(array):
+    """
+    Transfer array to GPU if available.
+    
+    Parameters
+    ----------
+    array : np.ndarray
+        Input array
+        
+    Returns
+    -------
+    array
+        CuPy array if GPU available, else original numpy array
+    """
+    if GPU_AVAILABLE:
+        import cupy as cp
+        if isinstance(array, cp.ndarray):
+            return array
+        return cp.asarray(array)
+    return array
+
+
+def to_cpu(array):
+    """
+    Transfer array to CPU (numpy).
+    
+    Parameters
+    ----------
+    array : array-like
+        Input array (numpy or cupy)
+        
+    Returns
+    -------
+    np.ndarray
+        NumPy array
+    """
+    if GPU_AVAILABLE:
+        import cupy as cp
+        if isinstance(array, cp.ndarray):
+            return cp.asnumpy(array)
+    return array
+
+
+def gpu_info():
+    """
+    Get information about GPU availability and configuration.
+    
+    Returns
+    -------
+    dict
+        Dictionary with GPU information
+    """
+    return {
+        "gpu_available": GPU_AVAILABLE,
+        "cupy_installed": CUPY_AVAILABLE,
+        "device_name": GPU_DEVICE_NAME,
+        "memory_gb": GPU_MEMORY_GB,
+        "disabled_by_env": _GPU_DISABLED_BY_ENV,
+    }
+
+
+def print_gpu_info():
+    """Print GPU availability information."""
+    info = gpu_info()
+    print("=" * 50)
+    print("linumpy GPU Configuration")
+    print("=" * 50)
+    print(f"  GPU Available:     {info['gpu_available']}")
+    print(f"  CuPy Installed:    {info['cupy_installed']}")
+    print(f"  Device:            {info['device_name']}")
+    print(f"  Memory:            {info['memory_gb']:.1f} GB")
+    if info['disabled_by_env']:
+        print(f"  NOTE: GPU disabled via environment variable")
+    print("=" * 50)
+
+
+def list_gpus():
+    """
+    List all available GPUs with memory information.
+    
+    Returns
+    -------
+    list of dict
+        List of GPU info dictionaries with keys:
+        - id: Device ID
+        - name: Device name
+        - total_gb: Total memory in GB
+        - free_gb: Free memory in GB
+        - used_gb: Used memory in GB
+        - utilization: Memory utilization (0-1)
+    """
+    if not CUPY_AVAILABLE:
+        return []
+
+    import cupy as cp
+
+    gpus = []
+    n_devices = cp.cuda.runtime.getDeviceCount()
+
+    for i in range(n_devices):
+        with cp.cuda.Device(i):
+            free, total = cp.cuda.runtime.memGetInfo()
+            device = cp.cuda.Device(i)
+            name = device.name if hasattr(device, 'name') else f"GPU {i}"
+
+            gpus.append({
+                'id': i,
+                'name': name,
+                'total_gb': total / (1024 ** 3),
+                'free_gb': free / (1024 ** 3),
+                'used_gb': (total - free) / (1024 ** 3),
+                'utilization': (total - free) / total,
+            })
+
+    return gpus
+
+
+def select_best_gpu(verbose: bool = True):
+    """
+    Select the GPU with the most free memory.
+    
+    This function queries all available GPUs and switches to the one
+    with the most free memory. Useful when running on multi-GPU systems
+    where one GPU may already be in use.
+    
+    Parameters
+    ----------
+    verbose : bool
+        Print selection information
+        
+    Returns
+    -------
+    int or None
+        Selected GPU ID, or None if no GPU available
+        
+    Examples
+    --------
+    >>> from linumpy.gpu import select_best_gpu
+    >>> select_best_gpu()
+    Selected GPU 1: NVIDIA RTX A6000 (45.2 GB free / 48.0 GB total)
+    1
+    """
+    global GPU_AVAILABLE, GPU_DEVICE_NAME, GPU_MEMORY_GB
+
+    if not CUPY_AVAILABLE:
+        if verbose:
+            print("No GPU available (CuPy not installed)")
+        return None
+
+    import cupy as cp
+
+    gpus = list_gpus()
+
+    if not gpus:
+        if verbose:
+            print("No GPUs found")
+        return None
+
+    # Find GPU with most free memory
+    best_gpu = max(gpus, key=lambda g: g['free_gb'])
+    best_id = best_gpu['id']
+
+    # Switch to best GPU
+    cp.cuda.Device(best_id).use()
+
+    # Update module globals
+    GPU_AVAILABLE = True
+    GPU_DEVICE_NAME = best_gpu['name']
+    GPU_MEMORY_GB = best_gpu['total_gb']
+
+    if verbose:
+        print(f"Selected GPU {best_id}: {best_gpu['name']} "
+              f"({best_gpu['free_gb']:.1f} GB free / {best_gpu['total_gb']:.1f} GB total)")
+
+        if len(gpus) > 1:
+            print(f"  (Selected from {len(gpus)} available GPUs)")
+
+    return best_id
+
+
+def select_gpu(device_id: int, verbose: bool = True):
+    """
+    Select a specific GPU by device ID.
+    
+    Parameters
+    ----------
+    device_id : int
+        GPU device ID (0, 1, 2, ...)
+    verbose : bool
+        Print selection information
+        
+    Returns
+    -------
+    int or None
+        Selected GPU ID, or None if invalid
+        
+    Examples
+    --------
+    >>> from linumpy.gpu import select_gpu
+    >>> select_gpu(1)
+    Selected GPU 1: NVIDIA RTX A6000 (48.0 GB total)
+    1
+    """
+    global GPU_AVAILABLE, GPU_DEVICE_NAME, GPU_MEMORY_GB
+
+    if not CUPY_AVAILABLE:
+        if verbose:
+            print("No GPU available (CuPy not installed)")
+        return None
+
+    import cupy as cp
+
+    n_devices = cp.cuda.runtime.getDeviceCount()
+
+    if device_id < 0 or device_id >= n_devices:
+        if verbose:
+            print(f"Invalid GPU ID {device_id}. Available: 0-{n_devices - 1}")
+        return None
+
+    # Switch to specified GPU
+    cp.cuda.Device(device_id).use()
+
+    # Update module globals
+    with cp.cuda.Device(device_id):
+        free, total = cp.cuda.runtime.memGetInfo()
+        device = cp.cuda.Device(device_id)
+        name = device.name if hasattr(device, 'name') else f"GPU {device_id}"
+
+        GPU_AVAILABLE = True
+        GPU_DEVICE_NAME = name
+        GPU_MEMORY_GB = total / (1024 ** 3)
+
+    if verbose:
+        print(f"Selected GPU {device_id}: {name} ({GPU_MEMORY_GB:.1f} GB total)")
+
+    return device_id
+
+
+def print_gpu_status():
+    """
+    Print detailed status of all available GPUs.
+    
+    Shows memory usage for each GPU, highlighting the currently selected one.
+    """
+    if not CUPY_AVAILABLE:
+        print("No GPU available (CuPy not installed)")
+        return
+
+    import cupy as cp
+
+    gpus = list_gpus()
+    current_device = cp.cuda.Device().id
+
+    print("=" * 60)
+    print("GPU Status")
+    print("=" * 60)
+
+    for gpu in gpus:
+        marker = " *" if gpu['id'] == current_device else "  "
+        bar_width = 30
+        used_bars = int(gpu['utilization'] * bar_width)
+        bar = "█" * used_bars + "░" * (bar_width - used_bars)
+
+        print(f"{marker}GPU {gpu['id']}: {gpu['name']}")
+        print(f"    Memory: [{bar}] {gpu['utilization'] * 100:.1f}%")
+        print(f"    {gpu['used_gb']:.1f} GB used / {gpu['total_gb']:.1f} GB total "
+              f"({gpu['free_gb']:.1f} GB free)")
+
+    print("=" * 60)
+    print(f"  * = currently selected")
+
+
+# Import CUDA environment setup functions
+from linumpy.gpu.cuda_env import (
+    setup_jax_cuda_env,
+    get_cuda12_ld_path,
+    check_patchelf_needed,
+    apply_patchelf_fix,
+    verify_jax_cuda,
+)
+
+# Expose key components
+__all__ = [
+    'GPU_AVAILABLE',
+    'CUPY_AVAILABLE',
+    'GPU_DEVICE_NAME',
+    'GPU_MEMORY_GB',
+    'get_array_module',
+    'to_gpu',
+    'to_cpu',
+    'gpu_info',
+    'print_gpu_info',
+    'list_gpus',
+    'select_best_gpu',
+    'select_gpu',
+    'print_gpu_status',
+    # CUDA environment setup for JAX
+    'setup_jax_cuda_env',
+    'get_cuda12_ld_path',
+    'check_patchelf_needed',
+    'apply_patchelf_fix',
+    'verify_jax_cuda',
+]

--- a/linumpy/gpu/array_ops.py
+++ b/linumpy/gpu/array_ops.py
@@ -1,0 +1,402 @@
+"""GPU-accelerated array operations for linumpy.
+
+Provides GPU versions of normalization, clipping, and thresholding.
+Note: Simple reductions (mean, max) should use numpy directly - GPU offers no benefit.
+"""
+
+import numpy as np
+
+from . import GPU_AVAILABLE, to_cpu
+
+
+def normalize_percentile(image, p_low=1, p_high=99, use_gpu=True):
+    """
+    GPU-accelerated percentile-based normalization.
+    
+    Parameters
+    ----------
+    image : np.ndarray
+        Input image
+    p_low : float
+        Lower percentile for normalization (0-100)
+    p_high : float
+        Upper percentile for normalization (0-100)
+    use_gpu : bool
+        Whether to use GPU
+        
+    Returns
+    -------
+    np.ndarray
+        Normalized image in [0, 1] range
+    """
+    if use_gpu and GPU_AVAILABLE:
+        import cupy as cp
+        img_gpu = cp.asarray(image.astype(np.float32))
+
+        low, high = cp.percentile(img_gpu, [p_low, p_high])
+
+        if high - low < 1e-10:
+            return to_cpu(cp.zeros_like(img_gpu))
+
+        normalized = (img_gpu - low) / (high - low)
+        normalized = cp.clip(normalized, 0, 1)
+
+        return to_cpu(normalized)
+    else:
+        low, high = np.percentile(image, [p_low, p_high])
+        if high - low < 1e-10:
+            return np.zeros_like(image, dtype=np.float32)
+        normalized = (image - low) / (high - low)
+        return np.clip(normalized, 0, 1).astype(np.float32)
+
+
+def normalize_minmax(image, use_gpu=True):
+    """
+    GPU-accelerated min-max normalization.
+    
+    Parameters
+    ----------
+    image : np.ndarray
+        Input image
+    use_gpu : bool
+        Whether to use GPU
+        
+    Returns
+    -------
+    np.ndarray
+        Normalized image in [0, 1] range
+    """
+    if use_gpu and GPU_AVAILABLE:
+        import cupy as cp
+        img_gpu = cp.asarray(image.astype(np.float32))
+
+        vmin, vmax = cp.min(img_gpu), cp.max(img_gpu)
+
+        if vmax - vmin < 1e-10:
+            return to_cpu(cp.zeros_like(img_gpu))
+
+        normalized = (img_gpu - vmin) / (vmax - vmin)
+
+        return to_cpu(normalized)
+    else:
+        vmin, vmax = np.min(image), np.max(image)
+        if vmax - vmin < 1e-10:
+            return np.zeros_like(image, dtype=np.float32)
+        return ((image - vmin) / (vmax - vmin)).astype(np.float32)
+
+
+def clip_percentile(image, p_low=0.5, p_high=99.5, use_gpu=True):
+    """
+    GPU-accelerated percentile clipping.
+    
+    Parameters
+    ----------
+    image : np.ndarray
+        Input image
+    p_low : float
+        Lower percentile to clip
+    p_high : float
+        Upper percentile to clip
+    use_gpu : bool
+        Whether to use GPU
+        
+    Returns
+    -------
+    np.ndarray
+        Clipped image
+    """
+    if use_gpu and GPU_AVAILABLE:
+        import cupy as cp
+        img_gpu = cp.asarray(image)
+
+        low, high = cp.percentile(img_gpu, [p_low, p_high])
+        clipped = cp.clip(img_gpu, low, high)
+
+        return to_cpu(clipped)
+    else:
+        low, high = np.percentile(image, [p_low, p_high])
+        return np.clip(image, low, high)
+
+
+def compute_percentiles_memory_efficient(image: np.ndarray, percentiles: list,
+                                         use_gpu: bool = True,
+                                         max_samples: int = 10_000_000) -> list:
+    """
+    Compute percentiles using subsampling to reduce memory usage.
+
+    For large arrays, computing exact percentiles requires sorting the entire array,
+    which can cause memory issues. This function uses random subsampling to estimate
+    percentiles with minimal memory overhead.
+
+    Parameters
+    ----------
+    image : np.ndarray
+        Input image
+    percentiles : list
+        List of percentiles to compute (0-100)
+    use_gpu : bool
+        Whether to use GPU
+    max_samples : int
+        Maximum number of samples to use for percentile estimation
+
+    Returns
+    -------
+    list
+        Computed percentile values
+    """
+    flat = image.ravel()
+
+    # Subsample if the array is too large
+    if flat.size > max_samples:
+        # Use random sampling for memory efficiency
+        rng = np.random.default_rng(42)  # Fixed seed for reproducibility
+        indices = rng.choice(flat.size, size=max_samples, replace=False)
+        sample = flat[indices]
+    else:
+        sample = flat
+
+    if use_gpu and GPU_AVAILABLE:
+        import cupy as cp
+        try:
+            sample_gpu = cp.asarray(sample)
+            result = [float(cp.percentile(sample_gpu, p).get()) for p in percentiles]
+            del sample_gpu
+            cp.get_default_memory_pool().free_all_blocks()
+            return result
+        except cp.cuda.memory.OutOfMemoryError:
+            # Fall back to CPU if GPU runs out of memory
+            pass
+
+    return [float(np.percentile(sample, p)) for p in percentiles]
+
+
+def compute_nonzero_percentile_memory_efficient(image: np.ndarray, percentile: float,
+                                                use_gpu: bool = True,
+                                                max_samples: int = 10_000_000) -> float:
+    """
+    Compute percentile of non-zero values using subsampling.
+
+    Parameters
+    ----------
+    image : np.ndarray
+        Input image
+    percentile : float
+        Percentile to compute (0-100)
+    use_gpu : bool
+        Whether to use GPU
+    max_samples : int
+        Maximum number of samples to use
+
+    Returns
+    -------
+    float
+        Computed percentile value
+    """
+    flat = image.ravel()
+    nonzero_mask = flat > 0
+    nonzero_vals = flat[nonzero_mask]
+
+    if nonzero_vals.size == 0:
+        return 0.0
+
+    # Subsample if too large
+    if nonzero_vals.size > max_samples:
+        rng = np.random.default_rng(42)
+        indices = rng.choice(nonzero_vals.size, size=max_samples, replace=False)
+        sample = nonzero_vals[indices]
+    else:
+        sample = nonzero_vals
+
+    if use_gpu and GPU_AVAILABLE:
+        import cupy as cp
+        try:
+            sample_gpu = cp.asarray(sample)
+            result = float(cp.percentile(sample_gpu, percentile).get())
+            del sample_gpu
+            cp.get_default_memory_pool().free_all_blocks()
+            return result
+        except cp.cuda.memory.OutOfMemoryError:
+            pass
+
+    return float(np.percentile(sample, percentile))
+
+
+def apply_flatfield_correction(image, flatfield, darkfield=None, use_gpu=True):
+    """
+    GPU-accelerated flatfield correction.
+    
+    Corrected = (Image - Darkfield) / (Flatfield - Darkfield)
+    
+    Parameters
+    ----------
+    image : np.ndarray
+        Input image
+    flatfield : np.ndarray
+        Flatfield image
+    darkfield : np.ndarray, optional
+        Darkfield image
+    use_gpu : bool
+        Whether to use GPU
+        
+    Returns
+    -------
+    np.ndarray
+        Corrected image
+    """
+    if use_gpu and GPU_AVAILABLE:
+        import cupy as cp
+        img_gpu = cp.asarray(image.astype(np.float32))
+        flat_gpu = cp.asarray(flatfield.astype(np.float32))
+
+        if darkfield is not None:
+            dark_gpu = cp.asarray(darkfield.astype(np.float32))
+            numerator = img_gpu - dark_gpu
+            denominator = flat_gpu - dark_gpu
+        else:
+            numerator = img_gpu
+            denominator = flat_gpu
+
+        # Avoid division by zero
+        denominator = cp.where(cp.abs(denominator) < 1e-10, 1.0, denominator)
+        corrected = numerator / denominator
+
+        return to_cpu(corrected)
+    else:
+        if darkfield is not None:
+            numerator = image.astype(np.float32) - darkfield
+            denominator = flatfield.astype(np.float32) - darkfield
+        else:
+            numerator = image.astype(np.float32)
+            denominator = flatfield.astype(np.float32)
+
+        denominator = np.where(np.abs(denominator) < 1e-10, 1.0, denominator)
+        return numerator / denominator
+
+
+def compute_std_projection(volume, axis=0, use_gpu=True):
+    """
+    GPU-accelerated standard deviation projection.
+    
+    Parameters
+    ----------
+    volume : np.ndarray
+        Input volume
+    axis : int
+        Axis along which to compute std
+    use_gpu : bool
+        Whether to use GPU
+        
+    Returns
+    -------
+    np.ndarray
+        Standard deviation projection
+    """
+    if use_gpu and GPU_AVAILABLE:
+        import cupy as cp
+        vol_gpu = cp.asarray(volume)
+        result = cp.std(vol_gpu, axis=axis)
+        return to_cpu(result)
+    else:
+        return np.std(volume, axis=axis)
+
+
+def threshold_otsu(image, use_gpu=True):
+    """
+    GPU-accelerated Otsu thresholding.
+    
+    Parameters
+    ----------
+    image : np.ndarray
+        Input image
+    use_gpu : bool
+        Whether to use GPU
+        
+    Returns
+    -------
+    float
+        Otsu threshold value
+    """
+    if use_gpu and GPU_AVAILABLE:
+        import cupy as cp
+        img_gpu = cp.asarray(image.astype(np.float32))
+
+        # Compute histogram
+        hist, bin_edges = cp.histogram(img_gpu.ravel(), bins=256)
+        bin_centers = (bin_edges[:-1] + bin_edges[1:]) / 2
+
+        hist = hist.astype(cp.float64)
+        hist_norm = hist / hist.sum()
+
+        # Cumulative sums
+        weight1 = cp.cumsum(hist_norm)
+        weight2 = cp.cumsum(hist_norm[::-1])[::-1]
+
+        # Cumulative means
+        mean1 = cp.cumsum(hist_norm * bin_centers) / weight1
+        mean2 = (cp.cumsum((hist_norm * bin_centers)[::-1]) / weight2[::-1])[::-1]
+
+        # Between-class variance
+        variance = weight1[:-1] * weight2[1:] * (mean1[:-1] - mean2[1:]) ** 2
+
+        # Find maximum
+        idx = cp.argmax(variance)
+        threshold = float(bin_centers[idx].get())
+
+        # Free GPU memory
+        del img_gpu, hist, bin_edges, bin_centers, hist_norm, weight1, weight2, mean1, mean2, variance
+        cp.get_default_memory_pool().free_all_blocks()
+
+        return threshold
+    else:
+        from skimage.filters import threshold_otsu as sk_otsu
+        return sk_otsu(image)
+
+
+def apply_xy_shift(image, reference, dy, dx, use_gpu=True):
+    """
+    GPU-accelerated XY shift application.
+    
+    Parameters
+    ----------
+    image : np.ndarray
+        Image to shift
+    reference : np.ndarray
+        Reference image (determines output shape)
+    dy : float
+        Y shift in pixels
+    dx : float
+        X shift in pixels
+    use_gpu : bool
+        Whether to use GPU
+        
+    Returns
+    -------
+    np.ndarray
+        Shifted image
+    """
+    # Get a representative non-zero value for out-of-bounds fill
+    nonzero_vals = image[image > 0]
+    if len(nonzero_vals) > 0:
+        cval = float(np.percentile(nonzero_vals, 1))
+    else:
+        cval = 0.0
+
+    if use_gpu and GPU_AVAILABLE:
+        import cupy as cp
+        from cupyx.scipy.ndimage import shift as cp_shift
+
+        img_gpu = cp.asarray(image.astype(np.float32))
+
+        # Apply shift with edge value fill to avoid black dots
+        if image.ndim == 2:
+            shifted = cp_shift(img_gpu, [dy, dx], order=1, cval=cval)
+        else:  # 3D
+            shifted = cp_shift(img_gpu, [0, dy, dx], order=1, cval=cval)
+
+        return to_cpu(shifted)
+    else:
+        from scipy.ndimage import shift as scipy_shift
+        if image.ndim == 2:
+            return scipy_shift(image, [dy, dx], order=1, cval=cval)
+        else:
+            return scipy_shift(image, [0, dy, dx], order=1, cval=cval)

--- a/linumpy/gpu/corrections.py
+++ b/linumpy/gpu/corrections.py
@@ -1,0 +1,85 @@
+"""GPU-accelerated correction operations for linumpy."""
+
+import numpy as np
+
+from . import GPU_AVAILABLE, to_cpu
+
+
+def fix_galvo_shift(volume, shift, axis=1, use_gpu=True):
+    """
+    GPU-accelerated galvo shift correction.
+    
+    Parameters
+    ----------
+    volume : np.ndarray
+        Input volume
+    shift : int
+        Shift amount in pixels
+    axis : int
+        Axis along which to shift
+    use_gpu : bool
+        Whether to use GPU
+        
+    Returns
+    -------
+    np.ndarray
+        Corrected volume
+    """
+    if shift == 0:
+        return volume
+
+    if use_gpu and GPU_AVAILABLE:
+        import cupy as cp
+        vol_gpu = cp.asarray(volume)
+        result = cp.roll(vol_gpu, shift, axis=axis)
+        return to_cpu(result)
+    else:
+        return np.roll(volume, shift, axis=axis)
+
+
+def detect_and_fix_galvo_shift(volume, n_pixel_return=40, threshold=0.5,
+                               axis=1, use_gpu=True):
+    """
+    Detect and conditionally fix galvo shift.
+    
+    Note: Detection uses CPU (GPU offers no benefit). Only the fix uses GPU.
+    
+    Parameters
+    ----------
+    volume : np.ndarray
+        Input volume (3D)
+    n_pixel_return : int
+        Number of pixels in galvo return region
+    threshold : float
+        Confidence threshold for applying fix (default 0.5, higher = more conservative)
+    axis : int
+        A-line axis
+    use_gpu : bool
+        Whether to use GPU for the fix operation
+        
+    Returns
+    -------
+    np.ndarray
+        Corrected volume (or original if no fix needed)
+    dict
+        Detection results with 'shift', 'confidence', 'fixed' keys
+    """
+    from linumpy.preproc.xyzcorr import detect_galvo_shift
+
+    # Compute AIP
+    aip = np.mean(volume, axis=0)
+
+    # Detect shift using CPU (GPU offers no benefit for detection)
+    shift, confidence = detect_galvo_shift(aip, n_pixel_return)
+
+    result = {
+        'shift': shift,
+        'confidence': confidence,
+        'fixed': False
+    }
+
+    if confidence >= threshold:
+        volume = fix_galvo_shift(volume, shift, axis=axis, use_gpu=use_gpu)
+        result['fixed'] = True
+
+    return volume, result

--- a/linumpy/gpu/cuda_env.py
+++ b/linumpy/gpu/cuda_env.py
@@ -1,0 +1,336 @@
+"""
+CUDA environment setup for JAX GPU support.
+
+This module provides functions to automatically configure LD_LIBRARY_PATH
+for JAX CUDA 12 plugin compatibility.
+
+JAX 0.4.23 was compiled with CUDA 12 driver API and requires specific library versions:
+  - libcusolver.so.11 (from nvidia-cusolver-cu12==11.5.4.101)
+  - libcusparse.so.12 (from nvidia-cusparse-cu12==12.2.0.103)
+  - libcufft.so.11 (from nvidia-cufft-cu12==11.0.12.1)
+  - libcublas.so.12 (from nvidia-cublas-cu12==12.3.4.1)
+  - libcudnn.so.8 (from nvidia-cudnn-cu12==8.9.7.29)
+
+These exact versions must be installed - newer versions have different .so versions
+that are INCOMPATIBLE with JAX 0.4.23.
+
+Usage:
+    # Before importing JAX (e.g., in scripts that use BaSiCPy):
+    from linumpy.gpu.cuda_env import setup_jax_cuda_env
+    setup_jax_cuda_env()
+
+    # Then import JAX/BaSiCPy
+    import jax
+    from basicpy import BaSiC
+"""
+
+import os
+import site
+import subprocess
+import sys
+import warnings
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+__all__ = [
+    'setup_jax_cuda_env',
+    'get_cuda12_ld_path',
+    'check_patchelf_needed',
+    'apply_patchelf_fix',
+    'verify_jax_cuda',
+]
+
+
+def get_site_packages() -> str:
+    """Get the primary site-packages directory."""
+    return site.getsitepackages()[0]
+
+
+def get_cuda12_ld_path(include_existing: bool = True) -> Tuple[str, List[str]]:
+    """
+    Build LD_LIBRARY_PATH for CUDA 12 compatible libraries.
+
+    JAX 0.4.23 needs .so.11 libraries from the -cu12 packages.
+    Order matters - -cu12 package paths should be listed.
+
+    Parameters
+    ----------
+    include_existing : bool
+        Whether to append existing LD_LIBRARY_PATH. Default True.
+
+    Returns
+    -------
+    ld_path : str
+        Colon-separated LD_LIBRARY_PATH string
+    cuda_paths : list
+        List of individual paths that were found
+    """
+    sp = get_site_packages()
+    cuda_paths = []
+
+    # Priority 1: Check for system CUDA 12 installation
+    system_cuda_paths = [
+        "/usr/local/cuda-12.4/lib64",
+        "/usr/local/cuda-12/lib64",
+        "/usr/local/cuda/lib64",
+    ]
+    for cuda_path in system_cuda_paths:
+        cublas_path = os.path.join(cuda_path, "libcublas.so.11")
+        if os.path.exists(cublas_path):
+            cuda_paths.append(cuda_path)
+            break
+
+    # Priority 2: -cu12 pip packages (pinned versions with correct library files)
+    # JAX 0.4.23 needs specific .so versions from pinned nvidia packages
+    cu12_lib_paths = [
+        ("nvidia/cublas/lib", "libcublas.so.12"),
+        ("nvidia/cuda_runtime/lib", "libcudart.so.12"),
+        ("nvidia/cusolver/lib", "libcusolver.so.11"),
+        ("nvidia/cusparse/lib", "libcusparse.so.12"),
+        ("nvidia/cufft/lib", "libcufft.so.11"),
+        ("nvidia/cudnn/lib", "libcudnn.so.8"),
+        ("nvidia/nvjitlink/lib", "libnvJitLink.so.12"),
+    ]
+
+    for lib_path, check_file in cu12_lib_paths:
+        full_path = os.path.join(sp, lib_path)
+        if os.path.isdir(full_path):
+            # Check for the expected file or any .so file
+            expected = os.path.join(full_path, check_file)
+            if os.path.exists(expected) or any(Path(full_path).glob("*.so*")):
+                if full_path not in cuda_paths:
+                    cuda_paths.append(full_path)
+
+    # Priority 3: Check for system cuDNN 8.x (if pip package doesn't have it)
+    system_cudnn_paths = ["/usr/lib/x86_64-linux-gnu", "/usr/local/cuda/lib64", "/usr/lib64"]
+    for sys_path in system_cudnn_paths:
+        if os.path.exists(os.path.join(sys_path, "libcudnn.so.8")):
+            if sys_path not in cuda_paths:
+                cuda_paths.insert(0, sys_path)  # System cuDNN first
+            break
+
+    # Build path string
+    new_ld_path = ':'.join(cuda_paths)
+
+    # Optionally append existing LD_LIBRARY_PATH
+    if include_existing:
+        existing = os.environ.get('LD_LIBRARY_PATH', '')
+        if existing:
+            new_ld_path = f"{new_ld_path}:{existing}"
+
+    return new_ld_path, cuda_paths
+
+
+def check_patchelf_needed() -> Tuple[bool, Optional[str]]:
+    """
+    Check if patchelf fix is needed for JAX CUDA plugin.
+
+    Returns
+    -------
+    needs_fix : bool
+        True if patchelf fix is needed
+    plugin_path : str or None
+        Path to the xla_cuda_plugin.so file, or None if not found
+    """
+    sp = get_site_packages()
+    plugin_path = os.path.join(sp, "jax_plugins", "xla_cuda12", "xla_cuda_plugin.so")
+
+    if not os.path.exists(plugin_path):
+        return False, None
+
+    # Check if it has executable stack using execstack or readelf
+    try:
+        result = subprocess.run(
+            ['readelf', '-l', plugin_path],
+            capture_output=True, text=True, timeout=10
+        )
+        if result.returncode == 0:
+            # Look for GNU_STACK with RWE (read-write-execute)
+            for line in result.stdout.split('\n'):
+                if 'GNU_STACK' in line and 'RWE' in line:
+                    return True, plugin_path
+        return False, plugin_path
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        # Can't check - assume it might need fix
+        return True, plugin_path
+
+
+def apply_patchelf_fix(verbose: bool = False) -> bool:
+    """
+    Apply patchelf fix to JAX CUDA plugin and jaxlib .so files.
+
+    Returns True if successful, False if patchelf not available.
+    """
+    try:
+        subprocess.run(['patchelf', '--version'], capture_output=True, check=True)
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        if verbose:
+            print("patchelf not installed. Install with: sudo apt install patchelf")
+        return False
+
+    sp = get_site_packages()
+    patched_count = 0
+
+    # Patch jaxlib
+    jaxlib = None
+    try:
+        import jaxlib
+        jaxlib_path = jaxlib.__path__[0]
+        for so_file in Path(jaxlib_path).rglob("*.so"):
+            try:
+                subprocess.run(
+                    ['patchelf', '--clear-execstack', str(so_file)],
+                    capture_output=True, check=True
+                )
+                patched_count += 1
+            except subprocess.CalledProcessError:
+                pass
+    except ImportError:
+        # jaxlib not installed
+        jaxlib = None
+
+    # Patch jax_plugins
+    jax_plugins_path = os.path.join(sp, "jax_plugins")
+    if os.path.isdir(jax_plugins_path):
+        for so_file in Path(jax_plugins_path).rglob("*.so"):
+            try:
+                subprocess.run(
+                    ['patchelf', '--clear-execstack', str(so_file)],
+                    capture_output=True, check=True
+                )
+                patched_count += 1
+            except subprocess.CalledProcessError:
+                pass
+
+    if verbose:
+        print(f"Patched {patched_count} .so files")
+
+    return patched_count > 0
+
+
+def setup_jax_cuda_env(
+        auto_patchelf: bool = True,
+        verbose: bool = False,
+        warn_on_failure: bool = True,
+) -> bool:
+    """
+    Set up the environment for JAX CUDA support.
+
+    This function should be called BEFORE importing JAX to ensure
+    LD_LIBRARY_PATH is set correctly for CUDA 12 library loading.
+
+    Parameters
+    ----------
+    auto_patchelf : bool
+        Automatically apply patchelf fix if needed. Default True.
+    verbose : bool
+        Print diagnostic information. Default False.
+    warn_on_failure : bool
+        Issue warnings if setup fails. Default True.
+
+    Returns
+    -------
+    success : bool
+        True if environment was set up successfully.
+
+    Example
+    -------
+    >>> from linumpy.gpu.cuda_env import setup_jax_cuda_env
+    >>> setup_jax_cuda_env()
+    >>> import jax  # Now JAX should find CUDA libraries
+    >>> print(jax.devices())
+    """
+    # Check if JAX is already imported - warn that it may be too late
+    if 'jax' in sys.modules:
+        if warn_on_failure:
+            warnings.warn(
+                "JAX is already imported. setup_jax_cuda_env() should be called "
+                "BEFORE importing JAX for LD_LIBRARY_PATH changes to take effect. "
+                "You may need to restart the Python process."
+            )
+
+    # Build and set LD_LIBRARY_PATH
+    new_ld_path, cuda_paths = get_cuda12_ld_path(include_existing=True)
+
+    if not cuda_paths:
+        if warn_on_failure:
+            warnings.warn(
+                "No CUDA 12 libraries found. Install with:\n"
+                "  pip install --extra-index-url https://pypi.nvidia.com \\\n"
+                "      nvidia-cusolver nvidia-cufft nvidia-cusparse \\\n"
+                "      nvidia-cublas-cu12 nvidia-cuda-runtime-cu12 \\\n"
+                "      nvidia-nvjitlink-cu12 nvidia-cudnn-cu12\n"
+                "Or run: source scripts/fix_jax_cuda_plugin.sh"
+            )
+        return False
+
+    os.environ['LD_LIBRARY_PATH'] = new_ld_path
+
+    if verbose:
+        print(f"Set LD_LIBRARY_PATH with {len(cuda_paths)} CUDA library paths")
+        for p in cuda_paths:
+            print(f"  {p}")
+
+    # Check and apply patchelf fix if needed
+    if auto_patchelf:
+        needs_fix, plugin_path = check_patchelf_needed()
+        if needs_fix:
+            if verbose:
+                print("Applying patchelf fix...")
+            success = apply_patchelf_fix(verbose=verbose)
+            if not success and warn_on_failure:
+                warnings.warn(
+                    "Could not apply patchelf fix. JAX CUDA may fail with "
+                    "'cannot enable executable stack' error. "
+                    "Install patchelf: sudo apt install patchelf"
+                )
+
+    return True
+
+
+def verify_jax_cuda(verbose: bool = True) -> bool:
+    """
+    Verify that JAX CUDA is working correctly.
+
+    This imports JAX and tests basic GPU operations including SVD
+    which is used by BaSiCPy.
+
+    Parameters
+    ----------
+    verbose : bool
+        Print diagnostic information. Default True.
+
+    Returns
+    -------
+    working : bool
+        True if JAX CUDA is working.
+    """
+    try:
+        import jax
+        devices = jax.devices()
+
+        has_gpu = any('cuda' in str(d).lower() for d in devices)
+
+        if verbose:
+            print(f"JAX devices: {devices}")
+
+        if not has_gpu:
+            if verbose:
+                print("⚠️  JAX is using CPU only")
+            return False
+
+        # Test SVD (used by BaSiCPy)
+        import jax.numpy as jnp
+        a = jnp.array([[1.0, 2.0], [3.0, 4.0]])
+        result = jnp.linalg.svd(a)
+
+        if verbose:
+            print(f"✅ JAX GPU working - SVD test passed")
+            print(f"   Singular values: {result[1]}")
+
+        return True
+
+    except Exception as e:
+        if verbose:
+            print(f"❌ JAX CUDA verification failed: {e}")
+        return False

--- a/linumpy/gpu/fft_ops.py
+++ b/linumpy/gpu/fft_ops.py
@@ -1,0 +1,265 @@
+"""
+GPU-accelerated FFT operations for linumpy.
+
+Provides GPU versions of FFT-based operations including phase correlation
+for image registration and stitching.
+"""
+
+import numpy as np
+
+from . import GPU_AVAILABLE, to_cpu
+
+
+def phase_correlation(vol1, vol2, n_peaks=8, use_gpu=True):
+    """
+    GPU-accelerated phase correlation for finding translation between images.
+    
+    Parameters
+    ----------
+    vol1 : np.ndarray
+        Fixed image (2D or 3D)
+    vol2 : np.ndarray
+        Moving image (2D or 3D)
+    n_peaks : int
+        Number of peaks to sample for refinement
+    use_gpu : bool
+        Whether to use GPU acceleration
+        
+    Returns
+    -------
+    list
+        Translation [dx, dy] or [dx, dy, dz] of vol2 relative to vol1
+    float
+        Cross-correlation score
+    """
+    if use_gpu and GPU_AVAILABLE:
+        return _phase_correlation_gpu(vol1, vol2, n_peaks)
+    else:
+        return _phase_correlation_cpu(vol1, vol2, n_peaks)
+
+
+def _phase_correlation_gpu(vol1, vol2, n_peaks=8):
+    """GPU implementation of phase correlation."""
+    import cupy as cp
+    from cupyx.scipy.ndimage import uniform_filter
+
+    vol_shape = vol1.shape
+    ndim = vol1.ndim
+
+    # Transfer to GPU
+    vol1_gpu = cp.asarray(vol1, dtype=cp.float32)
+    vol2_gpu = cp.asarray(vol2, dtype=cp.float32)
+
+    # Extend images by 1/4 of their size (padding)
+    new_shape = tuple(int(s * 1.25) for s in vol_shape)
+    pad_size = tuple((int(np.ceil(0.5 * (n - s))),) * 2
+                     for s, n in zip(vol_shape, new_shape))
+
+    vol1_p = cp.pad(vol1_gpu, pad_size, mode='reflect')
+    vol2_p = cp.pad(vol2_gpu, pad_size, mode='reflect')
+
+    # Apply Hanning window
+    vol1_p = _apply_hanning_window_gpu(vol1_p, [p[0] for p in pad_size])
+    vol2_p = _apply_hanning_window_gpu(vol2_p, [p[0] for p in pad_size])
+
+    # Phase correlation using cuFFT
+    if ndim == 2:
+        fft_func = cp.fft.fft2
+        ifft_func = cp.fft.ifft2
+    else:
+        fft_func = cp.fft.fftn
+        ifft_func = cp.fft.ifftn
+
+    Q_num = fft_func(vol2_p) * cp.conj(fft_func(vol1_p))
+    Q_denum = cp.abs(Q_num)
+
+    # Avoid division by zero
+    Q_freq = cp.where(Q_denum > 1e-10, Q_num / Q_denum, 0)
+    Q = ifft_func(Q_freq)
+    Q_abs = cp.abs(Q)
+
+    # Find peaks
+    from cupyx.scipy.ndimage import maximum_filter
+
+    # Local maxima detection
+    local_max = maximum_filter(Q_abs, size=3)
+    peaks_mask = (Q_abs == local_max)
+
+    # Get top n_peaks
+    flat_indices = cp.argsort(Q_abs.ravel())[-n_peaks:]
+    coordinates = cp.unravel_index(flat_indices, Q_abs.shape)
+    coordinates = cp.stack(coordinates, axis=1)
+
+    # Try all translation permutations
+    best_translation = None
+    best_score = -1
+
+    coordinates_cpu = to_cpu(coordinates)
+    vol1_cpu = to_cpu(vol1_gpu)
+    vol2_cpu = to_cpu(vol2_gpu)
+
+    for indices in coordinates_cpu:
+        deltas = []
+        for idx, s in zip(indices, vol1_p.shape):
+            deltas.append(int(-idx + s / 2))
+
+        # Check bounds
+        for ii in range(len(deltas)):
+            if abs(deltas[ii]) > vol_shape[ii]:
+                deltas[ii] -= int(np.sign(deltas[ii]) * vol_shape[ii])
+
+        # Generate candidate translations
+        if ndim == 2:
+            dx, dy = deltas
+            candidates = [
+                [dx, dy],
+                [dx - int(np.sign(dx) * vol1_p.shape[0] / 2), dy],
+                [dx, dy - int(np.sign(dy) * vol1_p.shape[1] / 2)],
+                [dx - int(np.sign(dx) * vol1_p.shape[0] / 2),
+                 dy - int(np.sign(dy) * vol1_p.shape[1] / 2)],
+            ]
+        else:
+            dx, dy, dz = deltas
+            nxp = int(np.sign(dx) * vol1_p.shape[0] / 2)
+            nyp = int(np.sign(dy) * vol1_p.shape[1] / 2)
+            nzp = int(np.sign(dz) * vol1_p.shape[2] / 2)
+            candidates = [
+                [dx, dy, dz],
+                [dx - nxp, dy, dz],
+                [dx, dy - nyp, dz],
+                [dx - nxp, dy - nyp, dz],
+                [dx, dy, dz - nzp],
+                [dx, dy - nyp, dz - nzp],
+                [dx - nxp, dy, dz - nzp],
+                [dx - nxp, dy - nyp, dz - nzp],
+            ]
+
+        for trans in candidates:
+            score = _compute_correlation_score(vol1_cpu, vol2_cpu, trans)
+            if score > best_score:
+                best_score = score
+                best_translation = trans
+
+    return best_translation, best_score
+
+
+def _apply_hanning_window_gpu(vol, pad_sizes):
+    """Apply Hanning window on GPU."""
+    import cupy as cp
+
+    ndim = vol.ndim
+    result = vol.copy()
+
+    for axis, pad in enumerate(pad_sizes):
+        if pad <= 0:
+            continue
+
+        s = vol.shape[axis]
+        h = cp.hanning(pad * 2)
+        h_full = cp.ones(s)
+        h_full[:pad] = h[:pad]
+        h_full[-pad:] = h[pad:]
+
+        # Reshape for broadcasting
+        shape = [1] * ndim
+        shape[axis] = s
+        h_full = h_full.reshape(shape)
+
+        result = result * h_full
+
+    return result
+
+
+def _compute_correlation_score(vol1, vol2, translation):
+    """Compute normalized cross-correlation score for a translation."""
+    ndim = vol1.ndim
+
+    # Compute overlap region
+    slices1 = []
+    slices2 = []
+
+    for i, t in enumerate(translation):
+        t = int(t)
+        if t >= 0:
+            slices1.append(slice(t, None))
+            slices2.append(slice(None, vol2.shape[i] - t if t > 0 else None))
+        else:
+            slices1.append(slice(None, vol1.shape[i] + t))
+            slices2.append(slice(-t, None))
+
+    try:
+        ov1 = vol1[tuple(slices1)]
+        ov2 = vol2[tuple(slices2)]
+
+        if ov1.size == 0 or ov2.size == 0:
+            return 0
+
+        # Normalized cross-correlation
+        ov1_norm = ov1 - np.mean(ov1)
+        ov2_norm = ov2 - np.mean(ov2)
+
+        std1 = np.std(ov1_norm)
+        std2 = np.std(ov2_norm)
+
+        if std1 < 1e-10 or std2 < 1e-10:
+            return 0
+
+        return float(np.mean(ov1_norm * ov2_norm) / (std1 * std2))
+    except:
+        return 0
+
+
+def _phase_correlation_cpu(vol1, vol2, n_peaks=8):
+    """CPU fallback for phase correlation - calls existing implementation."""
+    from linumpy.stitching.registration import pairWisePhaseCorrelation
+    return pairWisePhaseCorrelation(vol1, vol2, nPeaks=n_peaks, returnCC=True)
+
+
+def fft2(image, use_gpu=True):
+    """
+    GPU-accelerated 2D FFT.
+    
+    Parameters
+    ----------
+    image : np.ndarray
+        Input 2D image
+    use_gpu : bool
+        Whether to use GPU
+        
+    Returns
+    -------
+    np.ndarray
+        FFT result (complex)
+    """
+    if use_gpu and GPU_AVAILABLE:
+        import cupy as cp
+        img_gpu = cp.asarray(image)
+        result = cp.fft.fft2(img_gpu)
+        return to_cpu(result)
+    else:
+        return np.fft.fft2(image)
+
+
+def ifft2(spectrum, use_gpu=True):
+    """
+    GPU-accelerated 2D inverse FFT.
+    
+    Parameters
+    ----------
+    spectrum : np.ndarray
+        Input spectrum (complex)
+    use_gpu : bool
+        Whether to use GPU
+        
+    Returns
+    -------
+    np.ndarray
+        Inverse FFT result
+    """
+    if use_gpu and GPU_AVAILABLE:
+        import cupy as cp
+        spec_gpu = cp.asarray(spectrum)
+        result = cp.fft.ifft2(spec_gpu)
+        return to_cpu(result)
+    else:
+        return np.fft.ifft2(spectrum)

--- a/linumpy/gpu/image_quality.py
+++ b/linumpy/gpu/image_quality.py
@@ -1,0 +1,412 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+GPU-accelerated image quality assessment functions.
+
+This module provides CuPy-accelerated versions of quality assessment functions.
+All functions automatically fall back to CPU if GPU is not available.
+
+Usage:
+    from linumpy.gpu.image_quality import (
+        compute_ssim_2d_gpu,
+        compute_ssim_3d_gpu,
+        compute_edge_score_gpu,
+        assess_slice_quality_gpu,
+    )
+
+    # All functions accept numpy arrays and return numpy scalars
+    ssim = compute_ssim_3d_gpu(vol1, vol2)
+"""
+
+from typing import Optional, Tuple, Dict, Any
+
+import numpy as np
+
+from linumpy.gpu import GPU_AVAILABLE, CUPY_AVAILABLE
+
+if CUPY_AVAILABLE:
+    import cupy as cp
+    from cupyx.scipy.ndimage import sobel as cupy_sobel
+    from cupyx.scipy.ndimage import uniform_filter as cupy_uniform_filter
+else:
+    cp = None
+    cupy_sobel = None
+    cupy_uniform_filter = None
+
+
+def _to_gpu(arr: np.ndarray) -> "cp.ndarray":
+    """Transfer numpy array to GPU."""
+    return cp.asarray(arr, dtype=cp.float32)
+
+
+def _to_cpu(arr) -> np.ndarray:
+    """Transfer GPU array to CPU."""
+    if hasattr(arr, 'get'):
+        return arr.get()
+    return np.asarray(arr)
+
+
+def normalize_image_gpu(img: "cp.ndarray") -> "cp.ndarray":
+    """
+    Normalize image to [0, 1] range on GPU.
+
+    Parameters
+    ----------
+    img : cp.ndarray
+        Input image on GPU.
+
+    Returns
+    -------
+    cp.ndarray
+        Normalized image.
+    """
+    img_min = cp.min(img)
+    img_max = cp.max(img)
+    if img_max > img_min:
+        return (img - img_min) / (img_max - img_min)
+    return img
+
+
+def compute_ssim_2d_gpu(img1: np.ndarray, img2: np.ndarray,
+                        win_size: int = 7) -> float:
+    """
+    Compute SSIM between two 2D images using GPU.
+
+    Falls back to CPU if GPU is not available.
+
+    Parameters
+    ----------
+    img1, img2 : np.ndarray
+        Input images (2D).
+    win_size : int
+        Window size for SSIM computation.
+
+    Returns
+    -------
+    float
+        SSIM score (0 to 1, higher is better).
+    """
+    if not GPU_AVAILABLE or cp is None:
+        from linumpy.utils.image_quality import compute_ssim_2d
+        return compute_ssim_2d(img1, img2, win_size)
+
+    if img1.shape != img2.shape:
+        min_y = min(img1.shape[0], img2.shape[0])
+        min_x = min(img1.shape[1], img2.shape[1])
+        img1 = img1[:min_y, :min_x]
+        img2 = img2[:min_y, :min_x]
+
+    try:
+        # Transfer to GPU
+        i1 = _to_gpu(img1)
+        i2 = _to_gpu(img2)
+
+        # Normalize
+        i1 = normalize_image_gpu(i1)
+        i2 = normalize_image_gpu(i2)
+
+        # SSIM constants
+        C1 = 0.01 ** 2
+        C2 = 0.03 ** 2
+
+        # Compute local means using uniform filter
+        mu1 = cupy_uniform_filter(i1, size=win_size)
+        mu2 = cupy_uniform_filter(i2, size=win_size)
+
+        mu1_sq = mu1 * mu1
+        mu2_sq = mu2 * mu2
+        mu1_mu2 = mu1 * mu2
+
+        sigma1_sq = cupy_uniform_filter(i1 * i1, size=win_size) - mu1_sq
+        sigma2_sq = cupy_uniform_filter(i2 * i2, size=win_size) - mu2_sq
+        sigma12 = cupy_uniform_filter(i1 * i2, size=win_size) - mu1_mu2
+
+        # SSIM formula
+        numerator = (2 * mu1_mu2 + C1) * (2 * sigma12 + C2)
+        denominator = (mu1_sq + mu2_sq + C1) * (sigma1_sq + sigma2_sq + C2)
+
+        ssim_map = numerator / denominator
+
+        return float(cp.mean(ssim_map))
+    except Exception:
+        # Fall back to CPU
+        from linumpy.utils.image_quality import compute_ssim_2d
+        return compute_ssim_2d(img1, img2, win_size)
+
+
+def compute_ssim_3d_gpu(vol1: np.ndarray, vol2: np.ndarray,
+                        win_size: int = 7, sample_depth: int = 0) -> float:
+    """
+    Compute mean SSIM between two 3D volumes using GPU.
+
+    Parameters
+    ----------
+    vol1, vol2 : np.ndarray
+        Input volumes (Z, Y, X).
+    win_size : int
+        Window size for SSIM computation.
+    sample_depth : int
+        Number of z-planes to sample. 0 = all planes.
+
+    Returns
+    -------
+    float
+        Mean SSIM score (0 to 1, higher is better).
+    """
+    if not GPU_AVAILABLE:
+        from linumpy.utils.image_quality import compute_ssim_3d
+        return compute_ssim_3d(vol1, vol2, win_size, sample_depth)
+
+    if vol1.shape != vol2.shape:
+        min_z = min(vol1.shape[0], vol2.shape[0])
+        min_y = min(vol1.shape[1], vol2.shape[1])
+        min_x = min(vol1.shape[2], vol2.shape[2])
+        vol1 = vol1[:min_z, :min_y, :min_x]
+        vol2 = vol2[:min_z, :min_y, :min_x]
+
+    # Sample z-planes if requested
+    if sample_depth > 0 and vol1.shape[0] > sample_depth:
+        indices = np.linspace(0, vol1.shape[0] - 1, sample_depth, dtype=int)
+    else:
+        indices = np.arange(vol1.shape[0])
+
+    ssim_scores = []
+    for z in indices:
+        score = compute_ssim_2d_gpu(vol1[z], vol2[z], win_size)
+        ssim_scores.append(score)
+
+    return float(np.mean(ssim_scores))
+
+
+def compute_edge_score_gpu(vol: np.ndarray, reference: np.ndarray,
+                           sample_z: Optional[int] = None) -> float:
+    """
+    Compute edge preservation score using GPU.
+
+    Parameters
+    ----------
+    vol : np.ndarray
+        Input volume (Z, Y, X) or 2D image.
+    reference : np.ndarray
+        Reference volume or image.
+    sample_z : int, optional
+        Z-index to sample for 3D volumes.
+
+    Returns
+    -------
+    float
+        Edge preservation score (0 to 1, higher is better).
+    """
+    if not GPU_AVAILABLE or cp is None:
+        from linumpy.utils.image_quality import compute_edge_score
+        return compute_edge_score(vol, reference, sample_z)
+
+    try:
+        # Handle 3D volumes
+        if vol.ndim == 3:
+            if sample_z is None:
+                sample_z = vol.shape[0] // 2
+            v_cpu = vol[sample_z]
+            r_cpu = reference[sample_z] if reference.ndim == 3 else reference
+        else:
+            v_cpu = vol
+            r_cpu = reference
+
+        if v_cpu.shape != r_cpu.shape:
+            min_y = min(v_cpu.shape[0], r_cpu.shape[0])
+            min_x = min(v_cpu.shape[1], r_cpu.shape[1])
+            v_cpu = v_cpu[:min_y, :min_x]
+            r_cpu = r_cpu[:min_y, :min_x]
+
+        # Transfer to GPU and normalize
+        v = normalize_image_gpu(_to_gpu(v_cpu))
+        r = normalize_image_gpu(_to_gpu(r_cpu))
+
+        # Compute edges using Sobel
+        edges_v = cp.sqrt(cupy_sobel(v, axis=0) ** 2 + cupy_sobel(v, axis=1) ** 2)
+        edges_r = cp.sqrt(cupy_sobel(r, axis=0) ** 2 + cupy_sobel(r, axis=1) ** 2)
+
+        # Normalize edges
+        if cp.max(edges_v) > 0:
+            edges_v = edges_v / cp.max(edges_v)
+        if cp.max(edges_r) > 0:
+            edges_r = edges_r / cp.max(edges_r)
+
+        # Compute correlation on GPU
+        flat_v = edges_v.flatten()
+        flat_r = edges_r.flatten()
+
+        mean_v = cp.mean(flat_v)
+        mean_r = cp.mean(flat_r)
+
+        num = cp.sum((flat_v - mean_v) * (flat_r - mean_r))
+        den = cp.sqrt(cp.sum((flat_v - mean_v) ** 2) * cp.sum((flat_r - mean_r) ** 2))
+
+        if den > 0:
+            corr = float(num / den)
+            return max(0.0, corr) if not np.isnan(corr) else 0.0
+        return 0.0
+    except Exception:
+        from linumpy.utils.image_quality import compute_edge_score
+        return compute_edge_score(vol, reference, sample_z)
+
+
+def compute_variance_score_gpu(vol: np.ndarray, reference: np.ndarray) -> float:
+    """
+    Compute variance score using GPU.
+
+    Parameters
+    ----------
+    vol : np.ndarray
+        Input volume.
+    reference : np.ndarray
+        Reference volume.
+
+    Returns
+    -------
+    float
+        Variance score (0 to 1).
+    """
+    if not GPU_AVAILABLE or cp is None:
+        from linumpy.utils.image_quality import compute_variance_score
+        return compute_variance_score(vol, reference)
+
+    try:
+        v = _to_gpu(vol)
+        r = _to_gpu(reference)
+
+        var_v = float(cp.var(v))
+        var_r = float(cp.var(r))
+
+        if var_r == 0:
+            return 0.0
+
+        ratio = var_v / var_r
+        score = 2.0 / (1.0 + abs(np.log(ratio + 1e-10)))
+
+        return float(min(1.0, max(0.0, score)))
+    except Exception:
+        from linumpy.utils.image_quality import compute_variance_score
+        return compute_variance_score(vol, reference)
+
+
+def assess_slice_quality_gpu(vol: np.ndarray,
+                             vol_before: Optional[np.ndarray],
+                             vol_after: Optional[np.ndarray],
+                             sample_depth: int = 5,
+                             weights: Optional[Dict[str, float]] = None) -> Tuple[float, Dict[str, Any]]:
+    """
+    Assess overall quality of a slice volume using GPU acceleration.
+
+    Parameters
+    ----------
+    vol : np.ndarray
+        The slice volume (Z, Y, X).
+    vol_before : np.ndarray or None
+        The previous slice volume.
+    vol_after : np.ndarray or None
+        The next slice volume.
+    sample_depth : int
+        Number of z-planes to sample for SSIM.
+    weights : dict, optional
+        Custom weights for metrics.
+
+    Returns
+    -------
+    float
+        Overall quality score (0 to 1).
+    dict
+        Individual metric values.
+    """
+    if not GPU_AVAILABLE:
+        from linumpy.utils.image_quality import assess_slice_quality
+        return assess_slice_quality(vol, vol_before, vol_after, sample_depth, weights)
+
+    if weights is None:
+        weights = {'ssim': 0.5, 'edge': 0.3, 'variance': 0.2}
+
+    depth = vol.shape[0] if vol.ndim == 3 else 1
+    metrics: Dict[str, Any] = {
+        'ssim_before': 0.0,
+        'ssim_after': 0.0,
+        'ssim_mean': 0.0,
+        'edge_score': 0.0,
+        'variance_score': 0.0,
+        'depth': depth,
+        'has_data': True,
+    }
+
+    # Check if slice has meaningful data by sampling a single centre z-plane.
+    # zarr.Array supports integer indexing (returns numpy), so no full-volume I/O.
+    z_check = depth // 2 if vol.ndim == 3 else 0
+    check_plane = np.asarray(vol[z_check])
+    if check_plane.max() == check_plane.min() or np.std(check_plane) < 1e-6:
+        metrics['has_data'] = False
+        metrics['overall'] = 0.0
+        return 0.0, metrics
+
+    # Compute SSIM with neighbours.
+    # compute_ssim_3d_gpu internally accesses vol[z] one plane at a time, so
+    # zarr arrays are handled without loading the whole volume.
+    ssim_scores = []
+    if vol_before is not None:
+        metrics['ssim_before'] = compute_ssim_3d_gpu(vol, vol_before, sample_depth=sample_depth)
+        ssim_scores.append(metrics['ssim_before'])
+    if vol_after is not None:
+        metrics['ssim_after'] = compute_ssim_3d_gpu(vol, vol_after, sample_depth=sample_depth)
+        ssim_scores.append(metrics['ssim_after'])
+
+    if ssim_scores:
+        metrics['ssim_mean'] = float(np.mean(ssim_scores))
+
+    # Build sampled numpy arrays for edge and variance scores.
+    # Read only sample_depth z-planes via zarr integer indexing to avoid loading
+    # the full volume (compute_variance_score_gpu would otherwise call
+    # cp.asarray on the whole array).
+    n_planes = max(1, min(sample_depth, depth) if sample_depth > 0 else depth)
+    z_indices = np.linspace(0, depth - 1, n_planes, dtype=int)
+    vol_s = np.stack([np.asarray(vol[int(z)], dtype=np.float32) for z in z_indices])
+
+    ref_s = None
+    if vol_before is not None and vol_after is not None:
+        min_y = min(vol_before.shape[1], vol_after.shape[1])
+        min_x = min(vol_before.shape[2], vol_after.shape[2])
+        max_z_b = vol_before.shape[0] - 1
+        max_z_a = vol_after.shape[0] - 1
+        ref_s = (
+            0.5 * np.stack([np.asarray(vol_before[min(int(z), max_z_b)], dtype=np.float32)[:min_y, :min_x] for z in z_indices])
+            + 0.5 * np.stack([np.asarray(vol_after[min(int(z), max_z_a)], dtype=np.float32)[:min_y, :min_x] for z in z_indices])
+        )
+    elif vol_before is not None:
+        max_z_b = vol_before.shape[0] - 1
+        ref_s = np.stack([np.asarray(vol_before[min(int(z), max_z_b)], dtype=np.float32) for z in z_indices])
+    elif vol_after is not None:
+        max_z_a = vol_after.shape[0] - 1
+        ref_s = np.stack([np.asarray(vol_after[min(int(z), max_z_a)], dtype=np.float32) for z in z_indices])
+
+    # Compute edge preservation score
+    if ref_s is not None:
+        metrics['edge_score'] = compute_edge_score_gpu(vol_s, ref_s)
+
+    # Compute variance consistency
+    if ref_s is not None:
+        metrics['variance_score'] = compute_variance_score_gpu(vol_s, ref_s)
+
+    # Compute overall score
+    overall = (
+            weights['ssim'] * metrics['ssim_mean'] +
+            weights['edge'] * metrics['edge_score'] +
+            weights['variance'] * metrics['variance_score']
+    )
+    metrics['overall'] = float(overall)
+
+    return float(overall), metrics
+
+
+def clear_gpu_memory():
+    """Clear GPU memory pools."""
+    if GPU_AVAILABLE and cp is not None:
+        try:
+            cp.get_default_memory_pool().free_all_blocks()
+        except Exception:
+            pass

--- a/linumpy/gpu/interpolation.py
+++ b/linumpy/gpu/interpolation.py
@@ -1,0 +1,234 @@
+"""
+GPU-accelerated interpolation and resampling operations for linumpy.
+
+Provides GPU versions of image resampling, affine transforms, and
+coordinate mapping operations.
+"""
+
+import numpy as np
+
+from . import GPU_AVAILABLE, to_cpu
+
+
+def affine_transform(image, matrix, output_shape=None, order=1, use_gpu=True):
+    """
+    GPU-accelerated affine transformation.
+    
+    Parameters
+    ----------
+    image : np.ndarray
+        Input image (2D or 3D)
+    matrix : np.ndarray
+        Affine transformation matrix
+    output_shape : tuple, optional
+        Shape of output image. If None, uses input shape.
+    order : int
+        Interpolation order (0=nearest, 1=linear, 3=cubic)
+    use_gpu : bool
+        Whether to use GPU acceleration
+        
+    Returns
+    -------
+    np.ndarray
+        Transformed image
+    """
+    if output_shape is None:
+        output_shape = image.shape
+
+    if use_gpu and GPU_AVAILABLE:
+        return _affine_transform_gpu(image, matrix, output_shape, order)
+    else:
+        return _affine_transform_cpu(image, matrix, output_shape, order)
+
+
+def _affine_transform_gpu(image, matrix, output_shape, order):
+    """GPU implementation of affine transform."""
+    import cupy as cp
+    from cupyx.scipy.ndimage import affine_transform as cp_affine
+
+    img_gpu = cp.asarray(image.astype(np.float32))
+    matrix_gpu = cp.asarray(matrix.astype(np.float32))
+
+    result = cp_affine(img_gpu, matrix_gpu, output_shape=output_shape, order=order)
+
+    return to_cpu(result)
+
+
+def _affine_transform_cpu(image, matrix, output_shape, order):
+    """CPU fallback for affine transform."""
+    from scipy.ndimage import affine_transform as scipy_affine
+    return scipy_affine(image, matrix, output_shape=output_shape, order=order)
+
+
+def map_coordinates(image, coordinates, order=1, use_gpu=True):
+    """
+    GPU-accelerated coordinate mapping (general interpolation).
+    
+    Parameters
+    ----------
+    image : np.ndarray
+        Input image
+    coordinates : np.ndarray
+        Coordinates to sample at, shape (ndim, ...)
+    order : int
+        Interpolation order
+    use_gpu : bool
+        Whether to use GPU
+        
+    Returns
+    -------
+    np.ndarray
+        Interpolated values
+    """
+    if use_gpu and GPU_AVAILABLE:
+        return _map_coordinates_gpu(image, coordinates, order)
+    else:
+        return _map_coordinates_cpu(image, coordinates, order)
+
+
+def _map_coordinates_gpu(image, coordinates, order):
+    """GPU implementation of map_coordinates."""
+    import cupy as cp
+    from cupyx.scipy.ndimage import map_coordinates as cp_map
+
+    img_gpu = cp.asarray(image.astype(np.float32))
+    coords_gpu = cp.asarray(coordinates.astype(np.float32))
+
+    result = cp_map(img_gpu, coords_gpu, order=order)
+
+    return to_cpu(result)
+
+
+def _map_coordinates_cpu(image, coordinates, order):
+    """CPU fallback for map_coordinates."""
+    from scipy.ndimage import map_coordinates as scipy_map
+    return scipy_map(image, coordinates, order=order)
+
+
+def resize(image, output_shape, order=1, anti_aliasing=True, use_gpu=True):
+    """
+    GPU-accelerated image resize.
+    
+    Parameters
+    ----------
+    image : np.ndarray
+        Input image
+    output_shape : tuple
+        Desired output shape
+    order : int
+        Interpolation order
+    anti_aliasing : bool
+        Whether to apply anti-aliasing filter before downsampling
+    use_gpu : bool
+        Whether to use GPU
+        
+    Returns
+    -------
+    np.ndarray
+        Resized image
+    """
+    if use_gpu and GPU_AVAILABLE:
+        return _resize_gpu(image, output_shape, order, anti_aliasing)
+    else:
+        return _resize_cpu(image, output_shape, order, anti_aliasing)
+
+
+def _resize_gpu(image, output_shape, order, anti_aliasing):
+    """GPU implementation of resize using zoom."""
+    import cupy as cp
+    from cupyx.scipy.ndimage import zoom as cp_zoom
+    from cupyx.scipy.ndimage import gaussian_filter as cp_gaussian
+
+    img_gpu = cp.asarray(image if image.dtype == np.float32 else image.astype(np.float32))
+
+    # Scale factors: input/output for Gaussian sigma, output/input for zoom.
+    scale_factors = tuple(i / o for i, o in zip(image.shape, output_shape))
+    zoom_factors = tuple(o / i for i, o in zip(image.shape, output_shape))
+
+    # Anti-aliasing: single fused Gaussian call with per-axis sigma vector,
+    # replacing N sequential per-axis kernel launches.
+    if anti_aliasing:
+        sigmas = [(f - 1) / 2 if f > 1 else 0.0 for f in scale_factors]
+        if any(s > 0 for s in sigmas):
+            img_gpu = cp_gaussian(img_gpu, sigma=sigmas)
+
+    result = cp_zoom(img_gpu, zoom_factors, order=order)
+
+    return to_cpu(result)
+
+
+def _resize_cpu(image, output_shape, order, anti_aliasing):
+    """CPU fallback for resize using zoom."""
+    from scipy.ndimage import zoom as scipy_zoom
+    from scipy.ndimage import gaussian_filter as scipy_gaussian
+
+    img = image if image.dtype == np.float32 else image.astype(np.float32)
+
+    scale_factors = tuple(i / o for i, o in zip(image.shape, output_shape))
+    zoom_factors = tuple(o / i for i, o in zip(image.shape, output_shape))
+
+    if anti_aliasing:
+        sigmas = [(f - 1) / 2 if f > 1 else 0.0 for f in scale_factors]
+        if any(s > 0 for s in sigmas):
+            img = scipy_gaussian(img, sigma=sigmas)
+
+    return scipy_zoom(img, zoom_factors, order=order)
+
+
+def apply_displacement_field(image, displacement_field, use_gpu=True):
+    """
+    Apply a displacement field to warp an image.
+    
+    Parameters
+    ----------
+    image : np.ndarray
+        Input image (2D or 3D)
+    displacement_field : np.ndarray
+        Displacement field with shape (ndim, *image.shape)
+    use_gpu : bool
+        Whether to use GPU
+        
+    Returns
+    -------
+    np.ndarray
+        Warped image
+    """
+    ndim = image.ndim
+
+    # Create coordinate grid
+    coords = np.meshgrid(*[np.arange(s) for s in image.shape], indexing='ij')
+    coords = np.array(coords)
+
+    # Add displacement
+    new_coords = coords + displacement_field
+
+    return map_coordinates(image, new_coords, order=1, use_gpu=use_gpu)
+
+
+def resample_volume(volume, current_spacing, target_spacing, order=1, use_gpu=True):
+    """
+    Resample a volume to a new spacing.
+    
+    Parameters
+    ----------
+    volume : np.ndarray
+        Input volume
+    current_spacing : tuple
+        Current voxel spacing
+    target_spacing : tuple
+        Target voxel spacing
+    order : int
+        Interpolation order
+    use_gpu : bool
+        Whether to use GPU
+        
+    Returns
+    -------
+    np.ndarray
+        Resampled volume
+    """
+    # Compute new shape
+    scale_factors = tuple(c / t for c, t in zip(current_spacing, target_spacing))
+    new_shape = tuple(int(s * f) for s, f in zip(volume.shape, scale_factors))
+
+    return resize(volume, new_shape, order=order, anti_aliasing=True, use_gpu=use_gpu)

--- a/linumpy/gpu/morphology.py
+++ b/linumpy/gpu/morphology.py
@@ -1,0 +1,426 @@
+"""
+GPU-accelerated morphological operations for linumpy.
+
+Provides GPU versions of binary morphology, mask creation,
+and connected component operations.
+"""
+
+import numpy as np
+
+from . import GPU_AVAILABLE, to_cpu
+
+
+def binary_closing(mask, iterations=1, structure=None, use_gpu=True):
+    """
+    GPU-accelerated binary closing.
+    
+    Parameters
+    ----------
+    mask : np.ndarray
+        Binary mask
+    iterations : int
+        Number of iterations
+    structure : np.ndarray, optional
+        Structuring element
+    use_gpu : bool
+        Whether to use GPU
+        
+    Returns
+    -------
+    np.ndarray
+        Closed mask
+    """
+    if use_gpu and GPU_AVAILABLE:
+        import cupy as cp
+        from cupyx.scipy.ndimage import binary_closing as cp_closing
+        from cupyx.scipy.ndimage import generate_binary_structure
+
+        mask_gpu = cp.asarray(mask.astype(np.bool_))
+
+        if structure is None:
+            structure = generate_binary_structure(mask.ndim, 1)
+        else:
+            structure = cp.asarray(structure)
+
+        result = cp_closing(mask_gpu, structure=structure, iterations=iterations, brute_force=True)
+
+        output = to_cpu(result)
+        # Free GPU memory
+        del mask_gpu, result
+        cp.get_default_memory_pool().free_all_blocks()
+        return output
+    else:
+        from scipy.ndimage import binary_closing as scipy_closing
+        from scipy.ndimage import generate_binary_structure
+
+        if structure is None:
+            structure = generate_binary_structure(mask.ndim, 1)
+
+        return scipy_closing(mask, structure=structure, iterations=iterations)
+
+
+def binary_opening(mask, iterations=1, structure=None, use_gpu=True):
+    """
+    GPU-accelerated binary opening.
+    
+    Parameters
+    ----------
+    mask : np.ndarray
+        Binary mask
+    iterations : int
+        Number of iterations
+    structure : np.ndarray, optional
+        Structuring element
+    use_gpu : bool
+        Whether to use GPU
+        
+    Returns
+    -------
+    np.ndarray
+        Opened mask
+    """
+    if use_gpu and GPU_AVAILABLE:
+        import cupy as cp
+        from cupyx.scipy.ndimage import binary_opening as cp_opening
+        from cupyx.scipy.ndimage import generate_binary_structure
+
+        mask_gpu = cp.asarray(mask.astype(np.bool_))
+
+        if structure is None:
+            structure = generate_binary_structure(mask.ndim, 1)
+        else:
+            structure = cp.asarray(structure)
+
+        result = cp_opening(mask_gpu, structure=structure, iterations=iterations, brute_force=True)
+
+        output = to_cpu(result)
+        # Free GPU memory
+        del mask_gpu, result
+        cp.get_default_memory_pool().free_all_blocks()
+        return output
+    else:
+        from scipy.ndimage import binary_opening as scipy_opening
+        from scipy.ndimage import generate_binary_structure
+
+        if structure is None:
+            structure = generate_binary_structure(mask.ndim, 1)
+
+        return scipy_opening(mask, structure=structure, iterations=iterations)
+
+
+def binary_dilation(mask, iterations=1, structure=None, use_gpu=True):
+    """
+    GPU-accelerated binary dilation.
+    
+    Parameters
+    ----------
+    mask : np.ndarray
+        Binary mask
+    iterations : int
+        Number of iterations
+    structure : np.ndarray, optional
+        Structuring element
+    use_gpu : bool
+        Whether to use GPU
+        
+    Returns
+    -------
+    np.ndarray
+        Dilated mask
+    """
+    if use_gpu and GPU_AVAILABLE:
+        import cupy as cp
+        from cupyx.scipy.ndimage import binary_dilation as cp_dilation
+        from cupyx.scipy.ndimage import generate_binary_structure
+
+        mask_gpu = cp.asarray(mask.astype(np.bool_))
+
+        if structure is None:
+            structure = generate_binary_structure(mask.ndim, 1)
+        else:
+            structure = cp.asarray(structure)
+
+        result = cp_dilation(mask_gpu, structure=structure, iterations=iterations, brute_force=True)
+
+        output = to_cpu(result)
+        # Free GPU memory
+        del mask_gpu, result
+        cp.get_default_memory_pool().free_all_blocks()
+        return output
+    else:
+        from scipy.ndimage import binary_dilation as scipy_dilation
+        from scipy.ndimage import generate_binary_structure
+
+        if structure is None:
+            structure = generate_binary_structure(mask.ndim, 1)
+
+        return scipy_dilation(mask, structure=structure, iterations=iterations)
+
+
+def binary_erosion(mask, iterations=1, structure=None, use_gpu=True):
+    """
+    GPU-accelerated binary erosion.
+    
+    Parameters
+    ----------
+    mask : np.ndarray
+        Binary mask
+    iterations : int
+        Number of iterations
+    structure : np.ndarray, optional
+        Structuring element
+    use_gpu : bool
+        Whether to use GPU
+        
+    Returns
+    -------
+    np.ndarray
+        Eroded mask
+    """
+    if use_gpu and GPU_AVAILABLE:
+        import cupy as cp
+        from cupyx.scipy.ndimage import binary_erosion as cp_erosion
+        from cupyx.scipy.ndimage import generate_binary_structure
+
+        mask_gpu = cp.asarray(mask.astype(np.bool_))
+
+        if structure is None:
+            structure = generate_binary_structure(mask.ndim, 1)
+        else:
+            structure = cp.asarray(structure)
+
+        result = cp_erosion(mask_gpu, structure=structure, iterations=iterations, brute_force=True)
+
+        output = to_cpu(result)
+        # Free GPU memory
+        del mask_gpu, result
+        cp.get_default_memory_pool().free_all_blocks()
+        return output
+    else:
+        from scipy.ndimage import binary_erosion as scipy_erosion
+        from scipy.ndimage import generate_binary_structure
+
+        if structure is None:
+            structure = generate_binary_structure(mask.ndim, 1)
+
+        return scipy_erosion(mask, structure=structure, iterations=iterations)
+
+
+def binary_fill_holes(mask, use_gpu=True):
+    """
+    GPU-accelerated binary hole filling.
+    
+    Parameters
+    ----------
+    mask : np.ndarray
+        Binary mask
+    use_gpu : bool
+        Whether to use GPU
+        
+    Returns
+    -------
+    np.ndarray
+        Mask with holes filled
+    """
+    if use_gpu and GPU_AVAILABLE:
+        import cupy as cp
+        from cupyx.scipy.ndimage import binary_fill_holes as cp_fill
+
+        mask_gpu = cp.asarray(mask.astype(np.bool_))
+        result = cp_fill(mask_gpu)
+
+        output = to_cpu(result)
+        # Free GPU memory
+        del mask_gpu, result
+        cp.get_default_memory_pool().free_all_blocks()
+        return output
+    else:
+        from scipy.ndimage import binary_fill_holes as scipy_fill
+        return scipy_fill(mask)
+
+
+def gaussian_filter(image, sigma, use_gpu=True):
+    """
+    GPU-accelerated Gaussian filter.
+    
+    Parameters
+    ----------
+    image : np.ndarray
+        Input image
+    sigma : float or sequence
+        Standard deviation for Gaussian kernel
+    use_gpu : bool
+        Whether to use GPU
+        
+    Returns
+    -------
+    np.ndarray
+        Filtered image
+    """
+    if use_gpu and GPU_AVAILABLE:
+        import cupy as cp
+        from cupyx.scipy.ndimage import gaussian_filter as cp_gaussian
+
+        img_gpu = cp.asarray(image.astype(np.float32))
+        result = cp_gaussian(img_gpu, sigma=sigma)
+
+        output = to_cpu(result)
+        # Free GPU memory
+        del img_gpu, result
+        cp.get_default_memory_pool().free_all_blocks()
+        return output
+    else:
+        from scipy.ndimage import gaussian_filter as scipy_gaussian
+        return scipy_gaussian(image, sigma=sigma)
+
+
+def median_filter(image, size, use_gpu=True):
+    """
+    GPU-accelerated median filter.
+    
+    Parameters
+    ----------
+    image : np.ndarray
+        Input image
+    size : int or sequence
+        Filter size
+    use_gpu : bool
+        Whether to use GPU
+        
+    Returns
+    -------
+    np.ndarray
+        Filtered image
+    """
+    if use_gpu and GPU_AVAILABLE:
+        import cupy as cp
+        from cupyx.scipy.ndimage import median_filter as cp_median
+
+        img_gpu = cp.asarray(image)
+        result = cp_median(img_gpu, size=size)
+
+        output = to_cpu(result)
+        # Free GPU memory
+        del img_gpu, result
+        cp.get_default_memory_pool().free_all_blocks()
+        return output
+    else:
+        from scipy.ndimage import median_filter as scipy_median
+        return scipy_median(image, size=size)
+
+
+def create_tissue_mask(image, sigma=2, threshold=None, fill_holes=True,
+                       min_opening=1, use_gpu=True):
+    """
+    GPU-accelerated tissue mask creation.
+    
+    Parameters
+    ----------
+    image : np.ndarray
+        Input image
+    sigma : float
+        Gaussian smoothing sigma
+    threshold : float, optional
+        Threshold value. If None, uses Otsu
+    fill_holes : bool
+        Whether to fill holes
+    min_opening : int
+        Opening iterations for noise removal
+    use_gpu : bool
+        Whether to use GPU
+        
+    Returns
+    -------
+    np.ndarray
+        Binary tissue mask
+    """
+    from .array_ops import threshold_otsu
+
+    # Smooth
+    smoothed = gaussian_filter(image, sigma, use_gpu=use_gpu)
+
+    # Threshold
+    if threshold is None:
+        threshold = threshold_otsu(smoothed, use_gpu=use_gpu)
+
+    if use_gpu and GPU_AVAILABLE:
+        import cupy as cp
+        smoothed_gpu = cp.asarray(smoothed)
+        mask = smoothed_gpu > threshold
+        mask = to_cpu(mask)
+    else:
+        mask = smoothed > threshold
+
+    # Clean up
+    if min_opening > 0:
+        mask = binary_opening(mask, iterations=min_opening, use_gpu=use_gpu)
+
+    if fill_holes:
+        mask = binary_fill_holes(mask, use_gpu=use_gpu)
+
+    return mask
+
+
+def label_connected_components(mask, use_gpu=True):
+    """
+    Label connected components in a binary mask.
+    
+    Note: CuPy's connected components is limited. Falls back to CPU
+    for complex cases.
+    
+    Parameters
+    ----------
+    mask : np.ndarray
+        Binary mask
+    use_gpu : bool
+        Whether to attempt GPU (may fall back to CPU)
+        
+    Returns
+    -------
+    np.ndarray
+        Labeled array
+    int
+        Number of labels
+    """
+    # CuPy's label function is limited, use CPU for reliability
+    from scipy.ndimage import label as scipy_label
+    return scipy_label(mask)
+
+
+def get_largest_component(mask, use_gpu=True):
+    """
+    Get the largest connected component from a mask.
+    
+    Parameters
+    ----------
+    mask : np.ndarray
+        Binary mask
+    use_gpu : bool
+        Whether to use GPU for histogram
+        
+    Returns
+    -------
+    np.ndarray
+        Binary mask of largest component
+    """
+    labeled, n_labels = label_connected_components(mask, use_gpu=False)
+
+    if n_labels == 0:
+        return mask
+
+    if use_gpu and GPU_AVAILABLE:
+        import cupy as cp
+        labeled_gpu = cp.asarray(labeled)
+
+        # Find largest component (excluding background 0)
+        counts = cp.bincount(labeled_gpu.ravel())
+        counts[0] = 0  # Ignore background
+        largest_label = int(cp.argmax(counts).get())
+
+        result = labeled_gpu == largest_label
+        return to_cpu(result)
+    else:
+        counts = np.bincount(labeled.ravel())
+        counts[0] = 0
+        largest_label = np.argmax(counts)
+        return labeled == largest_label

--- a/linumpy/gpu/registration.py
+++ b/linumpy/gpu/registration.py
@@ -1,0 +1,324 @@
+"""
+GPU-accelerated registration operations for linumpy.
+
+Provides a hybrid approach where metric computation is done on GPU
+while the optimizer runs on CPU (SimpleITK).
+"""
+
+import numpy as np
+
+from . import GPU_AVAILABLE, to_cpu
+from .interpolation import affine_transform
+
+
+class GPUAcceleratedRegistration:
+    """
+    Hybrid GPU/CPU registration class.
+    
+    Uses GPU for:
+    - Image resampling/transformation
+    - Metric computation (MSE, NCC)
+    
+    Uses CPU (SimpleITK) for:
+    - Optimization loop
+    - Transform management
+    
+    Parameters
+    ----------
+    use_gpu : bool
+        Whether to use GPU for metric computation
+    metric : str
+        Registration metric: 'mse', 'ncc', 'mi'
+    """
+
+    def __init__(self, use_gpu=True, metric='mse'):
+        self.use_gpu = use_gpu and GPU_AVAILABLE
+        self.metric = metric.lower()
+
+        if self.use_gpu:
+            import cupy as cp
+            self._cp = cp
+
+    def compute_metric(self, fixed, moving):
+        """
+        Compute registration metric between two images.
+        
+        Parameters
+        ----------
+        fixed : np.ndarray
+            Fixed image
+        moving : np.ndarray
+            Moving image (already transformed)
+            
+        Returns
+        -------
+        float
+            Metric value (lower is better for MSE, higher for NCC)
+        """
+        if self.use_gpu:
+            return self._compute_metric_gpu(fixed, moving)
+        else:
+            return self._compute_metric_cpu(fixed, moving)
+
+    def _compute_metric_gpu(self, fixed, moving):
+        """GPU implementation of metric computation."""
+        cp = self._cp
+
+        fixed_gpu = cp.asarray(fixed.astype(np.float32))
+        moving_gpu = cp.asarray(moving.astype(np.float32))
+
+        # Create mask for valid pixels
+        mask = (fixed_gpu > 0) & (moving_gpu > 0)
+
+        if self.metric == 'mse':
+            diff = fixed_gpu - moving_gpu
+            mse = cp.mean(diff[mask] ** 2)
+            return float(mse.get())
+
+        elif self.metric == 'ncc':
+            # Normalized cross-correlation
+            fixed_masked = fixed_gpu[mask]
+            moving_masked = moving_gpu[mask]
+
+            fixed_norm = fixed_masked - cp.mean(fixed_masked)
+            moving_norm = moving_masked - cp.mean(moving_masked)
+
+            std_fixed = cp.std(fixed_norm)
+            std_moving = cp.std(moving_norm)
+
+            if std_fixed < 1e-10 or std_moving < 1e-10:
+                return 0.0
+
+            ncc = cp.mean(fixed_norm * moving_norm) / (std_fixed * std_moving)
+            return float(ncc.get())
+
+        elif self.metric == 'mi':
+            # Mutual information (simplified histogram-based)
+            return self._compute_mi_gpu(fixed_gpu, moving_gpu, mask)
+
+        else:
+            raise ValueError(f"Unknown metric: {self.metric}")
+
+    def _compute_mi_gpu(self, fixed, moving, mask, bins=32):
+        """Compute mutual information on GPU."""
+        cp = self._cp
+
+        # Normalize to [0, bins-1]
+        fixed_masked = fixed[mask]
+        moving_masked = moving[mask]
+
+        f_min, f_max = cp.min(fixed_masked), cp.max(fixed_masked)
+        m_min, m_max = cp.min(moving_masked), cp.max(moving_masked)
+
+        if f_max - f_min < 1e-10 or m_max - m_min < 1e-10:
+            return 0.0
+
+        fixed_binned = ((fixed_masked - f_min) / (f_max - f_min) * (bins - 1)).astype(cp.int32)
+        moving_binned = ((moving_masked - m_min) / (m_max - m_min) * (bins - 1)).astype(cp.int32)
+
+        fixed_binned = cp.clip(fixed_binned, 0, bins - 1)
+        moving_binned = cp.clip(moving_binned, 0, bins - 1)
+
+        # Joint histogram
+        joint_hist = cp.zeros((bins, bins), dtype=cp.float32)
+        for i in range(len(fixed_binned)):
+            joint_hist[fixed_binned[i], moving_binned[i]] += 1
+
+        # Normalize
+        joint_hist /= joint_hist.sum()
+
+        # Marginal histograms
+        p_fixed = joint_hist.sum(axis=1)
+        p_moving = joint_hist.sum(axis=0)
+
+        # Mutual information
+        mi = 0.0
+        for i in range(bins):
+            for j in range(bins):
+                if joint_hist[i, j] > 1e-10:
+                    mi += joint_hist[i, j] * cp.log(
+                        joint_hist[i, j] / (p_fixed[i] * p_moving[j] + 1e-10) + 1e-10
+                    )
+
+        return float(mi.get())
+
+    def _compute_metric_cpu(self, fixed, moving):
+        """CPU fallback for metric computation."""
+        mask = (fixed > 0) & (moving > 0)
+
+        if self.metric == 'mse':
+            diff = fixed - moving
+            return float(np.mean(diff[mask] ** 2))
+
+        elif self.metric == 'ncc':
+            fixed_masked = fixed[mask]
+            moving_masked = moving[mask]
+
+            fixed_norm = fixed_masked - np.mean(fixed_masked)
+            moving_norm = moving_masked - np.mean(moving_masked)
+
+            std_fixed = np.std(fixed_norm)
+            std_moving = np.std(moving_norm)
+
+            if std_fixed < 1e-10 or std_moving < 1e-10:
+                return 0.0
+
+            return float(np.mean(fixed_norm * moving_norm) / (std_fixed * std_moving))
+
+        else:
+            raise ValueError(f"Unknown metric: {self.metric}")
+
+    def transform_image(self, image, transform_matrix, output_shape=None):
+        """
+        Apply transformation to image using GPU.
+        
+        Parameters
+        ----------
+        image : np.ndarray
+            Input image
+        transform_matrix : np.ndarray
+            Transformation matrix
+        output_shape : tuple, optional
+            Output shape
+            
+        Returns
+        -------
+        np.ndarray
+            Transformed image
+        """
+        return affine_transform(image, transform_matrix, output_shape,
+                                order=1, use_gpu=self.use_gpu)
+
+
+def register_2d_gpu(fixed, moving, method='affine', metric='mse',
+                    max_iterations=1000, use_gpu=True):
+    """
+    GPU-accelerated 2D image registration.
+    
+    Uses SimpleITK optimizer with GPU metric computation.
+    
+    Parameters
+    ----------
+    fixed : np.ndarray
+        Fixed image
+    moving : np.ndarray
+        Moving image
+    method : str
+        Transform type: 'translation', 'euler', 'affine'
+    metric : str
+        Metric: 'mse', 'ncc', 'mi'
+    max_iterations : int
+        Maximum optimizer iterations
+    use_gpu : bool
+        Whether to use GPU acceleration
+        
+    Returns
+    -------
+    transform : sitk.Transform
+        Computed transform
+    str
+        Optimizer stop condition
+    float
+        Final metric value
+    """
+
+    # For now, use SimpleITK's built-in registration
+    # GPU acceleration is applied via pre/post processing
+
+    # Normalize images on GPU if available
+    if use_gpu and GPU_AVAILABLE:
+        import cupy as cp
+
+        fixed_gpu = cp.asarray(fixed.astype(np.float32))
+        moving_gpu = cp.asarray(moving.astype(np.float32))
+
+        # Normalize
+        fixed_norm = (fixed_gpu - cp.min(fixed_gpu)) / (cp.max(fixed_gpu) - cp.min(fixed_gpu) + 1e-10)
+        moving_norm = (moving_gpu - cp.min(moving_gpu)) / (cp.max(moving_gpu) - cp.min(moving_gpu) + 1e-10)
+
+        fixed = to_cpu(fixed_norm)
+        moving = to_cpu(moving_norm)
+
+    # Use existing CPU registration
+    from linumpy.stitching.registration import register_2d_images_sitk
+
+    return register_2d_images_sitk(
+        fixed, moving,
+        method=method,
+        metric='MSE' if metric.lower() == 'mse' else metric.upper(),
+        max_iterations=max_iterations
+    )
+
+
+def apply_transform_gpu(image, transform, use_gpu=True):
+    """
+    Apply SimpleITK transform to image using GPU resampling.
+    
+    Parameters
+    ----------
+    image : np.ndarray
+        Input image
+    transform : sitk.Transform
+        SimpleITK transform
+    use_gpu : bool
+        Whether to use GPU
+        
+    Returns
+    -------
+    np.ndarray
+        Transformed image
+    """
+
+    # For complex transforms, use SimpleITK
+    # Could potentially extract matrix and use GPU affine_transform
+
+    if use_gpu and GPU_AVAILABLE and _is_affine_transform(transform):
+        # Extract affine matrix and use GPU
+        matrix, offset = _sitk_transform_to_matrix(transform, image.shape)
+        return affine_transform(image, matrix, use_gpu=True)
+    else:
+        # Fall back to SimpleITK
+        from linumpy.stitching.registration import apply_transform
+        return apply_transform(image, transform)
+
+
+def _is_affine_transform(transform):
+    """Check if transform can be represented as affine matrix."""
+    import SimpleITK as sitk
+    return isinstance(transform, (sitk.AffineTransform,
+                                  sitk.Euler2DTransform,
+                                  sitk.Euler3DTransform,
+                                  sitk.TranslationTransform))
+
+
+def _sitk_transform_to_matrix(transform, image_shape):
+    """Convert SimpleITK transform to affine matrix."""
+    import SimpleITK as sitk
+
+    ndim = len(image_shape)
+
+    if isinstance(transform, sitk.TranslationTransform):
+        matrix = np.eye(ndim)
+        offset = np.array(transform.GetOffset())
+        return matrix, offset
+
+    elif isinstance(transform, sitk.Euler2DTransform):
+        angle = transform.GetAngle()
+        center = np.array(transform.GetCenter())
+        translation = np.array(transform.GetTranslation())
+
+        cos_a, sin_a = np.cos(angle), np.sin(angle)
+        rotation = np.array([[cos_a, -sin_a], [sin_a, cos_a]])
+
+        # Affine: y = R(x - c) + c + t = Rx + (c - Rc + t)
+        offset = center - rotation @ center + translation
+
+        return rotation, offset
+
+    elif isinstance(transform, sitk.AffineTransform):
+        matrix = np.array(transform.GetMatrix()).reshape(ndim, ndim)
+        offset = np.array(transform.GetTranslation())
+        return matrix, offset
+
+    else:
+        raise ValueError(f"Cannot convert {type(transform)} to matrix")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-numpy
-scipy
+numpy<2.3
+scipy<1.13
 scikit-image
 scikit-learn
 matplotlib
@@ -12,9 +12,12 @@ tqdm
 pqdm
 hyperactive<=4.8.0
 basicpy
+jax<=0.4.23
+jaxlib<=0.4.23
 zarr>=3.0.10
 ome-zarr>=0.9.0
 napari[all]
 napari-ome-zarr
 pynrrd==1.1.3
 numcodecs<0.16
+threadpoolctl

--- a/scripts/linum_aip_gpu.py
+++ b/scripts/linum_aip_gpu.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""Compute an Average Intensity Projection (AIP) from a 3D mosaic grid and save as PNG.
+
+The AIP is computed by averaging voxel intensities along the Z-axis, producing a 2D
+image at full XY resolution (1 data pixel = 1 output pixel). The result is saved as
+a 16-bit PNG for QC visualization.
+
+Falls back to CPU if GPU is not available.
+"""
+
+# Configure thread limits before numpy/scipy imports
+import linumpy._thread_config  # noqa: F401
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+from skimage.io import imsave
+
+from linumpy.gpu import GPU_AVAILABLE, to_cpu, print_gpu_info
+from linumpy.io.zarr import read_omezarr
+
+
+def compute_aip(vol, use_gpu: bool = True) -> np.ndarray:
+    """Compute the AIP of a mosaic grid volume tile-by-tile.
+
+    Parameters
+    ----------
+    vol:
+        Dask array of shape (Z, X, Y) from read_omezarr.
+    use_gpu:
+        Whether to use GPU acceleration for the averaging.
+
+    Returns
+    -------
+    np.ndarray
+        2D float32 AIP array of shape (X, Y).
+    """
+    tile_shape = vol.chunks
+    nx = vol.shape[1] // tile_shape[1]
+    ny = vol.shape[2] // tile_shape[2]
+
+    aip = np.empty((vol.shape[1], vol.shape[2]), dtype=np.float32)
+
+    for i in range(nx):
+        for j in range(ny):
+            rmin = i * tile_shape[1]
+            rmax = (i + 1) * tile_shape[1]
+            cmin = j * tile_shape[2]
+            cmax = (j + 1) * tile_shape[2]
+
+            tile = np.asarray(vol[:, rmin:rmax, cmin:cmax])
+
+            if use_gpu:
+                import cupy as cp
+                tile_gpu = cp.asarray(tile.astype(np.float32))
+                aip[rmin:rmax, cmin:cmax] = to_cpu(cp.mean(tile_gpu, axis=0))
+                del tile_gpu
+            else:
+                aip[rmin:rmax, cmin:cmax] = tile.mean(axis=0)
+
+    if use_gpu:
+        try:
+            import cupy as cp
+            cp.get_default_memory_pool().free_all_blocks()
+        except Exception:
+            pass
+
+    return aip
+
+
+def save_aip_png(aip: np.ndarray, output_path: Path) -> None:
+    """Normalize and save an AIP array as a 16-bit PNG.
+
+    Intensities are clipped to the 0.1–99.9 percentile range and mapped
+    to the full uint16 range. Spatial resolution is preserved: each data
+    pixel maps to exactly one output pixel.
+
+    Parameters
+    ----------
+    aip:
+        2D float32 array.
+    output_path:
+        Destination PNG file path.
+    """
+    vmin = np.percentile(aip, 0.1)
+    vmax = np.percentile(aip, 99.9)
+    if vmax > vmin:
+        aip_norm = np.clip((aip - vmin) / (vmax - vmin), 0, 1)
+    else:
+        aip_norm = np.zeros_like(aip)
+    imsave(output_path, (aip_norm * 65535).astype(np.uint16))
+
+
+def _build_arg_parser():
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
+    p.add_argument("input_zarr",
+                   help="Full path to the input mosaic grid OME-Zarr volume.")
+    p.add_argument("output_png",
+                   help="Full path to the output PNG file.")
+    p.add_argument("--use_gpu", default=True,
+                   action=argparse.BooleanOptionalAction,
+                   help="Use GPU acceleration if available. [%(default)s]")
+    p.add_argument("--verbose", "-v", action="store_true",
+                   help="Print GPU information.")
+    return p
+
+
+def main():
+    p = _build_arg_parser()
+    args = p.parse_args()
+
+    input_file = Path(args.input_zarr)
+    output_file = Path(args.output_png)
+
+    use_gpu = args.use_gpu and GPU_AVAILABLE
+
+    if args.verbose:
+        print_gpu_info()
+
+    if args.use_gpu and not GPU_AVAILABLE:
+        print("WARNING: GPU requested but not available, falling back to CPU")
+    elif use_gpu:
+        print("GPU: ENABLED")
+    else:
+        print("GPU: DISABLED (using CPU)")
+
+    vol, _ = read_omezarr(input_file, level=0)
+    aip = compute_aip(vol, use_gpu=use_gpu)
+    save_aip_png(aip, output_file)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/linum_benchmark_gpu.py
+++ b/scripts/linum_benchmark_gpu.py
@@ -1,0 +1,498 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Benchmark GPU vs CPU performance for linumpy operations.
+
+This script tests all GPU-accelerated operations and compares their
+performance against CPU implementations. It also verifies that results
+are numerically equivalent.
+
+Usage:
+    # Quick benchmark with synthetic data
+    linum_benchmark_gpu.py
+    
+    # Benchmark with real data
+    linum_benchmark_gpu.py --input /path/to/mosaic.ome.zarr
+    
+    # Full benchmark with multiple sizes
+    linum_benchmark_gpu.py --full
+    
+    # Save results to file
+    linum_benchmark_gpu.py --output benchmark_results.json
+"""
+
+# Configure thread limits before numpy/scipy imports
+import linumpy._thread_config  # noqa: F401
+
+import argparse
+import json
+import sys
+import time
+from datetime import datetime
+
+import numpy as np
+
+# Import GPU module
+from linumpy.gpu import GPU_AVAILABLE, gpu_info, print_gpu_info
+
+
+def _build_arg_parser():
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
+    p.add_argument("--input", type=str,
+                   help="Path to OME-Zarr file for real-data benchmark")
+    p.add_argument("--output", "-o", type=str,
+                   help="Save results to JSON file")
+    p.add_argument("--iterations", "-n", type=int, default=3,
+                   help="Number of iterations per test [%(default)s]")
+    p.add_argument("--full", action="store_true",
+                   help="Run full benchmark with multiple sizes")
+    p.add_argument("--skip-correctness", action="store_true",
+                   help="Skip result correctness checks")
+    p.add_argument("--sizes", nargs="+", type=int, 
+                   default=[512, 1024, 2048],
+                   help="Image sizes to test [%(default)s]")
+    p.add_argument("--select-best-gpu", action="store_true",
+                   help="Automatically select GPU with most free memory")
+    p.add_argument("--gpu", type=int, metavar="ID",
+                   help="Select specific GPU by ID")
+    return p
+
+
+class BenchmarkTimer:
+    """Context manager for timing operations."""
+    
+    def __init__(self):
+        self.elapsed = 0
+        
+    def __enter__(self):
+        self.start = time.perf_counter()
+        return self
+        
+    def __exit__(self, *args):
+        self.elapsed = time.perf_counter() - self.start
+
+
+def benchmark_operation(func_cpu, func_gpu, data, name, iterations=3, check_correctness=True):
+    """
+    Benchmark a single operation comparing CPU and GPU.
+    
+    Returns dict with timing results.
+    """
+    results = {
+        "name": name,
+        "cpu_times": [],
+        "gpu_times": [],
+        "correct": None,
+        "max_diff": None,
+    }
+    
+    # Warmup GPU
+    if GPU_AVAILABLE:
+        try:
+            _ = func_gpu(data)
+        except Exception:
+            pass
+    
+    # CPU benchmark
+    for _ in range(iterations):
+        with BenchmarkTimer() as t:
+            result_cpu = func_cpu(data)
+        results["cpu_times"].append(t.elapsed)
+    
+    # GPU benchmark
+    if GPU_AVAILABLE:
+        for _ in range(iterations):
+            with BenchmarkTimer() as t:
+                result_gpu = func_gpu(data)
+            results["gpu_times"].append(t.elapsed)
+        
+        # Check correctness
+        if check_correctness and result_cpu is not None and result_gpu is not None:
+            try:
+                if isinstance(result_cpu, tuple):
+                    result_cpu = result_cpu[0]
+                    result_gpu = result_gpu[0]
+                
+                cpu_arr = np.asarray(result_cpu)
+                gpu_arr = np.asarray(result_gpu)
+                
+                # Handle complex arrays by comparing magnitudes
+                if np.iscomplexobj(cpu_arr) or np.iscomplexobj(gpu_arr):
+                    cpu_arr = np.abs(cpu_arr)
+                    gpu_arr = np.abs(gpu_arr)
+                
+                cpu_arr = cpu_arr.astype(np.float64)
+                gpu_arr = gpu_arr.astype(np.float64)
+                
+                # Compute various error metrics
+                abs_diff = np.abs(cpu_arr - gpu_arr)
+                max_diff = np.max(abs_diff)
+                mean_diff = np.mean(abs_diff)
+                
+                # Relative error (avoid division by zero)
+                cpu_max = np.max(np.abs(cpu_arr))
+                rel_error = max_diff / cpu_max if cpu_max > 1e-10 else max_diff
+                
+                results["max_diff"] = float(max_diff)
+                results["mean_diff"] = float(mean_diff)
+                results["rel_error"] = float(rel_error)
+                
+                # Use relative tolerance for correctness check
+                # 1e-5 relative error is acceptable for float32 operations
+                results["correct"] = rel_error < 1e-4
+            except Exception as e:
+                results["correct"] = f"Check failed: {e}"
+    else:
+        results["gpu_times"] = [float('nan')] * iterations
+        results["correct"] = "GPU not available"
+    
+    # Compute statistics
+    results["cpu_mean"] = np.mean(results["cpu_times"])
+    results["cpu_std"] = np.std(results["cpu_times"])
+    results["gpu_mean"] = np.mean(results["gpu_times"]) if GPU_AVAILABLE else float('nan')
+    results["gpu_std"] = np.std(results["gpu_times"]) if GPU_AVAILABLE else float('nan')
+    results["speedup"] = results["cpu_mean"] / results["gpu_mean"] if GPU_AVAILABLE else float('nan')
+    
+    return results
+
+
+def benchmark_fft(size, iterations=3, check_correctness=True):
+    """Benchmark FFT operations."""
+    from linumpy.gpu.fft_ops import fft2
+    
+    data = np.random.rand(size, size).astype(np.float32)
+    
+    def cpu_fft(d):
+        return np.fft.fft2(d)
+    
+    def gpu_fft(d):
+        return fft2(d, use_gpu=True)
+    
+    return benchmark_operation(cpu_fft, gpu_fft, data, f"FFT2 ({size}x{size})",
+                               iterations, check_correctness)
+
+
+def benchmark_phase_correlation(size, iterations=3, check_correctness=True):
+    """Benchmark phase correlation."""
+    from linumpy.gpu.fft_ops import phase_correlation
+    from linumpy.stitching.registration import pairWisePhaseCorrelation
+    
+    # Create two slightly shifted images
+    img1 = np.random.rand(size, size).astype(np.float32)
+    img2 = np.roll(img1, (5, 10), axis=(0, 1))
+    
+    def cpu_pc(d):
+        return pairWisePhaseCorrelation(d[0], d[1], returnCC=True)
+    
+    def gpu_pc(d):
+        return phase_correlation(d[0], d[1], use_gpu=True)
+    
+    data = (img1, img2)
+    
+    return benchmark_operation(cpu_pc, gpu_pc, data, f"Phase Correlation ({size}x{size})",
+                               iterations, check_correctness=False)  # Results may differ slightly
+
+
+def benchmark_gaussian_filter(size, iterations=3, check_correctness=True):
+    """Benchmark Gaussian filtering."""
+    from linumpy.gpu.morphology import gaussian_filter
+    from scipy.ndimage import gaussian_filter as scipy_gaussian
+    
+    data = np.random.rand(size, size).astype(np.float32)
+    sigma = 2.0
+    
+    def cpu_gauss(d):
+        return scipy_gaussian(d, sigma=sigma)
+    
+    def gpu_gauss(d):
+        return gaussian_filter(d, sigma=sigma, use_gpu=True)
+    
+    return benchmark_operation(cpu_gauss, gpu_gauss, data,
+                               f"Gaussian Filter ({size}x{size})",
+                               iterations, check_correctness)
+
+
+def benchmark_binary_closing(size, iterations=3, check_correctness=True):
+    """Benchmark binary morphology."""
+    from linumpy.gpu.morphology import binary_closing
+    from scipy.ndimage import binary_closing as scipy_closing
+    
+    # Create random binary mask
+    data = (np.random.rand(size, size) > 0.5).astype(np.bool_)
+    
+    def cpu_close(d):
+        return scipy_closing(d, iterations=2)
+    
+    def gpu_close(d):
+        return binary_closing(d, iterations=2, use_gpu=True)
+    
+    return benchmark_operation(cpu_close, gpu_close, data,
+                               f"Binary Closing ({size}x{size})",
+                               iterations, check_correctness)
+
+
+def benchmark_resize(size, iterations=3, check_correctness=True):
+    """Benchmark image resize."""
+    from linumpy.gpu.interpolation import resize
+    
+    data = np.random.rand(size, size).astype(np.float32)
+    output_size = (size // 2, size // 2)
+    
+    def cpu_resize(d):
+        # Use the same function with use_gpu=False for fair comparison
+        return resize(d, output_size, order=1, anti_aliasing=False, use_gpu=False)
+    
+    def gpu_resize(d):
+        return resize(d, output_size, order=1, anti_aliasing=False, use_gpu=True)
+    
+    return benchmark_operation(cpu_resize, gpu_resize, data,
+                               f"Resize ({size}→{size//2})",
+                               iterations, check_correctness)
+
+
+def benchmark_rescale_3d(size, iterations=3, check_correctness=True):
+    """Benchmark 3D volume rescaling (like linum_resample_mosaic_grid)."""
+    from linumpy.gpu.interpolation import resize
+    
+    # Create 3D volume (typical OCT tile: depth x height x width)
+    depth = size // 4  # Typically depth is smaller than XY
+    data = np.random.rand(depth, size, size).astype(np.float32)
+    
+    # Rescale by 0.5 in each dimension (typical downsampling)
+    scale_factor = 0.5
+    output_size = (int(depth * scale_factor), int(size * scale_factor), int(size * scale_factor))
+    
+    def cpu_rescale(d):
+        return resize(d, output_size, order=1, anti_aliasing=True, use_gpu=False)
+    
+    def gpu_rescale(d):
+        return resize(d, output_size, order=1, anti_aliasing=True, use_gpu=True)
+    
+    return benchmark_operation(cpu_rescale, gpu_rescale, data,
+                               f"Rescale 3D ({depth}x{size}x{size}→{output_size[0]}x{output_size[1]}x{output_size[2]})",
+                               iterations, check_correctness)
+
+
+def benchmark_normalize(size, iterations=3, check_correctness=True):
+    """Benchmark percentile normalization."""
+    from linumpy.gpu.array_ops import normalize_percentile
+    
+    data = np.random.rand(size, size).astype(np.float32) * 1000
+    
+    def cpu_norm(d):
+        low, high = np.percentile(d, [1, 99])
+        return np.clip((d - low) / (high - low), 0, 1)
+    
+    def gpu_norm(d):
+        return normalize_percentile(d, p_low=1, p_high=99, use_gpu=True)
+    
+    return benchmark_operation(cpu_norm, gpu_norm, data,
+                               f"Normalize ({size}x{size})",
+                               iterations, check_correctness)
+
+def benchmark_intensity_normalization(size, iterations=3, check_correctness=True):
+    """Benchmark intensity normalization operations."""
+    from linumpy.gpu.array_ops import threshold_otsu, normalize_percentile
+    from linumpy.gpu.morphology import gaussian_filter
+
+    data = np.random.rand(size, size).astype(np.float32) * 1000
+
+    def cpu_norm(d):
+        # Simulate intensity normalization operations
+        from scipy.ndimage import gaussian_filter as scipy_gaussian
+        smoothed = scipy_gaussian(d, sigma=1.0)
+        from skimage.filters import threshold_otsu as sk_otsu
+        threshold = sk_otsu(smoothed)
+        mask = smoothed > threshold
+        low, high = np.percentile(smoothed, [1, 99])
+        normalized = np.clip((smoothed - low) / (high - low), 0, 1)
+        return normalized
+
+    def gpu_norm(d):
+        # Simulate intensity normalization operations
+        smoothed = gaussian_filter(d, sigma=1.0, use_gpu=True)
+        threshold = threshold_otsu(smoothed, use_gpu=True)
+        mask = smoothed > threshold
+        normalized = normalize_percentile(smoothed, p_low=1, p_high=99, use_gpu=True)
+        return normalized
+
+    return benchmark_operation(cpu_norm, gpu_norm, data,
+                               f"Intensity Normalization ({size}x{size})",
+                               iterations, check_correctness)
+
+def benchmark_real_data(input_path, iterations=3):
+    """Benchmark with real OME-Zarr data."""
+    from linumpy.io.zarr import read_omezarr
+    from linumpy.gpu.morphology import gaussian_filter
+    
+    print(f"\nLoading real data from: {input_path}")
+    vol, res = read_omezarr(input_path, level=0)
+    
+    # Load a manageable chunk
+    chunk_size = min(100, vol.shape[0])
+    data = np.array(vol[:chunk_size])
+    print(f"Loaded chunk shape: {data.shape}")
+    
+    results = []
+    
+    # Gaussian on real data AIP
+    aip = np.mean(data, axis=0).astype(np.float32)
+    from scipy.ndimage import gaussian_filter as scipy_gaussian
+    
+    def cpu_gauss(d):
+        return scipy_gaussian(d, sigma=2.0)
+    
+    def gpu_gauss(d):
+        return gaussian_filter(d, sigma=2.0, use_gpu=True)
+    
+    results.append(benchmark_operation(cpu_gauss, gpu_gauss, aip,
+                                       f"Real Data Gaussian {aip.shape}", iterations))
+    
+    return results
+
+
+def print_results(all_results, gpu_info_dict):
+    """Print formatted benchmark results."""
+    print("\n" + "=" * 90)
+    print("BENCHMARK RESULTS")
+    print("=" * 90)
+    print(f"Date: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+    print(f"GPU: {gpu_info_dict['device_name']}")
+    print(f"GPU Memory: {gpu_info_dict['memory_gb']:.1f} GB")
+    print(f"GPU Available: {gpu_info_dict['gpu_available']}")
+    print("=" * 90)
+    
+    print(f"\n{'Operation':<40} {'CPU (ms)':<12} {'GPU (ms)':<12} {'Speedup':<10} {'Correct':<8} {'Rel Err':<12}")
+    print("-" * 94)
+    
+    for result in all_results:
+        cpu_ms = result['cpu_mean'] * 1000
+        gpu_ms = result['gpu_mean'] * 1000 if not np.isnan(result['gpu_mean']) else float('nan')
+        speedup = result['speedup'] if not np.isnan(result['speedup']) else float('nan')
+        correct = "✓" if result.get('correct') == True else ("N/A" if result.get('correct') is None else "✗")
+        rel_err = result.get('rel_error', float('nan'))
+        
+        if np.isnan(gpu_ms):
+            print(f"{result['name']:<40} {cpu_ms:>10.2f}   {'N/A':^10}   {'N/A':^8}   {correct:^6}   {'N/A':^10}")
+        else:
+            rel_err_str = f"{rel_err:.2e}" if not np.isnan(rel_err) else "N/A"
+            print(f"{result['name']:<40} {cpu_ms:>10.2f}   {gpu_ms:>10.2f}   {speedup:>7.1f}x   {correct:^6}   {rel_err_str:>10}")
+    
+    print("-" * 94)
+    
+    # Summary statistics
+    valid_speedups = [r['speedup'] for r in all_results if not np.isnan(r['speedup'])]
+    if valid_speedups:
+        print(f"\nAverage speedup: {np.mean(valid_speedups):.1f}x")
+        print(f"Max speedup: {np.max(valid_speedups):.1f}x")
+        print(f"Min speedup: {np.min(valid_speedups):.1f}x")
+
+
+def main():
+    parser = _build_arg_parser()
+    args = parser.parse_args()
+    
+    # Handle GPU selection
+    if args.select_best_gpu:
+        from linumpy.gpu import select_best_gpu
+        select_best_gpu(verbose=True)
+        print()
+    elif args.gpu is not None:
+        from linumpy.gpu import select_gpu
+        select_gpu(args.gpu, verbose=True)
+        print()
+    
+    # Print GPU info
+    print_gpu_info()
+    info = gpu_info()
+    
+    if not info['gpu_available']:
+        print("\n⚠️  WARNING: GPU not available. Only CPU benchmarks will run.\n")
+    
+    all_results = []
+    iterations = args.iterations
+    check_correctness = not args.skip_correctness
+    
+    # Synthetic data benchmarks
+    sizes = args.sizes if args.full else [args.sizes[0]]
+    
+    print(f"\nRunning benchmarks with {iterations} iterations per test...")
+    print(f"Testing sizes: {sizes}")
+    
+    for size in sizes:
+        print(f"\n--- Size: {size}x{size} ---")
+        
+        # FFT
+        print("  Testing FFT...", end=" ", flush=True)
+        all_results.append(benchmark_fft(size, iterations, check_correctness))
+        print("done")
+        
+        # Phase correlation
+        print("  Testing Phase Correlation...", end=" ", flush=True)
+        all_results.append(benchmark_phase_correlation(size, iterations, check_correctness))
+        print("done")
+        
+        # Gaussian filter
+        print("  Testing Gaussian Filter...", end=" ", flush=True)
+        all_results.append(benchmark_gaussian_filter(size, iterations, check_correctness))
+        print("done")
+        
+        # Binary closing
+        print("  Testing Binary Closing...", end=" ", flush=True)
+        all_results.append(benchmark_binary_closing(size, iterations, check_correctness))
+        print("done")
+        
+        # Resize
+        print("  Testing Resize...", end=" ", flush=True)
+        all_results.append(benchmark_resize(size, iterations, check_correctness))
+        print("done")
+        
+        # Rescale 3D (like linum_resample_mosaic_grid_gpu)
+        print("  Testing Rescale 3D...", end=" ", flush=True)
+        all_results.append(benchmark_rescale_3d(size, iterations, check_correctness))
+        print("done")
+
+        # Normalize
+        print("  Testing Normalize...", end=" ", flush=True)
+        all_results.append(benchmark_normalize(size, iterations, check_correctness))
+        print("done")
+
+        # Intensity normalization
+        print("  Testing Intensity Normalization...", end=" ", flush=True)
+        all_results.append(benchmark_intensity_normalization(size, iterations, check_correctness))
+        print("done")
+    
+    # Real data benchmark
+    if args.input:
+        print("\n--- Real Data Benchmark ---")
+        real_results = benchmark_real_data(args.input, iterations)
+        all_results.extend(real_results)
+    
+    # Print results
+    print_results(all_results, info)
+    
+    # Save results
+    if args.output:
+        output_data = {
+            "timestamp": datetime.now().isoformat(),
+            "gpu_info": info,
+            "parameters": {
+                "iterations": iterations,
+                "sizes": sizes,
+                "input_file": args.input,
+            },
+            "results": all_results,
+        }
+        
+        with open(args.output, 'w', encoding='utf-8') as f:
+            json.dump(output_data, f, indent=2, default=str)
+        
+        print(f"\nResults saved to: {args.output}")
+    
+    # Return exit code based on GPU availability
+    sys.exit(0 if info['gpu_available'] else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/linum_create_masks_gpu.py
+++ b/scripts/linum_create_masks_gpu.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Create tissue masks from OME-Zarr images.
+
+GPU-accelerated version using linumpy.gpu module for filtering and morphology.
+Falls back to CPU if GPU is not available.
+Masks are saved with matching pyramid levels to the input image.
+"""
+# Configure thread limits before numpy/scipy imports
+import linumpy._thread_config  # noqa: F401
+
+import argparse
+
+import numpy as np
+import dask.array as da
+from scipy.ndimage import distance_transform_edt
+from skimage.morphology import remove_small_objects, local_maxima
+from skimage.measure import label
+from skimage.segmentation import watershed
+from skimage.filters import median
+from ome_zarr.io import parse_url
+from ome_zarr.reader import Reader, Multiscales
+
+from linumpy.io import read_omezarr, save_omezarr
+from linumpy.gpu import GPU_AVAILABLE, print_gpu_info
+from linumpy.gpu.array_ops import (
+    threshold_otsu,
+    compute_percentiles_memory_efficient,
+    compute_nonzero_percentile_memory_efficient
+)
+from linumpy.gpu.morphology import (
+    gaussian_filter, binary_opening, binary_closing, binary_fill_holes
+)
+
+
+def get_num_pyramid_levels(zarr_path):
+    """Get the number of pyramid levels in an OME-Zarr file."""
+    reader = Reader(parse_url(zarr_path))
+    nodes = list(reader())
+    image_node = nodes[0]
+    
+    for spec in image_node.specs:
+        if isinstance(spec, Multiscales):
+            return len(spec.datasets)
+    return 1
+
+
+def _build_arg_parser():
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter)
+    p.add_argument('image',
+                   help='Input image in .ome.zarr format to mask.')
+    p.add_argument('out_file',
+                   help='Output path for the masks in .ome.zarr format.')
+    p.add_argument('--sigma', type=float, default=5.0,
+                   help='Standard deviation for Gaussian smoothing. [%(default)s]')
+    p.add_argument('--selem_radius', type=int, default=1,
+                   help='Radius of the structuring element for morphological operations. [%(default)s]')
+    p.add_argument('--min_size', type=int, default=100,
+                   help='Minimum size of objects to keep in the final mask. [%(default)s]')
+    p.add_argument('--normalize', action='store_true',
+                   help='Normalize the image before processing.')
+    p.add_argument('--fill_holes', type=str, default='3d', choices=['none', '3d', 'slicewise'],
+                   help='Hole filling method: none (no extra filling), 3d (standard scipy fill), '
+                        'slicewise (fill in all 3 axes - best for masks with through-holes). [%(default)s]')
+    p.add_argument('--use_gpu', default=True,
+                   action=argparse.BooleanOptionalAction,
+                   help='Use GPU acceleration if available. [%(default)s]')
+    p.add_argument('--verbose', '-v', action='store_true',
+                   help='Print GPU information')
+    p.add_argument('--n_levels', type=int, default=None,
+                   help='Number of pyramid levels. If not specified, matches input image pyramid. [%(default)s]')
+    p.add_argument('--preview', type=str, default=None,
+                   help='Path to save a preview image (PNG) for visual verification.')
+    return p
+
+
+def fill_holes_slicewise(mask, use_gpu=False):
+    """
+    Fill holes in a 3D mask by applying 2D hole filling in all three axes.
+
+    Parameters
+    ----------
+    mask : np.ndarray
+        3D binary mask
+    use_gpu : bool
+        Whether to use GPU acceleration
+
+    Returns
+    -------
+    np.ndarray
+        Mask with holes filled
+    """
+    if mask.ndim != 3:
+        return binary_fill_holes(mask, use_gpu=use_gpu)
+
+    # First do 3D fill
+    mask = binary_fill_holes(mask, use_gpu=use_gpu)
+
+    # Then fill slice-by-slice in all three axes
+    # For GPU efficiency, we process on CPU for the slicewise operations
+    # as the overhead of many small GPU transfers outweighs the benefit
+    from scipy.ndimage import binary_fill_holes as scipy_fill_holes
+
+    nz, ny, nx = mask.shape
+
+    # Fill in XY planes (along Z axis)
+    for z in range(nz):
+        mask[z, :, :] = scipy_fill_holes(mask[z, :, :])
+
+    # Fill in XZ planes (along Y axis)
+    for y in range(ny):
+        mask[:, y, :] = scipy_fill_holes(mask[:, y, :])
+
+    # Fill in YZ planes (along X axis)
+    for x in range(nx):
+        mask[:, :, x] = scipy_fill_holes(mask[:, :, x])
+
+    # Final 3D fill
+    mask = binary_fill_holes(mask, use_gpu=use_gpu)
+
+    return mask
+
+
+
+def create_mask_gpu(image: np.ndarray, sigma: float = 5.0, selem_radius: int = 1,
+                    min_size: int = 100, normalize: bool = True, use_gpu: bool = True) -> np.ndarray:
+    """
+    Create a mask using GPU-accelerated operations where possible.
+    
+    This function is optimized for memory efficiency by:
+    - Using subsampling for percentile calculations
+    - Explicitly freeing GPU memory after operations
+    - Processing on CPU when GPU memory is insufficient
+
+    Parameters
+    ----------
+    image : np.ndarray
+        Input image
+    sigma : float
+        Gaussian smoothing sigma
+    selem_radius : int
+        Structuring element radius
+    min_size : int
+        Minimum object size
+    normalize : bool
+        Whether to normalize
+    use_gpu : bool
+        Whether to use GPU
+        
+    Returns
+    -------
+    np.ndarray
+        Binary mask
+    """
+    # Import cupy here to check memory and handle cleanup
+    if use_gpu and GPU_AVAILABLE:
+        import cupy as cp
+        # Clear any existing GPU memory before starting
+        cp.get_default_memory_pool().free_all_blocks()
+
+    if normalize:
+        # Memory-efficient normalization using subsampling for percentile calculation
+        image = image.copy().astype(np.float32)
+        
+        # Get percentiles using memory-efficient subsampling
+        p_low = compute_nonzero_percentile_memory_efficient(image, 0.5, use_gpu=use_gpu)
+        p_high = compute_percentiles_memory_efficient(image, [99.5], use_gpu=use_gpu)[0]
+
+        # Normalize in-place to save memory
+        image -= p_low
+        if (p_high - p_low) > 1e-10:
+            image /= (p_high - p_low)
+        np.clip(image, 0, 1, out=image)
+
+    # GPU-accelerated Gaussian smoothing
+    image = gaussian_filter(image, sigma=sigma, use_gpu=use_gpu)
+    
+    # Free GPU memory after gaussian filter
+    if use_gpu and GPU_AVAILABLE:
+        cp.get_default_memory_pool().free_all_blocks()
+
+    # Median filter (CPU - skimage version handles edge cases better)
+    image = median(image)
+
+    # GPU-accelerated threshold
+    threshold = threshold_otsu(image, use_gpu=use_gpu)
+    
+    # Create binary mask - do this on CPU to save GPU memory
+    mask = image > threshold
+    del image  # Free the image memory as we only need the mask now
+
+    if use_gpu and GPU_AVAILABLE:
+        cp.get_default_memory_pool().free_all_blocks()
+
+    # GPU-accelerated morphology
+    mask = binary_opening(mask, iterations=1, use_gpu=use_gpu)
+    if use_gpu and GPU_AVAILABLE:
+        cp.get_default_memory_pool().free_all_blocks()
+
+    mask = binary_closing(mask, iterations=1, use_gpu=use_gpu)
+    if use_gpu and GPU_AVAILABLE:
+        cp.get_default_memory_pool().free_all_blocks()
+
+    mask = binary_fill_holes(mask, use_gpu=use_gpu)
+    if use_gpu and GPU_AVAILABLE:
+        cp.get_default_memory_pool().free_all_blocks()
+
+    # Remove small objects (CPU - complex connected component analysis)
+    mask = remove_small_objects(mask, min_size=min_size)
+
+    # Distance transform and watershed (CPU - complex algorithms)
+    dist = distance_transform_edt(mask)
+    peaks = local_maxima(dist)
+    markers = label(peaks)
+    labels = watershed(-dist, markers=markers, mask=mask)
+    del dist, peaks, markers  # Free intermediate arrays
+
+    mask = labels > 0
+    del labels
+
+    mask = binary_fill_holes(mask, use_gpu=use_gpu)
+    if use_gpu and GPU_AVAILABLE:
+        cp.get_default_memory_pool().free_all_blocks()
+
+    mask = remove_small_objects(mask, min_size=min_size)
+
+    return mask
+
+
+def main():
+    parser = _build_arg_parser()
+    args = parser.parse_args()
+    
+    use_gpu = args.use_gpu and GPU_AVAILABLE
+    
+    if args.verbose:
+        print_gpu_info()
+        print(f"Using GPU: {use_gpu}")
+
+    # Load image
+    vol, res = read_omezarr(args.image, level=0)
+    vol = vol[:]
+
+    # Create mask with GPU acceleration
+    mask = create_mask_gpu(
+        vol, 
+        sigma=args.sigma, 
+        selem_radius=args.selem_radius, 
+        min_size=args.min_size,
+        normalize=args.normalize,
+        use_gpu=use_gpu
+    )
+
+    # Apply additional hole filling if requested
+    if args.fill_holes == 'slicewise':
+        print("Applying slicewise hole filling...")
+        mask = fill_holes_slicewise(mask, use_gpu=use_gpu)
+    elif args.fill_holes == '3d':
+        mask = binary_fill_holes(mask, use_gpu=use_gpu)
+    # 'none' - no additional filling
+
+    # Determine number of pyramid levels
+    if args.n_levels is not None:
+        n_levels = args.n_levels
+    else:
+        # Match the input image pyramid levels
+        n_levels = get_num_pyramid_levels(args.image) - 1  # -1 because n_levels is additional levels beyond base
+    
+    # Save mask with pyramid levels
+    save_omezarr(da.from_array(mask), args.out_file, res, n_levels=n_levels)
+
+    # Generate preview if requested
+    if args.preview:
+        from scripts.linum_create_masks import generate_mask_preview
+        generate_mask_preview(vol, mask, args.preview)
+        print(f"Preview saved: {args.preview}")
+
+    # Collect metrics using helper function
+    from linumpy.utils.metrics import collect_mask_metrics
+    collect_mask_metrics(
+        mask=mask,
+        input_vol=vol,
+        output_path=args.out_file,
+        input_path=args.image,
+        params={'sigma': args.sigma, 'selem_radius': args.selem_radius, 
+                'min_size': args.min_size, 'normalize': args.normalize,
+                'use_gpu': use_gpu, 'fill_holes': args.fill_holes}
+    )
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/linum_create_mosaic_grid_3d_gpu.py
+++ b/scripts/linum_create_mosaic_grid_3d_gpu.py
@@ -1,0 +1,412 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+Convert 3D OCT tiles to a 3D mosaic grid.
+
+GPU-accelerated version using linumpy.gpu module for:
+- Volume resampling/resizing (5-12x speedup)
+
+Note: Galvo shift detection uses CPU (no GPU benefit).
+Falls back to CPU if GPU is not available.
+"""
+
+# Configure thread limits before numpy/scipy imports
+import linumpy._thread_config  # noqa: F401
+
+import argparse
+import multiprocessing
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import numpy as np
+from tqdm.auto import tqdm
+
+from linumpy import reconstruction
+from linumpy.gpu import GPU_AVAILABLE, print_gpu_info
+from linumpy.gpu.interpolation import resize
+from linumpy.io.thorlabs import ThorOCT, PreprocessingConfig
+from linumpy.io.zarr import OmeZarrWriter
+from linumpy.microscope.oct import OCT
+from linumpy.utils.io import parse_processes_arg, add_processes_arg
+
+# Global flag for GPU usage (set in main, used in process_tile)
+_USE_GPU = True
+
+
+def _build_arg_parser():
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
+    p.add_argument("output_zarr",
+                   help="Full path to the output zarr file")
+    p.add_argument("--data_type", type=str, default='OCT', choices=['OCT', 'PSOCT'],
+                   help="Type of the data to process (default=%(default)s)")
+    input_g = p.add_argument_group("input")
+    input_mutex_g = input_g.add_mutually_exclusive_group(required=True)
+    input_mutex_g.add_argument("--from_root_directory",
+                               help="Full path to a directory containing the tiles to process.")
+    input_mutex_g.add_argument("--from_tiles_list", nargs='+',
+                               help='List of tiles to assemble (argument --slice is ignored).')
+    options_g = p.add_argument_group("other options")
+    options_g.add_argument("-r", "--resolution", type=float, default=10.0,
+                           help="Output isotropic resolution in micron per pixel. [%(default)s]")
+    options_g.add_argument("--axial_resolution", type=float, default=3.5,
+                           help='Axial resolution of the raw data in microns. [%(default)s]')
+    options_g.add_argument("-z", "--slice", type=int,
+                           help="Slice to process.")
+    options_g.add_argument("--keep_galvo_return", action="store_true",
+                           help="Keep the galvo return signal [%(default)s]")
+    options_g.add_argument('--zarr_root',
+                           help='Path to parent directory under which the zarr'
+                                ' temporary directory will be created [/tmp/].')
+    options_g.add_argument('--fix_galvo_shift', default=True,
+                           action=argparse.BooleanOptionalAction,
+                           help='Fix the galvo shift. [%(default)s]')
+    options_g.add_argument('--fix_camera_shift', default=False,
+                           action=argparse.BooleanOptionalAction,
+                           help='Fix the camera shift. [%(default)s]')
+    options_g.add_argument('--preprocess', default=False,
+                           action=argparse.BooleanOptionalAction,
+                           help='Apply preprocessing (rotate/flip) for legacy data. [%(default)s]')
+    options_g.add_argument('--galvo_threshold', type=float, default=0.6,
+                           help='Galvo detection confidence threshold. [%(default)s]')
+    options_g.add_argument('--sharding_factor', type=int, default=1,
+                           help='A sharding factor of N will result '
+                                'in N**2 tiles per shard. [%(default)s]')
+    options_g.add_argument('--use_gpu', default=True,
+                           action=argparse.BooleanOptionalAction,
+                           help='Use GPU acceleration if available. [%(default)s]')
+    options_g.add_argument('--verbose', '-v', action='store_true',
+                           help='Print GPU information')
+    add_processes_arg(options_g)
+    psoct_options_g = p.add_argument_group("PS-OCT options")
+    psoct_options_g.add_argument('--polarization', type=int, default=1, choices=[0, 1],
+                                 help="Polarization index to process")
+    psoct_options_g.add_argument('--number_of_angles', type=int, default=1,
+                                 help="Angle index to process")
+    psoct_options_g.add_argument('--angle_index', type=int, default=0,
+                                 help="Angle index to process")
+    psoct_options_g.add_argument('--return_complex', type=bool, default=False,
+                                 help="Return Complex64 or Float32 data type")
+    psoct_options_g.add_argument('--crop_first_index', type=int, default=320,
+                                 help="First index for cropping on the z axis (default=%(default)s)")
+    psoct_options_g.add_argument('--crop_second_index', type=int, default=750,
+                                 help="Second index for cropping on the z axis (default=%(default)s)")
+    return p
+
+
+def preprocess_volume(vol: np.ndarray, apply: bool = True) -> np.ndarray:
+    """Preprocess the volume by rotating and flipping it (for legacy data)."""
+    if not apply:
+        return vol
+    vol = np.rot90(vol, k=3, axes=(1, 2))
+    vol = np.flip(vol, axis=1)
+    return vol
+
+
+def load_single_tile(params: dict) -> tuple:
+    """Load a single tile from disk. Used for parallel I/O.
+    
+    Returns
+    -------
+    tuple
+        (params, volume) where volume is the loaded numpy array
+    """
+    f = params["file"]
+    crop = params["crop"]
+    galvo_shift = params["galvo_shift"]
+    fix_camera_shift = params["fix_camera_shift"]
+    preprocess = params["preprocess"]
+    data_type = params["data_type"]
+    psoct_config = params["psoct_config"]
+    
+    if data_type == 'OCT':
+        oct = OCT(f)
+        vol = oct.load_image(crop=crop, fix_galvo_shift=galvo_shift,
+                             fix_camera_shift=fix_camera_shift)
+        vol = preprocess_volume(vol, apply=preprocess)
+    elif data_type == 'PSOCT':
+        oct = ThorOCT(f, config=psoct_config)
+        if psoct_config.erase_polarization_2:
+            oct.load()
+            vol = oct.first_polarization
+        else:
+            oct.load()
+            vol = oct.second_polarization
+        vol = ThorOCT.orient_volume_psoct(vol)
+    else:
+        raise ValueError(f"Unknown data type: {data_type}")
+    
+    return (params, vol)
+
+
+def _load_shard_data(proc_params: dict) -> list:
+    """Load all tiles for a shard from disk (I/O stage of the pipeline).
+
+    For shards with multiple tiles (sharding_factor > 1) loads them in
+    parallel with a ThreadPoolExecutor; otherwise loads the single tile
+    directly to avoid threading overhead.
+
+    Returns a list of (params, volume) tuples, one per tile.
+    """
+    tiles_params = proc_params['params']
+    n_tiles = len(tiles_params)
+    if n_tiles > 1:
+        with ThreadPoolExecutor(max_workers=min(4, n_tiles)) as executor:
+            return list(executor.map(load_single_tile, tiles_params))
+    else:
+        return [load_single_tile(tiles_params[0])]
+
+
+def _resize_and_write_shard(proc_params: dict, loaded_tiles: list):
+    """GPU-resize pre-loaded tiles and write the shard to zarr (compute/write stage).
+
+    Separated from disk I/O so that _run_pipelined can overlap loading the
+    next shard with GPU work on the current one.
+    """
+    mosaic = proc_params['mosaic']
+    shard_shape = proc_params['shard_shape']
+    tiles_params = proc_params['params']
+    use_gpu = proc_params.get('use_gpu', _USE_GPU)
+
+    shard = np.zeros(shard_shape, dtype=mosaic.dtype)
+
+    mx_min = min(p["tile_pos"][0] for p in tiles_params)
+    my_min = min(p["tile_pos"][1] for p in tiles_params)
+
+    vol = None
+    for params, vol in loaded_tiles:
+        mx, my = params["tile_pos"]
+        tile_size = params["tile_size"]
+
+        tile_size_tuple = tuple(tile_size)
+        if np.iscomplexobj(vol):
+            real_resized = resize(vol.real, tile_size_tuple, order=1,
+                                  anti_aliasing=True, use_gpu=use_gpu)
+            imag_resized = resize(vol.imag, tile_size_tuple, order=1,
+                                  anti_aliasing=True, use_gpu=use_gpu)
+            vol = real_resized + 1j * imag_resized
+        else:
+            vol = resize(vol, tile_size_tuple, order=1, anti_aliasing=True, use_gpu=use_gpu)
+
+        rmin = (mx - mx_min) * vol.shape[1]
+        cmin = (my - my_min) * vol.shape[2]
+        rmax = rmin + vol.shape[1]
+        cmax = cmin + vol.shape[2]
+
+        shard[0:tile_size[0], rmin:rmax, cmin:cmax] = vol
+
+    mx_min *= vol.shape[1]
+    my_min *= vol.shape[2]
+    output_extent_x = min(shard_shape[1], mosaic.shape[1] - mx_min)
+    output_extent_y = min(shard_shape[2], mosaic.shape[2] - my_min)
+    mosaic[0:tile_size[0], mx_min:mx_min + output_extent_x, my_min:my_min + output_extent_y] = shard[
+        :, :output_extent_x, :output_extent_y]
+
+
+def _run_pipelined(params: list):
+    """Process shards with a prefetch pipeline.
+
+    A single background thread fetches the next shard's tiles from disk
+    while the main thread runs GPU resize and zarr write for the current
+    shard.  This hides most of the per-tile disk I/O latency behind GPU
+    compute and largely eliminates the three-way sequential stall of
+
+        disk read → GPU → zarr write → disk read → GPU → zarr write …
+
+    replacing it with the overlapped pattern
+
+        disk(i+1) ║ GPU+write(i)
+    """
+    if not params:
+        return
+
+    with ThreadPoolExecutor(max_workers=1) as prefetch_executor:
+        # Submit the first shard's I/O immediately so it can start before
+        # the loop begins.
+        pending_load = prefetch_executor.submit(_load_shard_data, params[0])
+
+        for i, p in enumerate(tqdm(params)):
+            # Block until current shard's tiles are in RAM.
+            loaded_tiles = pending_load.result()
+
+            # Fire off disk I/O for the next shard before doing any GPU
+            # work, so they overlap as much as possible.
+            if i + 1 < len(params):
+                pending_load = prefetch_executor.submit(_load_shard_data, params[i + 1])
+
+            # GPU resize + zarr write for the current shard.
+            # This runs concurrently with the prefetch of params[i+1].
+            _resize_and_write_shard(p, loaded_tiles)
+
+
+def process_tile_gpu(proc_params: dict):
+    """Process a shard: load tiles from disk, GPU resize, write to zarr.
+
+    This is the entry point used by the CPU multiprocessing pool.  For GPU
+    mode the pipelined path (_run_pipelined) is preferred because it
+    overlaps disk I/O with GPU work across shards.
+    """
+    loaded_tiles = _load_shard_data(proc_params)
+    _resize_and_write_shard(proc_params, loaded_tiles)
+
+
+def main():
+    global _USE_GPU
+
+    # Parse arguments
+    parser = _build_arg_parser()
+    args = parser.parse_args()
+
+    # Parameters
+    output_resolution = args.resolution
+    crop = not args.keep_galvo_return
+    fix_galvo_shift = args.fix_galvo_shift
+    fix_camera_shift = args.fix_camera_shift
+    preprocess = args.preprocess
+    galvo_threshold = args.galvo_threshold
+
+    _USE_GPU = args.use_gpu and GPU_AVAILABLE
+
+    if args.verbose:
+        print_gpu_info()
+        print(f"Using GPU: {_USE_GPU}")
+
+    data_type = args.data_type
+    angle_index = args.angle_index
+    n_cpus = parse_processes_arg(args.n_processes)
+    psoct_config = PreprocessingConfig()
+    psoct_config.crop_first_index = args.crop_first_index
+    psoct_config.crop_second_index = args.crop_second_index
+    psoct_config.erase_polarization_1 = not args.polarization == 1
+    psoct_config.erase_polarization_2 = not psoct_config.erase_polarization_1
+    psoct_config.return_complex = args.return_complex
+
+    # Analyze the tiles
+    if data_type == 'OCT':
+        if args.from_root_directory:
+            z = args.slice
+            tiles_directory = args.from_root_directory
+            tiles, tiles_pos = reconstruction.get_tiles_ids(tiles_directory, z=z)
+        else:
+            if args.slice is not None:
+                parser.error('Argument --slice is incompatible with --from_tiles_list.')
+            tiles = [Path(d) for d in args.from_tiles_list]
+            tiles_pos = reconstruction.get_tiles_ids_from_list(tiles)
+    elif data_type == 'PSOCT':
+        tiles, tiles_pos = ThorOCT.get_psoct_tiles_ids(
+            tiles_directory,
+            number_of_angles=args.number_of_angles
+        )
+        tiles = tiles[angle_index]
+
+    # Prepare the mosaic_grid
+    if data_type == 'OCT':
+        oct = OCT(tiles[0], args.axial_resolution)
+        vol = oct.load_image(crop=crop)
+        vol = preprocess_volume(vol, apply=preprocess)
+        resolution = [oct.resolution[2], oct.resolution[0], oct.resolution[1]]
+        n_extra = oct.info.get('n_extra', 0)
+    elif data_type == 'PSOCT':
+        oct = ThorOCT(tiles[0], config=psoct_config)
+        if psoct_config.erase_polarization_2:
+            oct.load()
+            vol = oct.first_polarization
+        else:
+            oct.load()
+            vol = oct.second_polarization
+        vol = ThorOCT.orient_volume_psoct(vol)
+        resolution = [oct.resolution[2], oct.resolution[0], oct.resolution[1]]
+        n_extra = 0  # PSOCT doesn't have galvo return
+    print(f"Resolution: z = {resolution[0]} , x = {resolution[1]} , y = {resolution[2]} ")
+
+    # Detect galvo shift by sampling multiple tiles
+    # galvo_shift: 0 = no fix, >0 = shift amount to apply
+    galvo_shift = 0
+    if fix_galvo_shift and data_type == 'OCT' and n_extra > 0:
+        from linumpy.preproc.xyzcorr import detect_galvo_for_slice
+        print(f"Running galvo detection on {len(tiles)} tiles with threshold={galvo_threshold}")
+        galvo_shift, confidence = detect_galvo_for_slice(
+            tiles, n_extra, threshold=galvo_threshold, axial_resolution=args.axial_resolution
+        )
+        print(f"Galvo detection result: shift={galvo_shift}, confidence={confidence:.3f}")
+        if galvo_shift > 0:
+            print(f"Galvo shift detected: shift={galvo_shift}, confidence={confidence:.3f} - will apply fix")
+        else:
+            print(f"Galvo shift not significant: confidence={confidence:.3f} - skipping fix")
+
+    # tiles position in the mosaic grid
+    pos_xy = np.asarray(tiles_pos)[:, :2]
+    pos_xy = pos_xy - np.min(pos_xy, axis=0)
+    nb_tiles_xy = np.max(pos_xy, axis=0) + 1
+
+    # Compute the rescaled tile size based on
+    # the minimum target output resolution
+    if output_resolution == -1:
+        tile_size = vol.shape
+        output_resolution = resolution
+    else:
+        tile_size = [int(vol.shape[i] * resolution[i] * 1000 / output_resolution) for i in range(3)]
+        output_resolution = [output_resolution / 1000.0] * 3
+    mosaic_shape = [tile_size[0], nb_tiles_xy[0] * tile_size[1], nb_tiles_xy[1] * tile_size[2]]
+
+    # sharding will lower the number of files stored on disk but increase
+    # RAM usage for writing the data (an entire shard must fit in memory)
+    shards = (tile_size[0],
+              args.sharding_factor * tile_size[1],
+              args.sharding_factor * tile_size[2])
+    nb_shards_xy = np.ceil(nb_tiles_xy / float(args.sharding_factor)).astype(int)
+
+    # Create the zarr writer
+    writer = OmeZarrWriter(args.output_zarr, shape=mosaic_shape,
+                           dtype=np.complex64 if args.return_complex else np.float32,
+                           chunk_shape=tile_size, shards=shards, overwrite=True)
+
+    # Create a params dictionary for every tile
+    params_grid = np.full((nb_shards_xy[0], nb_shards_xy[1]), None, dtype=object)
+    for i in range(len(tiles)):
+        shard_pos = (pos_xy[i] / args.sharding_factor).astype(int)
+
+        if params_grid[shard_pos[0], shard_pos[1]] is None:
+            params_grid[shard_pos[0], shard_pos[1]] = {
+                'params': [],
+                'mosaic': writer,
+                'shard_shape': shards if shards is not None else tile_size,
+                'use_gpu': _USE_GPU,
+            }
+
+        params_grid[shard_pos[0], shard_pos[1]]['params'].append({
+            "file": tiles[i],
+            "tile_pos": pos_xy[i],
+            "crop": crop,
+            "galvo_shift": galvo_shift,
+            "fix_camera_shift": fix_camera_shift,
+            "preprocess": preprocess,
+            "tile_size": tile_size,
+            "data_type": data_type,
+            "psoct_config": psoct_config,
+        })
+
+    # each item in params is a dictionary
+    params = [params_grid[i, j]
+              for i in range(nb_shards_xy[0])
+              for j in range(nb_shards_xy[1])
+              if params_grid[i, j] is not None]
+
+    if n_cpus > 1 and not _USE_GPU:
+        # CPU parallel processing
+        from linumpy._thread_config import worker_initializer
+        with multiprocessing.Pool(n_cpus, initializer=worker_initializer) as pool:
+            results = tqdm(pool.imap(process_tile_gpu, params), total=len(params))
+            tuple(results)
+    else:
+        # GPU mode: pipeline disk I/O with GPU compute + zarr write so that
+        # reading the next shard from disk overlaps with GPU work on the current one.
+        _run_pipelined(params)
+
+    # Convert to ome-zarr
+    writer.finalize(output_resolution, 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/linum_estimate_transform_gpu.py
+++ b/scripts/linum_estimate_transform_gpu.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+Estimate the affine transform used to compute tile positions in a 2D mosaic grid.
+
+GPU-accelerated version using linumpy.gpu module for phase correlation.
+Falls back to CPU if GPU is not available.
+
+Two modes are available:
+1. Registration-based (default): Uses phase correlation to find optimal tile positions
+2. Motor-position-based (--use_motor_positions): Uses expected tile spacing based on
+   overlap fraction, corresponding to precise motor/stage positions from acquisition
+"""
+
+# Configure thread limits before numpy/scipy imports
+import linumpy._thread_config  # noqa: F401
+
+import argparse
+import logging
+import random
+from pathlib import Path
+
+import SimpleITK as sitk
+import numpy as np
+import zarr
+from skimage.exposure import match_histograms
+from skimage.filters import threshold_otsu
+
+from linumpy.gpu import GPU_AVAILABLE, print_gpu_info
+from linumpy.gpu.fft_ops import phase_correlation
+from linumpy.io.zarr import read_omezarr
+from linumpy.utils import mosaic_grid
+
+# Configure all libraries (especially SimpleITK) to respect thread limits
+from linumpy._thread_config import configure_all_libraries
+configure_all_libraries()
+
+logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
+logger = logging.getLogger(__name__)
+
+
+def _build_arg_parser():
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
+    p.add_argument("input_images", nargs="+",
+                   help="Full path to a 2D mosaic grid image.")
+    p.add_argument("output_transform",
+                   help="Output affine transform filename (must be a npy)")
+    p.add_argument("--initial_overlap", type=float, default=0.2,
+                   help="Initial/expected overlap fraction between 0 and 1. (default=%(default)s)")
+    p.add_argument("-t", "--tile_shape", nargs="+", type=int, default=400,
+                   help="Tile shape in pixel. You can provide both the row and col shape if different. Additional "
+                        "shapes will be ignored. Note that this will be ignored if a zarr is provided. The zarr chunks will be used instead. (default=%(default)s)")
+    p.add_argument("--maximum_empty_fraction", type=float, default=0.9,
+                   help="Maximum empty pixel fraction within an overlap to tolerate (default=%(default)s)")
+    p.add_argument("--n_samples", type=int, default=512,
+                   help="Maximum number of tile pairs to use for the optimization. (default=%(default)s)")
+    p.add_argument("--seed", type=int,
+                   help="Seed value for the random number generator")
+    p.add_argument('--use_gpu', default=True,
+                   action=argparse.BooleanOptionalAction,
+                   help='Use GPU acceleration if available. [%(default)s]')
+    p.add_argument('--verbose', '-v', action='store_true',
+                   help='Print GPU information')
+
+    # Motor position mode
+    p.add_argument("--use_motor_positions", action="store_true",
+                   help="Use motor positions (expected tile spacing) instead of image registration.\n"
+                        "This creates a transform based purely on the overlap fraction,\n"
+                        "corresponding to the precise motor/stage positions from acquisition.\n"
+                        "Recommended when motor positions are reliable.")
+    return p
+
+
+def compute_motor_transform(tile_shape, overlap_fraction):
+    """
+    Compute the transform matrix for motor-based tile positions.
+    """
+    tile_size_y = tile_shape[0]  # rows (height)
+    tile_size_x = tile_shape[1]  # cols (width)
+
+    step_y = tile_size_y * (1.0 - overlap_fraction)
+    step_x = tile_size_x * (1.0 - overlap_fraction)
+
+    transform = np.array([
+        [step_y, 0],
+        [0, step_x]
+    ])
+
+    return transform
+
+
+def main():
+    # Parse arguments
+    p = _build_arg_parser()
+    args = p.parse_args()
+
+    # Parameters
+    input_images = args.input_images
+    if isinstance(input_images, str):
+        input_images = [input_images]
+    output_transform = Path(args.output_transform)
+    max_empty_fraction = args.maximum_empty_fraction
+    use_gpu = args.use_gpu and GPU_AVAILABLE
+
+    if args.verbose:
+        print_gpu_info()
+        print(f"Using GPU: {use_gpu}")
+
+    # Compute the tile shape
+    tile_shape = args.tile_shape
+    if isinstance(tile_shape, int):
+        tile_shape = [tile_shape] * 2
+    elif len(tile_shape) == 1:
+        tile_shape = [tile_shape[0]] * 2
+    elif len(tile_shape) > 2:
+        tile_shape = tile_shape[0:2]
+
+    if input_images[0].rstrip('/').endswith('.ome.zarr'):
+        img, _ = read_omezarr(input_images[0], level=0)
+        tile_shape = list(img.chunks[-2:])  # Get last 2 dimensions (Y, X)
+    elif input_images[0].rstrip('/').endswith(".zarr"):
+        img = zarr.open(input_images[0], mode="r")
+        tile_shape = list(img.chunks[-2:])
+
+    # Check the output filename extensions
+    assert output_transform.name.endswith(".npy"), "output_transform must be a .npy file"
+
+    if args.use_motor_positions:
+        # Motor-position mode: compute transform from expected overlap
+        logger.info(f"Using motor positions with {args.initial_overlap*100:.1f}% overlap")
+        logger.info(f"Tile shape: {tile_shape}")
+
+        transform = compute_motor_transform(tile_shape, args.initial_overlap)
+        residuals = np.array([0.0])
+        tile_count = 0
+
+        logger.info(f"Motor-based transform:")
+        logger.info(f"  Step Y: {transform[0, 0]:.1f} px")
+        logger.info(f"  Step X: {transform[1, 1]:.1f} px")
+
+    else:
+        # Registration mode: use phase correlation
+        logger.info(f"Using image-based registration (GPU: {use_gpu})")
+
+        # Load all input images
+        mosaics = []
+        thresholds = []
+        for file in input_images:
+            if file.rstrip('/').endswith(".ome.zarr"):
+                img, _ = read_omezarr(str(file), level=0)
+                image = img[:]
+            elif file.rstrip('/').endswith(".zarr"):
+                img = zarr.open(str(file), mode="r")
+                image = img[:]
+            else:
+                image = sitk.GetArrayFromImage(sitk.ReadImage(str(file)))
+            mosaic = mosaic_grid.MosaicGrid(image, tile_shape=tile_shape, overlap_fraction=args.initial_overlap)
+            mosaics.append(mosaic)
+
+            # Compute an intensity threshold
+            thresholds.append(threshold_otsu(mosaic.image))
+
+        # Perform registration for all nonempty overlaps
+        rows = []
+        rows_px = []
+        cols = []
+        cols_px = []
+        tile_count = 0
+
+        # Loop over mosaics (random order)
+        if args.seed is not None:
+            random.seed = args.seed
+        mosaic_idx = list(range(len(mosaics)))
+        random.shuffle(mosaic_idx)
+
+        for m_id in mosaic_idx:
+            mosaic = mosaics[m_id]
+            thresh = thresholds[m_id]
+
+            # Loop over tiles
+            for i in range(mosaic.n_tiles_x):
+                for j in range(mosaic.n_tiles_y):
+                    # Stop if max tile count is reached
+                    if tile_count > args.n_samples:
+                        break
+
+                    # Loop over neighborhood tiles
+                    neighbors, tiles = mosaic.get_neighbors_around_tile(i, j)
+                    for n, t in zip(neighbors, tiles):
+                        r = t[0] - i
+                        c = t[1] - j
+
+                        # Extract overlap
+                        o1, o2, p1, p2 = mosaic.get_neighbor_overlap_from_pos((i, j), t)
+
+                        # Check if one of the overlap is empty
+                        o1_empty = np.sum(o1 <= thresh) > max_empty_fraction * o1.size
+                        o2_empty = np.sum(o2 <= thresh) > max_empty_fraction * o2.size
+                        if o1_empty or o2_empty:
+                            continue
+
+                        # Match histogram
+                        o2 = match_histograms(o2, o1)
+
+                        # GPU-accelerated phase correlation
+                        result = phase_correlation(o1, o2, use_gpu=use_gpu)
+                        if isinstance(result, tuple):
+                            (dx, dy), _ = result
+                        else:
+                            dx, dy = result
+
+                        # Compute the tile position
+                        if r == -1:
+                            r_px = p1[2] - mosaic.tile_size_x + dx
+                        else:
+                            r_px = p1[0] + dx
+                        if c == -1:
+                            c_px = p1[3] - mosaic.tile_size_y + dy
+                        else:
+                            c_px = p1[1] + dy
+
+                        # Updating the rows/cols and rows_px/cols_px
+                        rows.append(r)
+                        cols.append(c)
+                        rows_px.append(r_px)
+                        cols_px.append(c_px)
+
+                        # Count the number of tiles used
+                        tile_count += 1
+
+        # Estimate the transform matrix from this analysis
+        a = np.zeros((len(rows) * 2, 4))
+        b = np.zeros((len(rows) * 2, 1))
+        for i in range(len(rows)):
+            a[2 * i, :] = [rows[i], cols[i], 0, 0]
+            b[2 * i, 0] = rows_px[i]
+            a[2 * i + 1, :] = [0, 0, rows[i], cols[i]]
+            b[2 * i + 1, 0] = cols_px[i]
+
+        # Solve this
+        result = np.linalg.lstsq(a, b, rcond=None)
+        transform = result[0].reshape((2, 2))
+        residuals = result[1] if len(result[1]) > 0 else np.array([0.0])
+
+        logger.info(f"Registration-based transform (from {tile_count} tile pairs):")
+        logger.info(f"  Step Y: {transform[0, 0]:.1f} px (expected: {tile_shape[0] * (1 - args.initial_overlap):.1f})")
+        logger.info(f"  Step X: {transform[1, 1]:.1f} px (expected: {tile_shape[1] * (1 - args.initial_overlap):.1f})")
+
+        # Compare with expected motor positions
+        expected_step_y = tile_shape[0] * (1 - args.initial_overlap)
+        expected_step_x = tile_shape[1] * (1 - args.initial_overlap)
+        diff_y = (transform[0, 0] - expected_step_y) / expected_step_y * 100
+        diff_x = (transform[1, 1] - expected_step_x) / expected_step_x * 100
+
+        if abs(diff_y) > 1 or abs(diff_x) > 1:
+            logger.warning(f"Registration differs from motor positions by Y={diff_y:.1f}%, X={diff_x:.1f}%")
+            logger.warning("Consider using --use_motor_positions if motor positions are reliable")
+
+    # Save the transform
+    output_transform.parent.mkdir(exist_ok=True, parents=True)
+    np.save(str(output_transform), transform)
+    logger.info(f"Transform saved to {output_transform}")
+
+    # Collect metrics using helper function
+    from linumpy.utils.metrics import collect_xy_transform_metrics
+    collect_xy_transform_metrics(
+        transform=transform,
+        tile_pairs_used=tile_count,
+        tile_shape=tuple(tile_shape),
+        residuals=residuals,
+        output_path=output_transform,
+        input_paths=input_images,
+        params={
+            'initial_overlap': args.initial_overlap,
+            'use_gpu': use_gpu,
+            'use_motor_positions': args.use_motor_positions
+        }
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/linum_fix_illumination_3d_gpu.py
+++ b/scripts/linum_fix_illumination_3d_gpu.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Detect and fix the lateral illumination inhomogeneities for each
+3D tiles of a mosaic grid.
+GPU-accelerated version using JAX/CUDA for BaSiCPy.
+For CPU-only processing, use linum_fix_illumination_3d.py
+"""
+# Configure thread limits before numpy/scipy imports
+import linumpy._thread_config  # noqa: F401
+import os
+import ctypes
+import site
+# When using multiprocessing with pqdm, we need to limit threads per worker
+# to prevent thread oversubscription. The number of threads per worker should be
+# calculated based on total CPUs and number of parallel processes.
+# This is set dynamically in main() after parsing arguments.
+# For now, we preserve any existing OMP_NUM_THREADS setting from Nextflow,
+# or default to 1 for safety when multiprocessing.
+if 'OMP_NUM_THREADS' not in os.environ:
+    os.environ["OMP_NUM_THREADS"] = "1"
+# Configure JAX/XLA thread limits for BaSiCPy
+# Must be set BEFORE importing jax/basicpy
+if 'XLA_FLAGS' not in os.environ:
+    omp_threads = os.environ.get('OMP_NUM_THREADS', '1')
+    os.environ['XLA_FLAGS'] = f'--xla_cpu_multi_thread_eigen=false intra_op_parallelism_threads={omp_threads}'
+if 'OMP_NUM_THREADS' not in os.environ:
+    os.environ["OMP_NUM_THREADS"] = "1"
+def _preload_cuda_libraries():
+    """Preload CUDA libraries before JAX import for GPU acceleration.
+    JAX 0.4.23 requires specific library versions from nvidia-xxx-cu12 packages.
+    These must be loaded via ctypes BEFORE JAX is imported so the symbols are
+    available when XLA initializes.
+    """
+    # Get site-packages paths
+    sp_paths = site.getsitepackages()
+    ld_path = os.environ.get('LD_LIBRARY_PATH', '')
+    # Build list of CUDA library search paths (pip packages + LD_LIBRARY_PATH)
+    search_paths = []
+    for sp in sp_paths:
+        for lib_dir in ['nvidia/cublas/lib', 'nvidia/cuda_runtime/lib',
+                        'nvidia/cusolver/lib', 'nvidia/cusparse/lib',
+                        'nvidia/cufft/lib', 'nvidia/cudnn/lib',
+                        'nvidia/nvjitlink/lib']:
+            path = os.path.join(sp, lib_dir)
+            if os.path.isdir(path):
+                search_paths.append(path)
+    search_paths.extend(ld_path.split(':'))
+    # Libraries to preload (order matters - dependencies first)
+    # These are the .so versions from pinned nvidia-xxx-cu12 packages
+    libs = [
+        'libcudart.so.12',
+        'libcublas.so.12',
+        'libcublasLt.so.12',
+        'libcusolver.so.11',  # JAX 0.4.23 needs .so.11
+        'libcusparse.so.12',
+        'libcufft.so.11',     # JAX 0.4.23 needs .so.11
+    ]
+    loaded = []
+    for lib in libs:
+        for path in search_paths:
+            lib_path = os.path.join(path, lib)
+            if os.path.exists(lib_path):
+                try:
+                    ctypes.CDLL(lib_path, mode=ctypes.RTLD_GLOBAL)
+                    loaded.append(lib)
+                except Exception:
+                    pass
+                break
+    if loaded:
+        # Update LD_LIBRARY_PATH so child processes can find libraries too
+        new_paths = ':'.join(search_paths)
+        if ld_path:
+            os.environ['LD_LIBRARY_PATH'] = f'{new_paths}:{ld_path}'
+        else:
+            os.environ['LD_LIBRARY_PATH'] = new_paths
+        return True
+    return False
+# Preload CUDA libraries BEFORE importing JAX/basicpy
+_cuda_available = _preload_cuda_libraries()
+if not _cuda_available:
+    print("Warning: CUDA libraries not found, JAX will use CPU fallback")
+import argparse
+import tempfile
+from pathlib import Path
+from basicpy import BaSiC
+import dask.array as da
+import zarr
+from tqdm.auto import tqdm
+import imageio as io
+import numpy as np
+from linumpy.io.zarr import save_omezarr, read_omezarr, create_tempstore
+from linumpy.utils.io import add_processes_arg, parse_processes_arg
+# TODO: add option to export the flatfields and darkfields
+def _build_arg_parser():
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
+    p.add_argument("input_zarr",
+                   help="Full path to the input zarr file")
+    p.add_argument("output_zarr",
+                   help="Full path to the output zarr file")
+    p.add_argument("--max_iterations", type=int, default=500,
+                   help='Maximum number of iterations for BaSiC. [%(default)s]')
+    p.add_argument("--percentile_max", type=float,
+                   help="Values above this percentile will be clipped when\n"
+                        "estimating the flatfield (inside range [0-100]).")
+    add_processes_arg(p)
+    return p
+def process_tile(params: dict):
+    """Process a tile and add it to the output mosaic.
+
+    GPU version processes tiles sequentially in the main process.
+    """
+    file = params["slice_file"]
+    z = params["z"]
+    tile_shape = params["tile_shape"]
+    max_iterations = params["max_iterations"]
+    p_upper = params["p_upper"]
+    vol = io.v3.imread(str(file))
+    file_output = Path(file).parent / file.name.replace(".tiff", "_corrected.tiff")
+    # Get the number of tiles
+    nx = vol.shape[0] // tile_shape[0]
+    ny = vol.shape[1] // tile_shape[1]
+    # Extract the tiles for this slice
+    tiles = []
+    for i in range(nx):
+        for j in range(ny):
+            rmin = i * tile_shape[0]
+            rmax = (i + 1) * tile_shape[0]
+            cmin = j * tile_shape[1]
+            cmax = (j + 1) * tile_shape[1]
+            tiles.append(vol[rmin:rmax, cmin:cmax])
+    # Estimate the illumination bias
+    tiles_for_fit = np.asarray(tiles)
+    if np.iscomplexobj(tiles[0]):  # if input is complex, take amplitude of signal
+        tiles_for_fit = np.abs(tiles_for_fit).astype(np.float64)
+    if p_upper is not None:
+        tiles_for_fit = np.clip(tiles_for_fit, None, p_upper)
+    optimizer = BaSiC(get_darkfield=False, max_iterations=max_iterations)
+    optimizer.fit(tiles_for_fit)
+    # apply correction to tiles
+    try:
+        # Check if tiles contain complex values
+        # TODO: Hasn't been validated for complex input since basicpy has replaced pybasic
+        if np.iscomplexobj(tiles[0]):
+            # Separate real and imaginary parts
+            tiles_real = [t.real for t in tiles]
+            tiles_imag = [t.imag for t in tiles]
+            # Store the original signs before applying BaSic as it requires positive values
+            sign_real = [np.sign(t) for t in tiles_real]
+            sign_imag = [np.sign(t) for t in tiles_imag]
+            # Run BaSiC
+            tiles_real_corr = optimizer.transform(np.asarray(tiles_real))
+            tiles_imag_corr = optimizer.transform(np.asarray(tiles_imag))
+            # Apply correction and reconstruct complex result with original signs
+            tiles_corrected = [
+                (t_real * s_real) + 1j * (t_imag * s_imag)
+                for t_real, t_imag, s_real, s_imag in zip(
+                    tiles_real_corr, tiles_imag_corr, sign_real, sign_imag)
+            ]
+        else:
+            # Process normally if tiles are real
+            # Apply correction to original (not clipped) tiles
+            tiles_corrected = optimizer.transform(np.asarray(tiles))
+    except RuntimeError:
+        print(f'Got runtime error at z={z}')
+        tiles_corrected = np.asarray(tiles)
+    # Fill the output mosaic
+    vol_output = np.zeros_like(vol)
+    for i in range(nx):
+        for j in range(ny):
+            rmin = i * tile_shape[0]
+            rmax = (i + 1) * tile_shape[0]
+            cmin = j * tile_shape[1]
+            cmax = (j + 1) * tile_shape[1]
+            t = tiles_corrected[i * ny + j]
+            if np.isnan(t).any():
+                print(f"NaN values found in tile {i}, {j} at z={z}. Replacing with zeros.")
+                t = np.nan_to_num(t, nan=0.0, posinf=0.0, neginf=0.0)
+            vol_output[rmin:rmax, cmin:cmax] = t
+    io.imsave(str(file_output), vol_output)
+    return z, file_output
+def main():
+    # Parse arguments
+    p = _build_arg_parser()
+    args = p.parse_args()
+    # Parameters
+    input_zarr = Path(args.input_zarr)
+    output_zarr = Path(args.output_zarr)
+    n_cpus = parse_processes_arg(args.n_processes)
+    # Log GPU status
+    try:
+        import jax
+        devices = jax.devices()
+        has_gpu = any('cuda' in str(d).lower() for d in devices)
+        if has_gpu:
+            print(f"JAX GPU acceleration enabled: {devices}")
+        else:
+            print(f"JAX running on CPU: {devices}")
+    except Exception as e:
+        print(f"JAX device check failed: {e}")
+    # Prepare the data for the parallel processing
+    vol, resolution = read_omezarr(input_zarr, level=0)
+    p_upper = None
+    if args.percentile_max is not None:
+        p_upper = np.percentile(vol[:], args.percentile_max)
+    n_slices = vol.shape[0]
+    tmp_dir = tempfile.TemporaryDirectory(
+        suffix="_linum_fix_illumination_3d_slices", dir=output_zarr.parent)
+    params_list = []
+    for z in tqdm(range(n_slices), "Preprocessing slices"):
+        slice_file = Path(tmp_dir.name) / f"slice_{z:03d}.tiff"
+        img = vol[z]
+        io.imsave(str(slice_file), img)
+        params = {
+            "z": z,
+            "slice_file": slice_file,
+            "tile_shape": vol.chunks[1:],
+            "max_iterations": args.max_iterations,
+            "p_upper": p_upper
+        }
+        params_list.append(params)
+    if n_cpus > 1:
+        # GPU version: Process sequentially - CUDA contexts don't work with multiprocessing
+        # The GPU speedup comes from JAX running on GPU, not from multiple processes
+        print(f"Note: GPU mode uses sequential processing (ignoring n_processes={n_cpus})")
+
+    # Process tiles sequentially
+    corrected_files = []
+    for param in tqdm(params_list, desc="Processing tiles"):
+        corrected_files.append(process_tile(param))
+    # Retrieve the results and fix the volume
+    temp_store = create_tempstore(suffix=".zarr")
+    vol_output = zarr.open(temp_store, mode="w", shape=vol.shape,
+                           dtype=vol.dtype, chunks=vol.chunks)
+    # TODO: Rebuilding volume step could be faster
+    for z, f in tqdm(corrected_files, "Rebuilding volume"):
+        slice_vol = io.v3.imread(str(f))
+        vol_output[z] = slice_vol[:]
+    out_dask = da.from_zarr(vol_output)
+    min_value = out_dask.min().compute()
+    if min_value < 0:
+        print(f"Minimum value in the output volume is {min_value}. Clipping at 0.")
+        out_dask = da.clip(out_dask, 0., None)
+    save_omezarr(out_dask, output_zarr, voxel_size=resolution,
+                 chunks=vol.chunks)
+    # Remove the temporary slice files used by the parallel processes
+    tmp_dir.cleanup()
+if __name__ == "__main__":
+    main()

--- a/scripts/linum_generate_mosaic_aips_gpu.py
+++ b/scripts/linum_generate_mosaic_aips_gpu.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Generate Average Intensity Projection (AIP) PNG previews from mosaic grid OME-Zarr files.
+
+GPU-accelerated version using CuPy for the tile averaging computation.
+Falls back to CPU if GPU is not available.
+
+Spatial resolution is preserved: each data pixel maps to exactly one output pixel.
+
+Example usage:
+    # Process all mosaic grids in a directory (GPU)
+    linum_generate_mosaic_aips_gpu.py /path/to/mosaics /path/to/aips
+
+    # Force CPU fallback
+    linum_generate_mosaic_aips_gpu.py /path/to/mosaics /path/to/aips --no-use_gpu
+
+    # Use a downsampled pyramid level for faster processing
+    linum_generate_mosaic_aips_gpu.py /path/to/mosaics /path/to/aips --level 1
+"""
+# Configure thread limits before numpy/scipy imports
+import linumpy._thread_config  # noqa: F401
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+from skimage.io import imsave
+from tqdm.auto import tqdm
+
+from linumpy.gpu import GPU_AVAILABLE, to_cpu, print_gpu_info
+from linumpy.io.zarr import read_omezarr
+
+
+def compute_aip_gpu(vol, use_gpu: bool = True) -> np.ndarray:
+    """Compute the AIP of a mosaic grid volume tile-by-tile.
+
+    Parameters
+    ----------
+    vol:
+        Dask array of shape (Z, X, Y) from read_omezarr.
+    use_gpu:
+        Whether to use GPU acceleration for the averaging.
+
+    Returns
+    -------
+    np.ndarray
+        2D float32 AIP array of shape (X, Y).
+    """
+    tile_shape = vol.chunks
+    nx = vol.shape[1] // tile_shape[1]
+    ny = vol.shape[2] // tile_shape[2]
+
+    aip = np.empty((vol.shape[1], vol.shape[2]), dtype=np.float32)
+
+    for i in range(nx):
+        for j in range(ny):
+            rmin = i * tile_shape[1]
+            rmax = (i + 1) * tile_shape[1]
+            cmin = j * tile_shape[2]
+            cmax = (j + 1) * tile_shape[2]
+
+            tile = np.asarray(vol[:, rmin:rmax, cmin:cmax])
+
+            if use_gpu:
+                import cupy as cp
+                tile_gpu = cp.asarray(tile.astype(np.float32))
+                aip[rmin:rmax, cmin:cmax] = to_cpu(cp.mean(tile_gpu, axis=0))
+                del tile_gpu
+            else:
+                aip[rmin:rmax, cmin:cmax] = tile.mean(axis=0)
+
+    if use_gpu:
+        try:
+            import cupy as cp
+            cp.get_default_memory_pool().free_all_blocks()
+        except Exception:
+            pass
+
+    return aip
+
+
+def save_aip_png(aip: np.ndarray, output_path: Path) -> None:
+    """Normalize and save an AIP array as a 16-bit PNG.
+
+    Intensities are clipped to the 0.1–99.9 percentile range and mapped
+    to the full uint16 range. Spatial resolution is preserved: each data
+    pixel maps to exactly one output pixel.
+
+    Parameters
+    ----------
+    aip:
+        2D float32 array.
+    output_path:
+        Destination PNG file path.
+    """
+    vmin = np.percentile(aip, 0.1)
+    vmax = np.percentile(aip, 99.9)
+    if vmax > vmin:
+        aip_norm = np.clip((aip - vmin) / (vmax - vmin), 0, 1)
+    else:
+        aip_norm = np.zeros_like(aip)
+    imsave(output_path, (aip_norm * 65535).astype(np.uint16))
+
+
+def _build_arg_parser():
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
+    p.add_argument("input",
+                   help="Input directory containing mosaic grid OME-Zarr files\n"
+                        "(mosaic_grid_3d_z*.ome.zarr).")
+    p.add_argument("output",
+                   help="Output directory where AIP PNG files will be saved.")
+    p.add_argument("--level", type=int, default=0,
+                   help="Pyramid level of the input mosaic grids to use.\n"
+                        "Higher levels are downsampled and faster to process.\n"
+                        "Default: 0 (full resolution)")
+
+    gpu_group = p.add_argument_group("GPU Options")
+    gpu_group.add_argument("--use_gpu", default=True,
+                           action=argparse.BooleanOptionalAction,
+                           help="Use GPU acceleration if available. [%(default)s]")
+    gpu_group.add_argument("--gpu_id", type=int, default=0,
+                           help="GPU device ID to use. Default: 0")
+    gpu_group.add_argument("--verbose", "-v", action="store_true",
+                           help="Print GPU information.")
+    return p
+
+
+def main():
+    p = _build_arg_parser()
+    args = p.parse_args()
+
+    input_dir = Path(args.input)
+    output_dir = Path(args.output)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    use_gpu = args.use_gpu and GPU_AVAILABLE
+
+    if args.verbose:
+        print_gpu_info()
+
+    if args.use_gpu and not GPU_AVAILABLE:
+        print("WARNING: GPU requested but not available, falling back to CPU")
+    elif use_gpu:
+        print("GPU: ENABLED")
+        try:
+            import cupy as cp
+            cp.cuda.Device(args.gpu_id).use()
+            device = cp.cuda.Device(args.gpu_id)
+            mem_info = device.mem_info
+            print(f"  Device: {args.gpu_id} - {cp.cuda.runtime.getDeviceProperties(args.gpu_id)['name'].decode()}")
+            print(f"  Memory: {mem_info[1] / 1e9:.1f} GB total, {mem_info[0] / 1e9:.1f} GB free")
+        except Exception as e:
+            print(f"  Warning: Could not select GPU {args.gpu_id}: {e}. Using default.")
+    else:
+        print("GPU: DISABLED (using CPU)")
+
+    mosaic_files = sorted(input_dir.glob("mosaic_grid_3d_z*.ome.zarr"))
+    if not mosaic_files:
+        raise FileNotFoundError(
+            f"No mosaic grid files found in {input_dir}.\n"
+            "Expected files matching 'mosaic_grid_3d_z*.ome.zarr'.")
+
+    for mosaic_file in tqdm(mosaic_files, desc="Generating AIPs"):
+        slice_id = mosaic_file.name[len("mosaic_grid_3d_z"):-len(".ome.zarr")]
+        output_file = output_dir / f"aip_z{slice_id}.png"
+        vol, _ = read_omezarr(mosaic_file, level=args.level)
+        aip = compute_aip_gpu(vol, use_gpu=use_gpu)
+        save_aip_png(aip, output_file)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/linum_gpu_info.py
+++ b/scripts/linum_gpu_info.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Print GPU availability and configuration information for linumpy.
+
+This script checks if GPU acceleration is available and prints
+diagnostic information useful for troubleshooting.
+
+Examples:
+    # Show basic GPU info
+    linum_gpu_info.py
+    
+    # Show detailed status of all GPUs with memory usage
+    linum_gpu_info.py --status
+    
+    # List all available GPUs
+    linum_gpu_info.py --list
+    
+    # Select GPU with most free memory (for multi-GPU systems)
+    linum_gpu_info.py --select-best
+    
+    # Select specific GPU by ID
+    linum_gpu_info.py --select 1
+    
+    # Run quick performance test
+    linum_gpu_info.py --test
+    
+    # Output as JSON (useful for scripting)
+    linum_gpu_info.py --json
+"""
+
+# Configure thread limits before numpy/scipy imports
+import linumpy._thread_config  # noqa: F401
+
+import argparse
+import sys
+
+
+def _build_arg_parser():
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
+    p.add_argument("--json", action="store_true",
+                   help="Output as JSON")
+    p.add_argument("--test", action="store_true",
+                   help="Run a quick GPU test")
+    p.add_argument("--status", action="store_true",
+                   help="Show detailed status of all GPUs")
+    p.add_argument("--list", action="store_true",
+                   help="List all available GPUs")
+    p.add_argument("--select-best", action="store_true",
+                   help="Select GPU with most free memory")
+    p.add_argument("--select", type=int, metavar="ID",
+                   help="Select specific GPU by ID")
+    return p
+
+
+def run_gpu_test():
+    """Run a quick GPU performance test."""
+    import time
+    import numpy as np
+    
+    print("\n" + "=" * 50)
+    print("GPU Performance Test")
+    print("=" * 50)
+    
+    # Test data
+    size = 2048
+    data = np.random.rand(size, size).astype(np.float32)
+    
+    # CPU FFT
+    start = time.time()
+    for _ in range(10):
+        _ = np.fft.fft2(data)
+    cpu_time = (time.time() - start) / 10
+    print(f"CPU FFT ({size}x{size}): {cpu_time*1000:.2f} ms")
+    
+    # GPU FFT
+    try:
+        import cupy as cp
+        
+        data_gpu = cp.asarray(data)
+        
+        # Warmup
+        _ = cp.fft.fft2(data_gpu)
+        cp.cuda.Stream.null.synchronize()
+        
+        start = time.time()
+        for _ in range(10):
+            _ = cp.fft.fft2(data_gpu)
+        cp.cuda.Stream.null.synchronize()
+        gpu_time = (time.time() - start) / 10
+        
+        print(f"GPU FFT ({size}x{size}): {gpu_time*1000:.2f} ms")
+        print(f"Speedup: {cpu_time/gpu_time:.1f}x")
+        
+    except Exception as e:
+        print(f"GPU test failed: {e}")
+    
+    print("=" * 50)
+
+
+def main():
+    parser = _build_arg_parser()
+    args = parser.parse_args()
+    
+    from linumpy.gpu import (
+        gpu_info, print_gpu_info, print_gpu_status,
+        list_gpus, select_best_gpu, select_gpu
+    )
+    
+    # Handle GPU selection first
+    if args.select_best:
+        select_best_gpu(verbose=True)
+        print()
+    elif args.select is not None:
+        select_gpu(args.select, verbose=True)
+        print()
+    
+    # Handle output modes
+    if args.json:
+        import json
+        info = gpu_info()
+        info['all_gpus'] = list_gpus()
+        print(json.dumps(info, indent=2))
+    elif args.status:
+        print_gpu_status()
+    elif args.list:
+        gpus = list_gpus()
+        if gpus:
+            print(f"Found {len(gpus)} GPU(s):\n")
+            for gpu in gpus:
+                print(f"  GPU {gpu['id']}: {gpu['name']}")
+                print(f"         {gpu['free_gb']:.1f} GB free / {gpu['total_gb']:.1f} GB total")
+        else:
+            print("No GPUs found")
+    else:
+        print_gpu_info()
+    
+    if args.test:
+        run_gpu_test()
+    
+    # Return exit code based on GPU availability
+    info = gpu_info()
+    sys.exit(0 if info['gpu_available'] else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/linum_normalize_intensities_per_slice_gpu.py
+++ b/scripts/linum_normalize_intensities_per_slice_gpu.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+# Configure thread limits before numpy/scipy imports
+import linumpy._thread_config  # noqa: F401
+
+#-*- coding:utf-8 -*-
+
+"""
+GPU-accelerated intensity normalization of ome.zarr volume along z axis.
+
+Uses linumpy.gpu module for:
+- Gaussian filtering (7-20x speedup) on 2D mean projection
+- Otsu thresholding (4-10x speedup) for mask creation
+
+Falls back to CPU if GPU is not available.
+"""
+
+import argparse
+from linumpy.io.zarr import read_omezarr, save_omezarr
+from linumpy.gpu import GPU_AVAILABLE, print_gpu_info
+from linumpy.gpu.morphology import gaussian_filter
+from linumpy.gpu.array_ops import threshold_otsu
+from linumpy.preproc.normalization import normalize_volume
+from linumpy.utils.metrics import collect_normalization_metrics
+
+import dask.array as da
+import numpy as np
+
+
+def _build_arg_parser():
+    p = argparse.ArgumentParser(description='__doc__',
+                                formatter_class=argparse.RawTextHelpFormatter)
+    p.add_argument('in_image',
+                   help='Input image.')
+    p.add_argument('out_image',
+                   help='Output image.')
+    p.add_argument('--percentile_max', type=float, default=99.9,
+                   help='Values above the ith percentile will be clipped. [%(default)s]')
+    p.add_argument('--sigma', type=float, default=1.0,
+                   help='Smoothing sigma for estimating the agarose mask. [%(default)s]')
+    p.add_argument('--min_contrast_fraction', type=float, default=0.1,
+                   help='Minimum contrast as fraction of global max to prevent\n'
+                        'over-amplification of weak/bad slices. [%(default)s]')
+    p.add_argument("--use_gpu", default=True,
+                   action=argparse.BooleanOptionalAction,
+                   help="Use GPU acceleration if available")
+    p.add_argument("--verbose", action="store_true",
+                   help="Print GPU information")
+    return p
+
+
+def get_agarose_mask(vol, smoothing_sigma, use_gpu=True):
+    """Compute agarose mask using GPU-accelerated operations."""
+    reference = np.mean(vol, axis=0)
+    reference_smooth = gaussian_filter(reference, sigma=smoothing_sigma, use_gpu=use_gpu)
+    threshold = threshold_otsu(reference_smooth[reference > 0], use_gpu=use_gpu)
+    agarose_mask = np.logical_and(reference_smooth < threshold, reference > 0)
+    return agarose_mask, float(threshold)
+
+
+def main():
+    parser = _build_arg_parser()
+    args = parser.parse_args()
+
+    use_gpu = args.use_gpu and GPU_AVAILABLE
+
+    if args.verbose:
+        print_gpu_info()
+        print(f"Using GPU: {use_gpu}")
+        if args.use_gpu and not GPU_AVAILABLE:
+            print("GPU requested but not available, falling back to CPU")
+
+    vol, res = read_omezarr(args.in_image, level=0)
+    vol_data = vol[:]
+
+    # Get agarose mask (GPU-accelerated)
+    agarose_mask, otsu_threshold = get_agarose_mask(vol_data, args.sigma, use_gpu=use_gpu)
+
+    # Normalize using shared function
+    vol_normalized, background_thresholds = normalize_volume(
+        vol_data, agarose_mask, args.percentile_max, args.min_contrast_fraction
+    )
+
+    # Save
+    save_omezarr(da.from_array(vol_normalized), args.out_image, res, n_levels=3)
+
+    # Collect metrics using helper function
+    collect_normalization_metrics(
+        vol_normalized=vol_normalized,
+        agarose_mask=agarose_mask,
+        otsu_threshold=otsu_threshold,
+        background_thresholds=background_thresholds,
+        output_path=args.out_image,
+        input_path=args.in_image,
+        params={
+            'percentile_max': args.percentile_max,
+            'sigma': args.sigma,
+            'min_contrast_fraction': args.min_contrast_fraction,
+            'use_gpu': use_gpu
+        }
+    )
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/linum_resample_mosaic_grid_gpu.py
+++ b/scripts/linum_resample_mosaic_grid_gpu.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+Resample a mosaic grid to a new isotropic resolution.
+
+GPU-accelerated version using CuPy for:
+- Volume resampling/rescaling (5-12x speedup)
+
+Falls back to CPU if GPU is not available.
+"""
+
+# Configure thread limits before numpy/scipy imports
+import linumpy._thread_config  # noqa: F401
+
+import argparse
+import itertools
+import time
+from concurrent.futures import ThreadPoolExecutor
+
+import numpy as np
+from tqdm import tqdm
+
+from linumpy.gpu import GPU_AVAILABLE, print_gpu_info
+from linumpy.gpu.interpolation import resize
+from linumpy.io import read_omezarr, OmeZarrWriter
+
+
+def _build_arg_parser():
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawTextHelpFormatter)
+    p.add_argument('in_mosaic',
+                   help='Input mosaic grid in .ome.zarr.')
+    p.add_argument('out_mosaic',
+                   help='Output resampled mosaic .ome.zarr.')
+    p.add_argument('--resolution', '-r', type=float, default=10.0,
+                   help='Isotropic resolution for resampling in microns.')
+    p.add_argument('--n_levels', type=int, default=5,
+                   help='Number of levels in pyramid decomposition [%(default)s].')
+    p.add_argument('--use_gpu', default=True,
+                   action=argparse.BooleanOptionalAction,
+                   help='Use GPU acceleration if available. [%(default)s]')
+    p.add_argument('--verbose', '-v', action='store_true',
+                   help='Print GPU information and timing')
+    return p
+
+
+def rescale_gpu(image, scale, order=1, use_gpu=True):
+    """
+    Rescale an image by a scale factor using GPU acceleration.
+
+    Parameters
+    ----------
+    image : np.ndarray
+        Input image (2D or 3D)
+    scale : float or tuple
+        Scale factor(s) for each axis
+    order : int
+        Interpolation order (1=linear)
+    use_gpu : bool
+        Whether to use GPU acceleration
+
+    Returns
+    -------
+    np.ndarray
+        Rescaled image
+    """
+    # Convert scalar scale to tuple
+    if np.isscalar(scale):
+        scale = tuple([scale] * image.ndim)
+    else:
+        scale = tuple(scale)
+
+    # Compute output shape
+    output_shape = tuple(int(round(s * sc)) for s, sc in zip(image.shape, scale))
+
+    # Use GPU-accelerated resize
+    return resize(image, output_shape, order=order, anti_aliasing=True, use_gpu=use_gpu)
+
+
+def _read_tile(vol, i, j, tile_shape):
+    """Read one tile from the input zarr array (I/O stage of the pipeline)."""
+    return np.asarray(vol[:, i * tile_shape[1]:(i + 1) * tile_shape[1],
+                          j * tile_shape[2]:(j + 1) * tile_shape[2]])
+
+
+def _run_pipelined(vol, out_zarr, tile_iter, tile_shape, out_tile_shape,
+                   scaling_factor, use_gpu):
+    """Process tiles with a prefetch pipeline.
+
+    A background thread reads the next tile from the input zarr while the
+    main thread runs GPU resize and writes the current tile to the output
+    zarr, hiding zarr read latency behind GPU compute:
+
+        zarr_read(i+1) ║ GPU_resize(i) + zarr_write(i)
+    """
+    if not tile_iter:
+        return
+
+    cupy_available = False
+    if use_gpu:
+        try:
+            import cupy as cp
+            cupy_available = True
+        except Exception:
+            pass
+
+    with ThreadPoolExecutor(max_workers=1) as prefetch_executor:
+        i0, j0 = tile_iter[0]
+        pending_load = prefetch_executor.submit(_read_tile, vol, i0, j0, tile_shape)
+
+        for k, (i, j) in enumerate(tqdm(tile_iter, desc="Resampling tiles", unit="tile")):
+            # Wait for current tile to be loaded from disk.
+            tile = pending_load.result()
+
+            # Fire off the next zarr read before GPU work so they overlap.
+            if k + 1 < len(tile_iter):
+                ni, nj = tile_iter[k + 1]
+                pending_load = prefetch_executor.submit(_read_tile, vol, ni, nj, tile_shape)
+
+            # GPU resize + zarr write (concurrent with prefetch of tile k+1).
+            resampled = rescale_gpu(tile, scaling_factor, order=1, use_gpu=use_gpu)
+            out_zarr[:, i * out_tile_shape[1]:(i + 1) * out_tile_shape[1],
+                     j * out_tile_shape[2]:(j + 1) * out_tile_shape[2]] = resampled
+
+            # Periodically free the GPU memory pool to avoid fragmentation.
+            if cupy_available and k % 10 == 9:
+                cp.get_default_memory_pool().free_all_blocks()
+
+
+def main():
+    parser = _build_arg_parser()
+    args = parser.parse_args()
+
+    # Determine GPU usage
+    use_gpu = args.use_gpu and GPU_AVAILABLE
+
+    if args.verbose:
+        print_gpu_info()
+
+    if args.use_gpu and not GPU_AVAILABLE:
+        print("WARNING: GPU requested but not available, falling back to CPU")
+    elif use_gpu:
+        print("GPU: ENABLED")
+        # Try to verify CUDA is working
+        try:
+            import cupy as cp
+            device = cp.cuda.Device()
+            print(f"  Device: {device.id} - {cp.cuda.runtime.getDeviceProperties(device.id)['name'].decode()}")
+            mem_info = device.mem_info
+            print(f"  Memory: {mem_info[1] / 1e9:.1f} GB total, {mem_info[0] / 1e9:.1f} GB free")
+        except Exception as e:
+            print(f"  Warning: Could not query GPU info: {e}")
+    else:
+        print("GPU: DISABLED (using CPU)")
+
+    start_time = time.time()
+
+    # Read input mosaic
+    print(f"Loading: {args.in_mosaic}")
+    vol, source_res = read_omezarr(args.in_mosaic)
+    target_res = args.resolution / 1000.0  # conversion um to mm
+
+    tile_shape = vol.chunks
+    scaling_factor = np.asarray(source_res) / target_res
+
+    print(f"  Volume shape: {vol.shape}")
+    print(f"  Tile shape: {tile_shape}")
+    print(f"  Source resolution: {[f'{r*1000:.2f}' for r in source_res]} µm")
+    print(f"  Target resolution: {args.resolution} µm")
+    print(f"  Scale factor: {scaling_factor}")
+
+    # Compute output tile shape analytically — no need to load a tile just for shape info.
+    out_tile_shape = tuple(int(round(s * sc)) for s, sc in zip(tile_shape, scaling_factor))
+
+    nx = vol.shape[1] // tile_shape[1]
+    ny = vol.shape[2] // tile_shape[2]
+    total_tiles = nx * ny
+
+    out_shape = (out_tile_shape[0], nx * out_tile_shape[1], ny * out_tile_shape[2])
+    print(f"  Output shape: {out_shape} ({total_tiles} tiles)")
+
+    out_zarr = OmeZarrWriter(args.out_mosaic, out_shape, out_tile_shape,
+                             dtype=vol.dtype, overwrite=True)
+
+    # Process all tiles with the prefetch pipeline.
+    tile_iter = list(itertools.product(range(nx), range(ny)))
+    _run_pipelined(vol, out_zarr, tile_iter, tile_shape, out_tile_shape, scaling_factor, use_gpu)
+
+    print("Building pyramid...")
+    out_zarr.finalize([target_res] * 3, args.n_levels)
+
+    elapsed = time.time() - start_time
+    print(f"Done in {elapsed:.1f}s ({total_tiles / elapsed:.1f} tiles/s)")
+
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,87 @@
 # -*- coding: utf-8 -*-
 import os
 import glob
+import subprocess
+import sys
+from pathlib import Path
 
 from setuptools import setup, find_packages
+from setuptools.command.install import install
+from setuptools.command.develop import develop
+
+
+class PostInstallCommand(install):
+    """Post-installation command to apply patchelf fix for JAX CUDA."""
+
+    def run(self):
+        install.run(self)
+        self._post_install()
+
+    def _post_install(self):
+        """Apply patchelf fix to JAX/jaxlib .so files if needed."""
+        # Only run on Linux where patchelf is needed
+        if sys.platform != 'linux':
+            return
+
+        # Check if patchelf is available
+        try:
+            subprocess.run(['patchelf', '--version'], capture_output=True, check=True)
+        except (FileNotFoundError, subprocess.CalledProcessError):
+            print("\n" + "=" * 70)
+            print("NOTE: patchelf not installed - skipping JAX CUDA fix")
+            print("If using GPU, install patchelf and run:")
+            print("  source scripts/fix_jax_cuda_plugin.sh")
+            print("=" * 70 + "\n")
+            return
+
+        # Try to find and patch jaxlib .so files
+        try:
+            import site
+            sp = site.getsitepackages()[0]
+            patched = 0
+
+            # Patch jaxlib
+            jaxlib_path = os.path.join(sp, 'jaxlib')
+            if os.path.isdir(jaxlib_path):
+                for so_file in Path(jaxlib_path).rglob("*.so"):
+                    try:
+                        subprocess.run(
+                            ['patchelf', '--clear-execstack', str(so_file)],
+                            capture_output=True, check=True
+                        )
+                        patched += 1
+                    except subprocess.CalledProcessError:
+                        pass
+
+            # Patch jax_plugins
+            jax_plugins_path = os.path.join(sp, 'jax_plugins')
+            if os.path.isdir(jax_plugins_path):
+                for so_file in Path(jax_plugins_path).rglob("*.so"):
+                    try:
+                        subprocess.run(
+                            ['patchelf', '--clear-execstack', str(so_file)],
+                            capture_output=True, check=True
+                        )
+                        patched += 1
+                    except subprocess.CalledProcessError:
+                        pass
+
+            if patched > 0:
+                print(f"\n✅ Applied patchelf fix to {patched} JAX .so files")
+                print("   JAX CUDA should work on modern Linux kernels.\n")
+        except Exception as e:
+            print(f"\n⚠️  Could not apply patchelf fix: {e}")
+            print("   Run manually: source scripts/fix_jax_cuda_plugin.sh\n")
+
+
+class PostDevelopCommand(develop):
+    """Post-develop command to apply patchelf fix for JAX CUDA."""
+
+    def run(self):
+        develop.run(self)
+        # Use the same post-install logic
+        PostInstallCommand._post_install(self)
+
 
 # Versions
 _version_major = 0
@@ -46,6 +125,89 @@ with open('requirements.txt') as f:
 # get all scripts in the script folder
 SCRIPTS=glob.glob("scripts/*.py")
 
+# Optional dependencies
+# NOTE: GPU extras are MUTUALLY EXCLUSIVE - install only ONE of: [gpu], [gpu-cuda11], [gpu-cuda13]
+# Installing multiple GPU extras will cause JAX plugin conflicts!
+#
+# GPU support requires CuPy matching your CUDA version:
+#   - CUDA 11.x: pip install linumpy[gpu-cuda11]
+#   - CUDA 12.x: pip install linumpy[gpu]  (default)
+#   - CUDA 13.x: pip install linumpy[gpu-cuda13]
+#
+# NOTE: BaSiCPy (fix_illumination) uses JAX which also supports GPU.
+# JAX versions are constrained by basicpy's requirements (jax<=0.4.23).
+# JAX CUDA 13 plugin requires jax>=0.4.36, so gpu-cuda13 uses CUDA 12 JAX packages.
+extras_require = {
+    'gpu': [
+        'cupy-cuda12x>=12.0.0',  # Default: CUDA 12.x
+        # JAX CUDA 12 packages (equivalent to jax[cuda12]<=0.4.23)
+        'jax<=0.4.23',
+        'jaxlib==0.4.23',
+        'jax-cuda12-plugin==0.4.23; sys_platform == "linux"',
+        'nvidia-cublas-cu12>=12.2.5.6; sys_platform == "linux"',
+        'nvidia-cuda-cupti-cu12>=12.2.142; sys_platform == "linux"',
+        'nvidia-cuda-nvcc-cu12>=12.2.140; sys_platform == "linux"',
+        'nvidia-cuda-runtime-cu12>=12.2.140; sys_platform == "linux"',
+        'nvidia-cudnn-cu12>=8.9; sys_platform == "linux"',
+        'nvidia-cufft-cu12>=11.0.8.103; sys_platform == "linux"',
+        'nvidia-cusolver-cu12>=11.5.2; sys_platform == "linux"',
+        'nvidia-cusparse-cu12>=12.1.2.141; sys_platform == "linux"',
+        'nvidia-nccl-cu12>=2.18.3; sys_platform == "linux"',
+        'nvidia-nvjitlink-cu12>=12.2; sys_platform == "linux"',
+    ],
+    'gpu-cuda11': [
+        'cupy-cuda11x>=11.0.0',
+        # JAX CUDA 11 packages (equivalent to jax[cuda11_pip]<=0.4.23)
+        'jax<=0.4.23',
+        'jaxlib==0.4.23+cuda11.cudnn86; sys_platform == "linux"',
+        'nvidia-cublas-cu11>=11.11; sys_platform == "linux"',
+        'nvidia-cuda-cupti-cu11>=11.8; sys_platform == "linux"',
+        'nvidia-cuda-nvcc-cu11>=11.8; sys_platform == "linux"',
+        'nvidia-cuda-runtime-cu11>=11.8; sys_platform == "linux"',
+        'nvidia-cudnn-cu11>=8.8; sys_platform == "linux"',
+        'nvidia-cufft-cu11>=10.9; sys_platform == "linux"',
+        'nvidia-cusolver-cu11>=11.4; sys_platform == "linux"',
+        'nvidia-cusparse-cu11>=11.7; sys_platform == "linux"',
+        'nvidia-nccl-cu11>=2.18.3; sys_platform == "linux"',
+    ],
+    'gpu-cuda13': [
+        'cupy-cuda13x>=13.0.0',  # CUDA 13.x for CuPy (linumpy operations)
+        # JAX 0.4.23 uses CUDA 12 driver API but links against library ABI version 11:
+        #   - libcusolver.so.11, libcusparse.so.11, libcufft.so.10, libcublas.so.11
+        # The -cu12 packages contain these .so.11 files (NOT .so.12!)
+        # Non-suffixed packages contain .so.12/.so.13 which are INCOMPATIBLE.
+        #
+        # IMPORTANT: After installing, run: source scripts/fix_jax_cuda_plugin.sh
+        # This applies patchelf fix and sets up LD_LIBRARY_PATH correctly.
+        'jax==0.4.23',
+        'jaxlib==0.4.23; sys_platform != "linux"',
+        # Note: jaxlib CUDA wheel must be installed separately on Linux:
+        # pip install jaxlib==0.4.23+cuda12.cudnn89 -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
+        # Pinned nvidia package versions that JAX 0.4.23 was built with (Dec 2023)
+        'nvidia-cublas-cu12==12.3.4.1; sys_platform == "linux"',
+        'nvidia-cuda-cupti-cu12==12.3.101; sys_platform == "linux"',
+        'nvidia-cuda-runtime-cu12==12.3.101; sys_platform == "linux"',
+        'nvidia-cudnn-cu12==8.9.7.29; sys_platform == "linux"',
+        'nvidia-cufft-cu12==11.0.12.1; sys_platform == "linux"',
+        'nvidia-cusolver-cu12==11.5.4.101; sys_platform == "linux"',
+        'nvidia-cusparse-cu12==12.2.0.103; sys_platform == "linux"',
+        'nvidia-nccl-cu12==2.19.3; sys_platform == "linux"',
+        'nvidia-nvjitlink-cu12==12.3.101; sys_platform == "linux"',
+    ],
+    'dev': [
+        'pytest>=7.0.0',
+        'pytest-cov>=4.0.0',
+        'black>=23.0.0',
+        'flake8>=6.0.0',
+    ],
+    'docs': [
+        'sphinx>=6.0.0',
+        'sphinx-rtd-theme>=1.0.0',
+    ],
+}
+# 'all' includes everything except GPU (since GPU requires specific CUDA version)
+extras_require['all'] = extras_require['dev'] + extras_require['docs']
+
 opts = dict(name="linumpy",
             maintainer="Joël Lefebvre",
             maintainer_email="lefebvre.joel@uqam.ca",
@@ -70,6 +232,12 @@ opts = dict(name="linumpy",
                     os.path.basename(s).split(".")[0]) for s in SCRIPTS]
             },
             install_requires=external_dependencies,
-            include_package_data=True)
+            extras_require=extras_require,
+            include_package_data=True,
+            # Post-install hooks to apply patchelf fix for JAX CUDA
+            cmdclass={
+                'install': PostInstallCommand,
+                'develop': PostDevelopCommand,
+            })
 
 setup(**opts)

--- a/shell_scripts/fix_jax_cuda_plugin.sh
+++ b/shell_scripts/fix_jax_cuda_plugin.sh
@@ -1,0 +1,388 @@
+#!/bin/bash
+# Fix JAX CUDA plugin for JAX 0.4.23 (required by BaSiCPy)
+#
+# JAX 0.4.23 was compiled with CUDA 12 driver API but uses:
+#   - cuSOLVER 11.x (libcusolver.so.11)
+#   - cuSPARSE 11.x (libcusparse.so.11)
+#   - cuFFT 10.x (libcufft.so.10 or .so.11)
+#   - cuBLAS 11.x (libcublas.so.11)
+#   - cuDNN 8.x (libcudnn.so.8)
+#
+# The nvidia-xxx-cu12 packages contain these .so.11 files.
+# Non-suffixed packages (nvidia-cusolver) contain .so.12/.so.13 which are INCOMPATIBLE.
+#
+# This script:
+# 1. Uninstalls conflicting packages
+# 2. Installs JAX 0.4.23 with correct CUDA 12 packages
+# 3. Applies patchelf fix for modern Linux kernels
+# 4. Verifies the installation
+#
+# Usage:
+#   source scripts/fix_jax_cuda_plugin.sh
+#   # or
+#   bash scripts/fix_jax_cuda_plugin.sh
+
+# Don't use set -e as it can cause SSH disconnection issues
+# Instead, handle errors explicitly where needed
+
+echo "========================================================================"
+echo " JAX CUDA Fix for JAX 0.4.23 (BaSiCPy compatibility)"
+echo "========================================================================"
+echo ""
+
+# Check if running interactively (for prompts)
+if [ -t 0 ]; then
+    INTERACTIVE=1
+else
+    INTERACTIVE=0
+    echo "Running in non-interactive mode (SSH/pipe detected)"
+fi
+
+# Find Python
+PYTHON_CMD=""
+if [ -n "$VIRTUAL_ENV" ] && [ -x "$VIRTUAL_ENV/bin/python" ]; then
+    PYTHON_CMD="$VIRTUAL_ENV/bin/python"
+elif [ -n "$PYENV_VIRTUAL_ENV" ] && [ -x "$PYENV_VIRTUAL_ENV/bin/python" ]; then
+    PYTHON_CMD="$PYENV_VIRTUAL_ENV/bin/python"
+elif command -v python3 &> /dev/null; then
+    PYTHON_CMD="python3"
+elif command -v python &> /dev/null; then
+    PYTHON_CMD="python"
+else
+    echo "❌ Python not found"
+    # Use return if sourced, exit if run as script
+    (return 0 2>/dev/null) && return 1 || exit 1
+fi
+
+echo "Python: $PYTHON_CMD"
+SP=$("$PYTHON_CMD" -c "import site; print(site.getsitepackages()[0])")
+echo "Site-packages: $SP"
+
+# Check for patchelf
+PATCHELF_AVAILABLE=0
+if command -v patchelf &> /dev/null; then
+    PATCHELF_AVAILABLE=1
+else
+    echo ""
+    echo "⚠️  patchelf is required but not installed"
+    echo "   Install with: sudo apt install patchelf"
+    if [ $INTERACTIVE -eq 1 ]; then
+        read -p "Continue without patchelf? (y/N) " -n 1 -r
+        echo
+        if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+            # Use return if sourced, exit if run as script
+            (return 0 2>/dev/null) && return 1 || exit 1
+        fi
+    else
+        echo "   Continuing without patchelf (non-interactive mode)"
+        echo "   You may need to run patchelf manually later."
+    fi
+fi
+
+# Step 1: Clean up conflicting packages
+echo ""
+echo "=== Step 1: Removing conflicting packages ==="
+
+# Remove non-suffixed nvidia packages that have wrong library versions
+echo "Removing non-suffixed nvidia packages (contain .so.12/.so.13, incompatible)..."
+"$PYTHON_CMD" -m pip uninstall -y \
+    nvidia-cusolver nvidia-cufft nvidia-cusparse nvidia-cublas \
+    nvidia-cuda-runtime nvidia-cudnn nvidia-nvjitlink nvidia-nccl \
+    2>/dev/null || true
+
+# Remove any CUDA 13 JAX plugins
+echo "Removing CUDA 13 JAX plugins..."
+"$PYTHON_CMD" -m pip uninstall -y \
+    jax-cuda13-plugin jax-cuda13-pjrt \
+    2>/dev/null || true
+
+# Step 2: Install JAX with CUDA 12 support
+echo ""
+echo "=== Step 2: Installing JAX 0.4.23 with CUDA 12 support ==="
+
+# Uninstall existing JAX and nvidia packages first
+"$PYTHON_CMD" -m pip uninstall -y jax jaxlib jax-cuda12-plugin jax-cuda12-pjrt 2>/dev/null || true
+
+# Also uninstall all nvidia packages to avoid version conflicts
+"$PYTHON_CMD" -m pip uninstall -y \
+    nvidia-cublas-cu12 nvidia-cuda-cupti-cu12 nvidia-cuda-nvcc-cu12 \
+    nvidia-cuda-runtime-cu12 nvidia-cudnn-cu12 nvidia-cufft-cu12 \
+    nvidia-cusolver-cu12 nvidia-cusparse-cu12 nvidia-nccl-cu12 \
+    nvidia-nvjitlink-cu12 nvidia-nvtx-cu12 \
+    2>/dev/null || true
+
+# Install JAX 0.4.23 with EXACT nvidia package versions it was built with
+# These versions are from the JAX 0.4.23 release (December 2023)
+echo "Installing JAX 0.4.23 with pinned nvidia package versions..."
+
+# First install JAX without cuda extra to avoid pulling in wrong versions
+"$PYTHON_CMD" -m pip install 'jax==0.4.23' 'jaxlib==0.4.23+cuda12.cudnn89' \
+    -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
+
+# Install the exact nvidia package versions that JAX 0.4.23 was built with
+# These are the versions from late 2023 that have the correct .so versions
+"$PYTHON_CMD" -m pip install \
+    'nvidia-cublas-cu12==12.3.4.1' \
+    'nvidia-cuda-cupti-cu12==12.3.101' \
+    'nvidia-cuda-runtime-cu12==12.3.101' \
+    'nvidia-cudnn-cu12==8.9.7.29' \
+    'nvidia-cufft-cu12==11.0.12.1' \
+    'nvidia-cusolver-cu12==11.5.4.101' \
+    'nvidia-cusparse-cu12==12.2.0.103' \
+    'nvidia-nccl-cu12==2.19.3' \
+    'nvidia-nvjitlink-cu12==12.3.101'
+
+echo "✓ JAX installed with pinned versions"
+
+# Step 3: Verify -cu12 packages have correct library versions
+echo ""
+echo "=== Step 3: Verifying library versions ==="
+
+"$PYTHON_CMD" << 'VERIFY_LIBS'
+import os
+import site
+import glob
+
+sp = site.getsitepackages()[0]
+
+# Check for correct library versions from pinned nvidia packages
+checks = [
+    ("nvidia/cusolver/lib", "libcusolver.so.11", "nvidia-cusolver-cu12==11.5.4.101"),
+    ("nvidia/cusparse/lib", "libcusparse.so.12", "nvidia-cusparse-cu12==12.2.0.103"),
+    ("nvidia/cufft/lib", "libcufft.so.11", "nvidia-cufft-cu12==11.0.12.1"),
+    ("nvidia/cublas/lib", "libcublas.so.12", "nvidia-cublas-cu12==12.3.4.1"),
+    ("nvidia/cuda_runtime/lib", "libcudart.so.12", "nvidia-cuda-runtime-cu12==12.3.101"),
+    ("nvidia/cudnn/lib", "libcudnn.so.8", "nvidia-cudnn-cu12==8.9.7.29"),
+]
+
+all_ok = True
+for lib_path, lib_file, package in checks:
+    full_path = os.path.join(sp, lib_path, lib_file)
+    # Also check for any version of this library
+    pattern = os.path.join(sp, lib_path, lib_file.rsplit('.so', 1)[0] + ".so*")
+    found = glob.glob(pattern)
+    if found:
+        found_name = os.path.basename(sorted(found)[0])
+        if os.path.exists(full_path):
+            print(f"  ✓ {lib_file} found")
+        else:
+            print(f"  ⚠️ {found_name} found (expected {lib_file}) - version mismatch!")
+            all_ok = False
+    else:
+        print(f"  ✗ {lib_file} NOT FOUND - install {package}")
+        all_ok = False
+
+if all_ok:
+    print("\n✓ All nvidia packages have correct library versions")
+else:
+    print("\n⚠️  Some libraries have wrong versions - JAX may not work correctly")
+    print("   Run this script again to reinstall correct versions")
+VERIFY_LIBS
+
+# Step 4: Apply patchelf fix
+echo ""
+echo "=== Step 4: Applying patchelf fix ==="
+
+if [ $PATCHELF_AVAILABLE -eq 1 ]; then
+    JAXLIB_PATH=$("$PYTHON_CMD" -c "import jaxlib; print(jaxlib.__path__[0])" 2>/dev/null || echo "")
+
+    if [ -n "$JAXLIB_PATH" ] && [ -d "$JAXLIB_PATH" ]; then
+        echo "Patching jaxlib at: $JAXLIB_PATH"
+        find "$JAXLIB_PATH" -name "*.so" -type f -exec patchelf --clear-execstack {} \; 2>/dev/null || true
+        echo "  ✓ Applied patchelf to jaxlib"
+    fi
+
+    JAX_PLUGINS_PATH="${SP}/jax_plugins"
+    if [ -d "$JAX_PLUGINS_PATH" ]; then
+        echo "Patching jax_plugins at: $JAX_PLUGINS_PATH"
+        find "$JAX_PLUGINS_PATH" -name "*.so" -type f -exec patchelf --clear-execstack {} \; 2>/dev/null || true
+        echo "  ✓ Applied patchelf to jax_plugins"
+    fi
+else
+    echo "⚠️  Skipping patchelf (not installed)"
+fi
+
+# Step 5: Set up LD_LIBRARY_PATH
+echo ""
+echo "=== Step 5: Setting up LD_LIBRARY_PATH ==="
+
+# Build LD_LIBRARY_PATH with -cu12 package paths
+NEW_LD_PATH=""
+for lib_dir in nvidia/cublas/lib nvidia/cuda_runtime/lib nvidia/cusolver/lib nvidia/cusparse/lib nvidia/cufft/lib nvidia/cudnn/lib nvidia/nvjitlink/lib; do
+    full_path="${SP}/${lib_dir}"
+    if [ -d "$full_path" ]; then
+        if [ -n "$NEW_LD_PATH" ]; then
+            NEW_LD_PATH="${NEW_LD_PATH}:${full_path}"
+        else
+            NEW_LD_PATH="${full_path}"
+        fi
+    fi
+done
+
+# Also check for system cuDNN 8.x
+SYSTEM_CUDNN=""
+for sys_path in /usr/lib/x86_64-linux-gnu /usr/local/cuda/lib64 /usr/lib64; do
+    if [ -f "${sys_path}/libcudnn.so.8" ]; then
+        SYSTEM_CUDNN="${sys_path}"
+        break
+    fi
+done
+
+if [ -n "$SYSTEM_CUDNN" ]; then
+    echo "Found system cuDNN 8.x at: $SYSTEM_CUDNN"
+    NEW_LD_PATH="${SYSTEM_CUDNN}:${NEW_LD_PATH}"
+fi
+
+# Append existing LD_LIBRARY_PATH
+if [ -n "$LD_LIBRARY_PATH" ]; then
+    export LD_LIBRARY_PATH="${NEW_LD_PATH}:${LD_LIBRARY_PATH}"
+else
+    export LD_LIBRARY_PATH="${NEW_LD_PATH}"
+fi
+
+echo "LD_LIBRARY_PATH configured with $(echo "$LD_LIBRARY_PATH" | tr ':' '\n' | wc -l) paths"
+
+# Step 6: Test JAX
+echo ""
+echo "=== Step 6: Testing JAX CUDA ==="
+
+# First, show what library files actually exist
+echo "Checking library files in nvidia packages..."
+"$PYTHON_CMD" << 'CHECK_LIBS'
+import os
+import site
+import glob
+
+sp = site.getsitepackages()[0]
+
+# Check each nvidia lib directory
+lib_dirs = [
+    'nvidia/cusolver/lib',
+    'nvidia/cublas/lib',
+    'nvidia/cusparse/lib',
+    'nvidia/cufft/lib',
+    'nvidia/cuda_runtime/lib',
+    'nvidia/cudnn/lib',
+]
+
+for lib_dir in lib_dirs:
+    full_path = os.path.join(sp, lib_dir)
+    if os.path.isdir(full_path):
+        files = [f for f in os.listdir(full_path) if '.so' in f]
+        print(f"  {lib_dir}: {', '.join(sorted(files)[:3])}...")
+CHECK_LIBS
+
+echo ""
+
+# Build LD_PRELOAD to force library loading before JAX initializes
+# Use the correct .so versions from pinned nvidia packages
+PRELOAD_LIBS=""
+for lib in libcusolver.so.11 libcublas.so.12 libcublasLt.so.12 libcusparse.so.12 libcufft.so.11; do
+    for search_path in ${SP}/nvidia/cusolver/lib ${SP}/nvidia/cublas/lib ${SP}/nvidia/cusparse/lib ${SP}/nvidia/cufft/lib; do
+        if [ -f "${search_path}/${lib}" ]; then
+            if [ -n "$PRELOAD_LIBS" ]; then
+                PRELOAD_LIBS="${PRELOAD_LIBS}:${search_path}/${lib}"
+            else
+                PRELOAD_LIBS="${search_path}/${lib}"
+            fi
+            break
+        fi
+    done
+done
+
+if [ -n "$PRELOAD_LIBS" ]; then
+    echo "Preloading CUDA libraries via LD_PRELOAD..."
+    export LD_PRELOAD="$PRELOAD_LIBS"
+fi
+
+TEST_RESULT=$("$PYTHON_CMD" -c "
+import os
+import sys
+import ctypes
+
+# Preload CUDA libraries using ctypes BEFORE importing JAX
+# This ensures cuSOLVER symbols are available when XLA initializes
+ld_path = os.environ.get('LD_LIBRARY_PATH', '')
+print('Preloading CUDA libraries...')
+
+# Libraries to preload in order (dependencies first)
+# These are the actual .so versions from the pinned nvidia packages
+libs_to_load = [
+    ('libcudart.so.12', 'CUDA runtime'),
+    ('libcublas.so.12', 'cuBLAS'),
+    ('libcublasLt.so.12', 'cuBLAS Lt'),
+    ('libcusolver.so.11', 'cuSOLVER'),
+    ('libcusparse.so.12', 'cuSPARSE'),
+    ('libcufft.so.11', 'cuFFT'),
+    ('libcudnn.so.8', 'cuDNN'),
+]
+
+loaded = set()
+for lib_name, desc in libs_to_load:
+    if desc in loaded:
+        continue
+    for path in ld_path.split(':'):
+        lib_path = os.path.join(path, lib_name)
+        if os.path.exists(lib_path):
+            try:
+                ctypes.CDLL(lib_path, mode=ctypes.RTLD_GLOBAL)
+                print(f'  ✓ {lib_name}')
+                loaded.add(desc)
+            except Exception as e:
+                print(f'  ✗ {lib_name}: {e}')
+            break
+
+# Test JAX
+try:
+    import jax
+    devices = jax.devices()
+    print(f'JAX devices: {devices}')
+
+    has_gpu = any('cuda' in str(d).lower() for d in devices)
+    if not has_gpu:
+        print('⚠️  No CUDA devices found')
+        sys.exit(1)
+
+    # Test SVD (used by BaSiCPy)
+    import jax.numpy as jnp
+    a = jnp.array([[1.0, 2.0], [3.0, 4.0]])
+    u, s, v = jnp.linalg.svd(a)
+    print(f'SVD test passed: singular values = {s}')
+    print('✅ JAX CUDA is working!')
+
+except Exception as e:
+    print(f'❌ JAX test failed: {e}')
+    sys.exit(1)
+" 2>&1)
+
+echo "$TEST_RESULT"
+
+if echo "$TEST_RESULT" | grep -q "JAX CUDA is working"; then
+    echo ""
+    echo "========================================================================"
+    echo " SUCCESS!"
+    echo "========================================================================"
+    echo ""
+    echo "Before running JAX/BaSiCPy, set LD_LIBRARY_PATH:"
+    echo ""
+    echo "  export LD_LIBRARY_PATH=\"${NEW_LD_PATH}:\${LD_LIBRARY_PATH}\""
+    echo ""
+    echo "Or add to ~/.bashrc for permanent setup."
+    echo ""
+    echo "Verify with: linum_diagnose_pipeline.py --benchmark"
+else
+    echo ""
+    echo "========================================================================"
+    echo " SETUP FAILED"
+    echo "========================================================================"
+    echo ""
+    echo "Common issues:"
+    echo "  1. patchelf not installed: sudo apt install patchelf"
+    echo "  2. Wrong cuDNN version: JAX 0.4.23 needs cuDNN 8.x (libcudnn.so.8)"
+    echo "  3. CUDA driver too old: Need CUDA 12+ driver"
+    echo ""
+    echo "For diagnostics: linum_diagnose_pipeline.py --debug-cuda"
+    # Use return if sourced, exit if run as script
+    # This prevents SSH session termination when sourced
+    (return 0 2>/dev/null) && return 1 || exit 1
+fi


### PR DESCRIPTION
## Summary

Introduces a `linumpy/gpu/` package that provides GPU-accelerated implementations of the most computationally expensive pipeline operations. All functions fall back to CPU (NumPy/SciPy) automatically when no GPU is available, so the package remains usable on CPU-only machines.

## New `linumpy/gpu/` Modules

| Module | Description |
|--------|-------------|
| `__init__.py` | CuPy/JAX detection, `get_array_module()`, device selection |
| `array_ops.py` | Projections, resizing, tiling |
| `corrections.py` | Galvo shift correction |
| `cuda_env.py` | CUDA environment detection and GPU selection |
| `fft_ops.py` | FFT and phase correlation |
| `image_quality.py` | Sharpness, contrast, SNR, SSIM metrics |
| `interpolation.py` | Affine transform and resampling |
| `morphology.py` | Morphological operations |
| `registration.py` | Phase-correlation registration |

## New GPU Scripts

Drop-in GPU replacements for CPU counterparts:
- `linum_aip_gpu.py`
- `linum_create_masks_gpu.py`
- `linum_create_mosaic_grid_3d_gpu.py`
- `linum_estimate_transform_gpu.py`
- `linum_fix_illumination_3d_gpu.py`
- `linum_generate_mosaic_aips_gpu.py`
- `linum_normalize_intensities_per_slice_gpu.py`
- `linum_resample_mosaic_grid_gpu.py`

## Utilities

- `linum_gpu_info.py` — list available GPUs and select a device
- `linum_benchmark_gpu.py` — CPU vs GPU performance comparison for all pipeline stages
- `shell_scripts/fix_jax_cuda_plugin.sh` — script to patch JAX/CUDA plugin compatibility

## Dependencies

Adds CuPy, JAX, and BaSiCPy as optional extras in `requirements.txt` and `setup.py`.

Depends on PR #85 (thread config module).

---

> **Merge order:** Merge after PR #85.