### PR TITLE
feat: GPU acceleration module and scripts

### DIFF
--- a/docs/GPU_ACCELERATION.md
+++ b/docs/GPU_ACCELERATION.md
@@ -1,8 +1,6 @@
 # GPU Acceleration
 
 
----
-
 ## Overview
 
 linumpy supports GPU acceleration for compute-intensive operations using NVIDIA CUDA via CuPy. GPU acceleration is **optional** - all functions automatically fall back to CPU (NumPy/SciPy) if:
@@ -10,6 +8,21 @@ linumpy supports GPU acceleration for compute-intensive operations using NVIDIA 
 - CuPy is not installed
 - No CUDA-capable GPU is available
 - GPU memory is insufficient
+
+```mermaid
+flowchart TD
+    CALL[GPU-aware function called<br/>backend='auto' default] --> CHK1{CuPy installed?}
+    CHK1 -->|no| CPU[Run on CPU<br/>NumPy / SciPy / SimpleITK]
+    CHK1 -->|yes| CHK2{CUDA device available?}
+    CHK2 -->|no| CPU
+    CHK2 -->|yes| PICK[Auto-select least-loaded GPU]
+    PICK --> RUN[Run CuPy kernel on device]
+    RUN -->|OOM / runtime error| CPU
+    RUN -->|success| OUT([Result])
+    CPU --> OUT
+```
+
+backend selection is per-call (`backend="cpu" | "gpu" | "auto"`); the auto path is the safe default and is what the Nextflow workflows use when `use_gpu=true`.
 
 ---
 
@@ -20,13 +33,12 @@ linumpy supports GPU acceleration for compute-intensive operations using NVIDIA 
 nvidia-smi | grep "CUDA Version"
 
 # Install linumpy with GPU support (choose your CUDA version)
-pip install linumpy[gpu]           # CUDA 12.x (default)
-pip install linumpy[gpu-cuda11]    # CUDA 11.x
-pip install linumpy[gpu-cuda13]    # CUDA 13.x (requires extra setup for JAX)
+uv pip install 'linumpy[gpu]'           # CUDA 13.x (default)
+uv pip install 'linumpy[gpu-cuda12]'    # CUDA 12.x
 
 # Verify GPU
-linum_gpu_info.py
-linum_diagnose_pipeline.py --benchmark
+linum-gpu-info
+linum-diagnose-pipeline --benchmark
 ```
 
 ---
@@ -43,98 +55,33 @@ linum_diagnose_pipeline.py --benchmark
 
 ### CuPy Version Reference
 
-| CUDA Version | CuPy Package |
-|--------------|--------------|
-| CUDA 11.x | `cupy-cuda11x` |
-| CUDA 12.x | `cupy-cuda12x` |
-| CUDA 13.x | `cupy-cuda13x` |
+| CUDA Version | CuPy Package | linumpy extra |
+|--------------|--------------|---------------|
+| CUDA 13.x    | `cupy-cuda13x` | `linumpy[gpu]` (default) |
+| CUDA 12.x    | `cupy-cuda12x` | `linumpy[gpu-cuda12]` |
 
 ---
 
-## JAX GPU for BaSiCPy (fix_illumination)
+## BaSiCPy (fix_illumination)
 
-The `fix_illumination` step uses BaSiCPy which is built on JAX. JAX GPU requires additional setup.
+The `fix_illumination` step uses BaSiCPy 2.x, which now ships with a
+**PyTorch backend** (no JAX). BaSiCPy will use a CUDA-enabled PyTorch wheel
+automatically when one is installed; otherwise it runs on CPU.
 
-### Important: JAX 0.4.23 Library Requirements
-
-BaSiCPy requires `jax<=0.4.23`. JAX 0.4.23 was compiled against specific library versions:
-- cuSOLVER 11 (libcusolver.so.11)
-- cuSPARSE 12 (libcusparse.so.12)
-- cuFFT 11 (libcufft.so.11)
-- cuBLAS 12 (libcublas.so.12)
-- cuDNN 8 (libcudnn.so.8)
-
-These exact versions are only available in **specific pinned versions** of the `nvidia-xxx-cu12` packages. Newer versions of these packages have different `.so` versions that are **incompatible**.
-
-### Automated Setup (Recommended)
+If you only need linumpy's CuPy paths (resampling, FFT, morphology, N4),
+no extra steps beyond `pip install 'linumpy[gpu]'` are required. To enable
+GPU acceleration of BaSiCPy as well, install a CUDA build of PyTorch:
 
 ```bash
-# Run the fix script - handles everything
-source shell_scripts/fix_jax_cuda_plugin.sh
+# Pick the index URL that matches your CUDA toolkit
+uv pip install torch --index-url https://download.pytorch.org/whl/cu121
 ```
 
-This script:
-1. Removes conflicting nvidia packages
-2. Installs JAX 0.4.23 with **pinned nvidia package versions**:
-   - `nvidia-cublas-cu12==12.3.4.1`
-   - `nvidia-cudnn-cu12==8.9.7.29`
-   - `nvidia-cusolver-cu12==11.5.4.101`
-   - etc.
-3. Applies patchelf fix (required for Linux 6.x+ kernels)
-4. Sets up LD_LIBRARY_PATH
-5. Tests JAX CUDA with SVD operation
-
-### Manual Setup
-
-If you prefer manual setup:
+Verify:
 
 ```bash
-# 1. Uninstall all conflicting packages
-pip uninstall -y jax jaxlib jax-cuda12-plugin nvidia-cusolver nvidia-cufft \
-    nvidia-cusparse nvidia-cublas nvidia-cuda-runtime nvidia-cudnn nvidia-nvjitlink \
-    nvidia-cublas-cu12 nvidia-cuda-cupti-cu12 nvidia-cuda-runtime-cu12 \
-    nvidia-cudnn-cu12 nvidia-cufft-cu12 nvidia-cusolver-cu12 nvidia-cusparse-cu12 \
-    nvidia-nccl-cu12 nvidia-nvjitlink-cu12
-
-# 2. Install JAX 0.4.23 with CUDA wheel
-pip install 'jax==0.4.23' 'jaxlib==0.4.23+cuda12.cudnn89' \
-    -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
-
-# 3. Install PINNED nvidia package versions (critical - newer versions won't work!)
-pip install \
-    'nvidia-cublas-cu12==12.3.4.1' \
-    'nvidia-cuda-cupti-cu12==12.3.101' \
-    'nvidia-cuda-runtime-cu12==12.3.101' \
-    'nvidia-cudnn-cu12==8.9.7.29' \
-    'nvidia-cufft-cu12==11.0.12.1' \
-    'nvidia-cusolver-cu12==11.5.4.101' \
-    'nvidia-cusparse-cu12==12.2.0.103' \
-    'nvidia-nccl-cu12==2.19.3' \
-    'nvidia-nvjitlink-cu12==12.3.101'
-
-# 4. Apply patchelf fix (required for modern Linux kernels)
-sudo apt install patchelf
-JAXLIB_PATH=$(python -c "import jaxlib; print(jaxlib.__path__[0])")
-find "$JAXLIB_PATH" -name "*.so" -exec patchelf --clear-execstack {} \;
-find $(python -c "import site; print(site.getsitepackages()[0])")/jax_plugins \
-    -name "*.so" -exec patchelf --clear-execstack {} \;
-
-# 5. Set LD_LIBRARY_PATH (before running JAX/BaSiCPy)
-SP=$(python -c "import site; print(site.getsitepackages()[0])")
-export LD_LIBRARY_PATH="${SP}/nvidia/cublas/lib:${SP}/nvidia/cuda_runtime/lib:${SP}/nvidia/cusolver/lib:${SP}/nvidia/cusparse/lib:${SP}/nvidia/cufft/lib:${SP}/nvidia/cudnn/lib:${LD_LIBRARY_PATH}"
-
-# 6. Test
-python -c "import jax; print(jax.devices()); import jax.numpy as jnp; print(jnp.linalg.svd(jnp.eye(2)))"
-```
-
-### Verify Installation
-
-```bash
-# Check GPU availability
-linum_gpu_info.py
-
-# Run full pipeline diagnostics
-linum_diagnose_pipeline.py --benchmark
+linum-gpu-info
+linum-diagnose-pipeline --benchmark
 ```
 
 ---
@@ -147,16 +94,16 @@ separate `_gpu.py` variant is needed.
 
 | Script | GPU-accelerated operation | Typical Speedup |
 |--------|--------------------------|-----------------|
-| `linum_estimate_transform.py` | FFT / phase correlation | 8-47x |
-| `linum_create_mosaic_grid_3d.py` | Volume resize | 5-12x |
-| `linum_resample_mosaic_grid.py` | Volume resize | 5-12x |
-| `linum_normalize_intensities_per_slice.py` | Gaussian filter, Otsu threshold | 4-10x |
-| `linum_fix_illumination_3d.py` | BaSiCPy via JAX/CUDA | 2-5x |
-| `linum_assess_slice_quality.py` | SSIM, morphology | 3-8x |
-| `linum_aip_png.py` | Mean projection | ≤1x |
-| `linum_generate_mosaic_aips.py` | Mean projection | ≤1x |
-| `linum_normalize_z_intensity.py` | Scale-factor computation | varies |
-| `linum_estimate_global_transform.py` | Phase correlation | 8-16x |
+| `linum-estimate-transform` | FFT / phase correlation | 8-47x |
+| `linum-create-mosaic-grid-3d` | Volume resize | 5-12x |
+| `linum-resample-mosaic-grid` | Volume resize | 5-12x |
+| `linum-normalize-intensities-per-slice` | Gaussian filter, Otsu threshold | 4-10x |
+| `linum-fix-illumination-3d` | BaSiCPy via PyTorch/CUDA | 2-5x |
+| `linum-assess-slice-quality` | SSIM, morphology | 3-8x |
+| `linum-aip-png` | Mean projection | ≤1x |
+| `linum-generate-mosaic-aips` | Mean projection | ≤1x |
+| `linum-correct-bias-field` | N4 bias field estimation | varies |
+| `linum-estimate-global-transform` | Phase correlation | 8-16x |
 
 ---
 
@@ -190,14 +137,43 @@ separate `_gpu.py` variant is needed.
 
 ---
 
+## CuPy acceleration backends (`CUPY_ACCELERATORS`)
+
+CuPy can route some array ops through additional NVIDIA backends. By default CuPy
+enables only `cub`; adding `cutensor` lets CuPy use the cuTENSOR backend for
+`tensordot`/`einsum` (the GPU B-spline / bias-field path in `linumpy.gpu.bspline`).
+cuTENSOR ships with the CUDA toolkit, so no extra install is needed.
+
+The Nextflow pipelines expose this via the `cupy_accelerators` param (default
+`'cub,cutensor'`), exported as `CUPY_ACCELERATORS` into every task:
+
+```bash
+# Default (cuTENSOR enabled)
+nextflow run workflows/reconst_3d/soct_3d_reconst.nf ...
+
+# Fall back to CuPy's built-in default
+nextflow run workflows/reconst_3d/soct_3d_reconst.nf ... --cupy_accelerators cub
+```
+
+Outside Nextflow, set the variable directly:
+
+```bash
+CUPY_ACCELERATORS=cub,cutensor linum-correct-bias-field ...
+```
+
+It only affects CuPy's `tensordot`/`einsum`; FFT phase correlation, morphology,
+Gaussian filtering, and N4 already run on dedicated CuPy/cuFFT kernels regardless.
+
+---
+
 ## Multi-GPU Systems
 
 ```bash
 # Show status of all GPUs
-linum_gpu_info.py --status
+linum-gpu-info --status
 
 # Select best GPU (most free memory)
-linum_gpu_info.py --select-best
+linum-gpu-info --select-best
 
 # Use specific GPU via environment
 CUDA_VISIBLE_DEVICES=1 nextflow run pipeline.nf --use_gpu true
@@ -229,18 +205,21 @@ print(f"GPU memory used: {mempool.used_bytes() / 1e9:.2f} GB")
 ```bash
 nvidia-smi
 python -c "import cupy; print(cupy.cuda.runtime.getDeviceCount())"
-linum_gpu_info.py
+linum-gpu-info
 ```
 
-### JAX CUDA Issues
+### BaSiCPy / PyTorch CUDA Issues
+
+If `linum-fix-illumination-3d` falls back to CPU unexpectedly, verify the
+PyTorch CUDA build is installed and visible:
 
 ```bash
-# Run the fix script
-source shell_scripts/fix_jax_cuda_plugin.sh
-
-# Or check diagnostics
-linum_diagnose_pipeline.py --debug-cuda
+python -c "import torch; print(torch.cuda.is_available(), torch.cuda.get_device_name(0))"
+linum-diagnose-pipeline --debug-cuda
 ```
+
+Reinstall PyTorch from the matching CUDA index URL (see the BaSiCPy section
+above) if `torch.cuda.is_available()` returns `False`.
 
 ### Out of Memory
 
@@ -282,4 +261,64 @@ from linumpy.gpu.fft_ops import fft2, ifft2, phase_correlation
 from linumpy.gpu.interpolation import resize, affine_transform
 from linumpy.gpu.morphology import binary_closing, gaussian_filter
 from linumpy.gpu.array_ops import normalize_percentile, clip_percentile
+from linumpy.gpu.zarr_io import read_zarr_to_gpu
 ```
+
+---
+
+## Fast zarr → GPU loading
+
+For zarr arrays on local NVMe, `linumpy.gpu.zarr_io.read_zarr_to_gpu` is the recommended entry point. It dispatches to the fastest backend available at runtime:
+
+```python
+from linumpy.gpu.zarr_io import read_zarr_to_gpu
+
+dev = read_zarr_to_gpu("/scratch_nvme/volume.zarr")
+# dev is a cupy.ndarray
+```
+
+Backend implementations live in their own modules:
+
+- `linumpy.gpu.kvikio_zarr` — kvikio / GPUDirect Storage reader (uncompressed zarr v2/v3 only).
+
+Selection order (when `prefer="auto"`):
+
+1. **kvikio (GPUDirect Storage, native mode)** — chunks DMA'd directly from NVMe into GPU memory. Fastest. Requires `kvikio` installed, GDS native mode enabled (`/etc/cufile.json`: `allow_compat_mode=false`), and an uncompressed zarr.
+2. **`zarr.config.enable_gpu()`** — host I/O with on-host decode, single H→D copy. Works for any zarr (compressed or not) and is the automatic fallback when GDS is unavailable, in compat mode, or the array is compressed.
+
+You can force a specific path with `prefer="kvikio"` or `prefer="zarr-gpu"`. The legacy `cupy.asarray(zarr.open_array(...)[:])` path is kept only as a reference baseline in `linum-benchmark-kvikio-zarr`.
+
+### Reference benchmark
+
+`scripts/utils/linum_benchmark_kvikio_zarr.py` measures all three paths. On a 16 GiB float32 zarr v3 (256³ chunks) on local NVMe ext4 with an RTX A6000:
+
+| Path | Cold | Warm |
+|---|---|---|
+| kvikio (GDS native) | 8.2 GiB/s | **9.9 GiB/s** |
+| `zarr.config.enable_gpu()` | 6.3 GiB/s | 7.1 GiB/s |
+| `zarr → numpy → cupy.asarray` | 1.1 GiB/s | 2.8 GiB/s |
+
+In compat mode (GDS bounce-buffer), kvikio drops to ~4 GiB/s — slower than the `zarr-gpu` path. The auto selector detects this via `kvikio.defaults.compat_mode()` and prefers `zarr-gpu` in that case.
+
+### Installing the GDS path
+
+```bash
+# CuPy + linumpy GPU support
+uv pip install 'linumpy[gpu]'           # CUDA 13.x (default)
+uv pip install 'linumpy[gpu-cuda12]'    # CUDA 12.x
+
+# kvikio (optional, only needed for the GDS fast path)
+uv pip install 'linumpy[gds]'           # CUDA 13.x (default)
+uv pip install 'linumpy[gds-cuda12]'    # CUDA 12.x
+```
+
+### Enabling native GDS
+
+Native GDS additionally requires:
+
+- A CUDA-aware filesystem on the source path (ext4 / xfs on local NVMe is fine; NFS, overlayfs, encrypted FS are not).
+- `/etc/cufile.json`: `properties.use_compat_mode = false`.
+- IOMMU disabled or in passthrough (`amd_iommu=off iommu=off` on AMD; `intel_iommu=off` on Intel).
+- nvidia-fs DKMS module loaded with matching ABI; verify `dmesg | grep nvidia_fs` shows no "no extended symbol version" warnings after driver/kernel updates.
+
+If any of these are missing, kvikio silently falls back to a POSIX bounce-buffer (compat mode) and `read_zarr_to_gpu` will route around it.

--- a/docs/LIBRARY_MODULES.md
+++ b/docs/LIBRARY_MODULES.md
@@ -1,854 +1,217 @@
-# Library Modules Documentation
+# Library Modules
 
+A concise map of the `linumpy` Python package. Use this page to find which
+subpackage owns what, then follow the auto-generated [API
+reference](api/linumpy/index) for full signatures and docstrings.
 
----
-
-## Overview
-
-The linumpy library provides Python modules for microscopy data processing. This document describes the main modules and their functionality.
-
----
-
-## Module Structure
+## Package layout
 
 ```
 linumpy/
-├── _thread_config.py      # CPU thread management
-├── __init__.py
-├── io/                    # Input/Output modules (zarr, allen, npz, thorlabs,
-│                          #   test_data, slice_config, data_io)
-├── gpu/                   # GPU acceleration modules
-├── microscope/            # Microscope-specific modules (oct)
-├── preproc/               # Preprocessing modules (icorr, normalization,
-│                          #   resampling, xyzcorr)
-├── psf/                   # Point spread function
-├── shifts/                # XY shift CSV utilities
-├── stitching/             # Image stitching (registration, motor, stacking,
-│                          #   interpolation, topology, mosaic_grid, ...)
-├── utils/                 # Utility modules (io, metrics, orientation,
-│                          #   image_quality, visualization)
-├── reconstruction.py      # Core reconstruction
-├── segmentation.py        # Segmentation tools
-└── utils_images.py        # Image utilities
+├── cli/             # argparse helpers shared by linum_* scripts
+├── config/          # thread/process limits (BLAS, OpenMP, threadpoolctl)
+├── geometry/        # crop, galvo correction, interface detection, resampling
+├── gpu/             # CuPy-backed FFT, morphology, B-spline, N4, registration
+├── imaging/         # orientation, overlays, simple transforms, visualization
+├── intensity/       # attenuation, bias-field, normalization, PSF model,
+│                    #   vignette, intensity conversion
+├── io/              # OME-Zarr I/O, slice-config, ThorLabs raw, test data
+├── metrics/         # PipelineMetrics + per-step metric collectors
+├── microscope/      # OCT-specific helpers
+├── mosaic/          # mosaic-grid layout, motor positions, stacking,
+│                    #   interpolation, blending, discovery
+├── psf/             # PSF extraction and synthetic generation
+├── reference/       # Allen brain atlas helpers
+├── registration/    # phase correlation, SimpleITK, manual, refinement
+├── segmentation/    # brain tissue segmentation
+└── stack_alignment/ # shifts CSV I/O, unit detection, filtering
 ```
 
----
+## Subpackage cheat sheet
 
-## I/O Modules (`linumpy.io`)
+### `linumpy.io`
 
-### zarr.py - OME-Zarr I/O
+OME-Zarr is the canonical on-disk format. Two writers are provided:
 
-Read and write OME-Zarr format files.
+* `OmeZarrWriter` — generic chunked writer with power-of-2 pyramid levels.
+* `AnalysisOmeZarrWriter` — writes analysis-friendly resolution levels
+  (10/25/50/100 µm) for the final 3D volume.
 
-```python
-from linumpy.io.zarr import read_omezarr, save_omezarr, OmeZarrWriter, AnalysisOmeZarrWriter
-
-# Read OME-Zarr
-image, resolution = read_omezarr("input.ome.zarr")
-# image: dask.array.Array
-# resolution: tuple (z, x, y) in mm/pixel
-
-# Save OME-Zarr
-save_omezarr(image, "output.ome.zarr", resolution, chunks=(10, 128, 128))
-
-# Write large volumes incrementally (traditional power-of-2 pyramid)
-writer = OmeZarrWriter("output.ome.zarr", shape, chunks, dtype)
-writer[0:10] = data_slice
-writer.finalize(resolution, n_levels=5)  # 2x downsampling per level
-
-# Write with analysis-optimized resolutions (10, 25, 50, 100 µm)
-writer = AnalysisOmeZarrWriter("output.ome.zarr", shape, chunks, dtype)
-writer[0:10] = data_slice
-writer.finalize(resolution, [10, 25, 50, 100])  # or use default
-writer.finalize(resolution)  # defaults to [10, 25, 50, 100] µm
-```
-
-### allen.py - Allen Brain Atlas
-
-Download and access Allen Brain Atlas data.
+Common entry points:
 
 ```python
-from linumpy.io.allen import download_allen_atlas
-
-# Download atlas
-download_allen_atlas(output_dir)
-```
-
-### npz.py - NPZ Files
-
-Handle NumPy compressed archives.
-
-```python
-from linumpy.io.npz import load_npz, save_npz
-
-data = load_npz("data.npz")
-save_npz("output.npz", array)
-```
-
-### thorlabs.py - Thorlabs Files
-
-Read Thorlabs microscope data formats.
-
-```python
-from linumpy.io.thorlabs import read_thorlabs
-
-data = read_thorlabs("thorlabs_file")
-```
-
-### test_data.py - Test Data
-
-Access test datasets for development.
-
-```python
+from linumpy.io.zarr import read_omezarr, read_omezarr_array, save_omezarr, OmeZarrWriter, AnalysisOmeZarrWriter
 from linumpy.io.test_data import get_data
-
-# Get path to test data
-raw_tiles_path = get_data('raw_tiles')
+from linumpy.io import slice_config        # slice_config.json reader/writer
+from linumpy.io.thorlabs import ThorImageOCT
 ```
 
-### slice_config.py - Slice Config I/O
+`read_omezarr(path, level=0)` returns a `(zarr.Array, voxel_size)` tuple (lazy).
+`read_omezarr_array(path, level=0, use_gpu=False)` is the high-level entry
+point: it materialises the requested level into memory and returns
+`(array, voxel_size)`. With ``use_gpu=False`` (default) the array is a
+``numpy.ndarray``; with ``use_gpu=True`` it dispatches through
+[`linumpy.gpu.zarr_io.read_zarr_to_gpu`](GPU_ACCELERATION.md) and returns a
+``cupy.ndarray`` (kvikio/GPUDirect Storage when available, otherwise the
+``zarr.config.enable_gpu`` fallback). Voxel size is ordered to match the array
+axes (Z, Y, X for 3D volumes; Y, X for 2D mosaics).
 
-Shared helpers for reading, writing, and stamping `slice_config.csv` — the
-per-slice trace file threaded through the reconstruction pipeline. Each
-pipeline stage that makes a per-slice decision (quality assessment, rehoming
-correction, auto-exclusion, missing-slice interpolation) stamps its flag
-columns via this module and hands the enriched file to the next stage.
+See [Mosaic Grid Format](MOSAIC_GRID_FORMAT.md) and
+[Slice Config Feature](SLICE_CONFIG_FEATURE.md) for format details.
 
-```python
-from linumpy.io.slice_config import (
-    CANONICAL_COLUMNS,  # list of pipeline decision columns
-    read,               # load slice_config.csv as dict keyed by slice_id
-    write,              # write dict back to CSV with canonical column order
-    stamp,              # update per-slice flags (use, auto_excluded, etc.) and write
-    merge_fragments,    # merge per-slice manifest fragments into a single CSV
-    force_skip_slices,  # return set of slice_ids where use=false or auto_excluded=true
-)
-```
+### `linumpy.cli` and `linumpy.config`
 
-The module does not implement file locking; concurrency safety is provided by
-Nextflow's channel discipline (each process receives an immutable copy; merges
-happen in a single downstream process).
+`linumpy.cli.args` provides `add_overwrite_arg`, `add_processes_arg`,
+`parse_processes_arg`, `assert_output_exists`, and `get_available_cpus`
+(honours `LINUMPY_MAX_CPUS` / `LINUMPY_RESERVED_CPUS` env vars).
 
-### data_io.py - Slicer Data I/O
+`linumpy.config.threads` configures BLAS/OpenMP/threadpoolctl thread caps and
+is imported as a side-effect at the top of every `linum_*` script (before
+NumPy/SciPy).
 
-Legacy readers for slicer-format volumes, NIfTI files and tile metadata.
+### `linumpy.metrics`
 
-```python
-from linumpy.io.data_io import (
-    listSlicesInDir,
-    getSliceListIndices,
-    load_volume,
-    loadTiffImage,
-    saveImage,
-)
-```
-
----
-
-## Microscope Module (`linumpy.microscope`)
-
-### oct.py - OCT Tile Reading
-
-Read raw OCT tiles with metadata and optional corrections.
+Structured metrics collected at every pipeline stage and aggregated into
+`PipelineMetrics`. Per-step collectors live alongside the dataclass.
 
 ```python
-from linumpy.microscope.oct import OCT
-
-# Open tile
-tile = OCT("/path/to/tile_x00_y00_z00")
-
-# Access properties
-shape = tile.shape           # (z, x, y)
-resolution = tile.resolution # (res_z, res_x, res_y)
-dimension = tile.dimension   # Physical dimensions
-position = tile.position     # Stage position (if available)
-
-# Read data with corrections
-data = tile.load_image(
-    crop=True,              # Crop galvo return region
-    fix_galvo_shift=True,   # Auto-detect and fix galvo artifacts
-    fix_camera_shift=False  # Fix camera timing shift (old data)
-)
-```
-
-**Properties:**
-- `shape`: Data shape (z, x, y)
-- `resolution`: Pixel size in mm
-- `dimension`: Physical dimensions in mm
-- `position`: Stage position (x, y, z) in mm
-- `position_available`: Whether position metadata exists
-
-**load_image() Parameters:**
-- `crop`: Remove extra pixels from galvo return
-- `fix_galvo_shift`: 
-  - `True`: Auto-detect artifact and fix if confident (≥0.3 confidence)
-  - `int`: Apply specific shift value
-  - `False`: No correction
-- `fix_camera_shift`: Correct camera timing offset (legacy data)
-
----
-
-## Preprocessing Modules (`linumpy.preproc`)
-
-### normalization.py - Intensity Normalization
-
-Normalize OCT volume intensities based on agarose background.
-
-```python
-from linumpy.preproc.normalization import normalize_volume
-
-# Normalize volume intensities
-# agarose_mask: 2D binary mask indicating agarose regions
-normalized, background_thresholds = normalize_volume(
-    vol,                    # Input volume (Z, X, Y)
-    agarose_mask,           # 2D mask for agarose detection
-    percentile_max=99.9     # Clip values above this percentile
-)
-```
-
-### icorr.py - Illumination Correction
-
-Correct illumination inhomogeneity.
-
-```python
-from linumpy.preproc.icorr import estimate_illumination, apply_illumination_correction
-
-# Estimate illumination profile
-profile = estimate_illumination(image)
-
-# Apply correction
-corrected = apply_illumination_correction(image, profile)
-```
-
-### xyzcorr.py - XYZ Corrections
-
-Apply spatial corrections including galvo shift detection and correction.
-
-```python
-from linumpy.preproc.xyzcorr import (
-    detect_galvo_shift,
-    detect_galvo_for_slice,
-    detect_galvo_artifact_presence,
-    fix_galvo_shift,
-    findTissueInterface,
-    cropVolume
-)
-
-# Detect galvo shift with confidence score
-aip = volume.mean(axis=0)  # Average intensity projection
-shift, confidence = detect_galvo_shift(
-    aip, 
-    n_pixel_return=40,      # Number of pixels in galvo return region
-    return_confidence=True  # Return confidence score (0-1)
-)
-
-# Only apply fix if confident (artifact is present)
-if confidence >= 0.3:
-    corrected = fix_galvo_shift(volume, shift=shift, axis=1)
-
-# Or apply with known shift value
-corrected = fix_galvo_shift(volume, shift=15, axis=1)
-
-# For slice-level detection (samples multiple tiles, skips background)
-shift, confidence = detect_galvo_for_slice(
-    tiles,                  # zarr array of tiles
-    n_extra=40,             # Number of extra pixels from galvo return
-    threshold=0.6,          # Minimum confidence threshold
-    n_samples=5,            # Number of tiles to sample
-    min_intensity=20.0      # Skip tiles with mean intensity below this
-)
-
-# For batch processing: check artifact presence separately
-presence_score = detect_galvo_artifact_presence(
-    aip,
-    n_pixel_return=40,
-    detected_shift=shift
-)
-```
-
-**Galvo Shift Detection:**
-
-The galvo mirror in OCT systems can cause horizontal banding artifacts when the galvo return region is not at the edge of the raw tile data. The detection system has three parts:
-
-1. **`detect_galvo_shift()`** - Finds *where* the galvo return boundary is located
-   - Analyzes average A-line intensity profile
-   - Searches for the shift that maximizes boundary discontinuities
-   - Returns shift value (in pixels) and optional confidence score
-
-2. **`detect_galvo_for_slice(tiles, n_extra, ...)`** - Slice-level detection
-   - Samples tiles from the center of the mosaic (more likely to contain tissue)
-   - Skips background tiles with low mean intensity
-   - Returns the detection with highest confidence
-   - Returns `(0, confidence)` if no artifact detected above threshold
-
-**Confidence Score Interpretation (0-1):**
-| Score | Meaning | Action |
-|-------|---------|--------|
-| < 0.5 | No clear artifact detected | Skip correction |
-| ≥ 0.5 | Galvo artifact likely present | Apply correction |
-| > 0.7 | Clear galvo artifact | High confidence |
-
-**Key Algorithm Details:**
-- Uses **gradient-based detection** to find intensity discontinuities
-- Finds pairs of high gradients separated by exactly `n_pixel_return` pixels
-- Checks B-scan subregions for subtle artifacts only visible in parts of the tile
-- Validates using peak dominance, boundary gradient ranking, and intensity contrast
-- Default threshold: 0.6 (configurable via `galvo_threshold` parameter)
-
-### resampling.py - Mosaic Grid Resampling
-
-Resample mosaic grid volumes to a target isotropic resolution, processing tile-by-tile to avoid loading the full volume into memory.
-
-```python
-from linumpy.preproc.resampling import resample_mosaic_grid
-
-# Resample to 10 µm isotropic
-resample_mosaic_grid(
-    vol,                # Dask/Zarr array with chunk structure (Z, nx*h, ny*w)
-    source_res,         # Source resolution (res_z, res_y, res_x)
-    target_res_um=10.0, # Target isotropic resolution in µm
-    n_levels=5,         # Number of output pyramid levels
-    out_path="output.ome.zarr"
-)
-```
-
----
-
-## PSF Module (`linumpy.psf`)
-
-### psf_estimator.py - PSF Estimation
-
-Estimate and model point spread functions.
-
-```python
-from linumpy.psf.psf_estimator import estimate_psf, apply_deconvolution
-
-# Estimate PSF from data
-psf = estimate_psf(image)
-
-# Apply deconvolution
-deconvolved = apply_deconvolution(image, psf)
-```
-
----
-
-## Stitching Module (`linumpy.stitching`)
-
-### registration.py - Image Registration
-
-Register images using various methods.
-
-```python
-from linumpy.stitching.registration import (
-    register_2d_images_sitk,
-    apply_transform,
-    pairWisePhaseCorrelation
-)
-
-# Get initial translation estimate using phase correlation
-deltas = pairWisePhaseCorrelation(fixed_image, moving_image)
-initial_translation = (deltas[1], deltas[0])  # (x, y) order for SimpleITK
-
-# Register 2D images with phase correlation initialization
-transform, moving_registered, error = register_2d_images_sitk(
-    fixed_image, 
-    moving_image,
-    metric='MSE',              # MSE, CC, AntsCC, MI
-    method='affine',           # affine, euler, translation
-    max_iterations=2500,
-    grad_mag_tol=1e-6,
-    moving_mask=None,
-    fixed_mask=None,
-    return_3d_transform=True,
-    initial_translation=initial_translation,  # Optional: phase correlation result
-    initial_step=None          # Optional: optimizer step size (auto-reduced with initial_translation)
-)
-
-# Apply transform to volume
-transformed = apply_transform(volume, transform)
-```
-
-**Note:** When `initial_translation` is provided, the optimizer uses a smaller step size (1.0 vs 4.0 pixels) to prevent drifting away from the correct solution.
-
-### stitch_utils.py - Stitching Utilities
-
-Helper functions for stitching operations.
-
-```python
-from linumpy.stitching.stitch_utils import (
-    compute_overlap,
-    blend_images
-)
-```
-
-### topology.py - Mosaic Topology
-
-Manage tile arrangements and topology.
-
-```python
-from linumpy.stitching.topology import (
-    build_topology_graph,
-    find_optimal_path
-)
-```
-
-### motor.py - Motor-Position Tile Placement
-
-Compute tile pixel positions from motor grid geometry (regular grid with configurable overlap, scale, and rotation).
-
-```python
-from linumpy.stitching.motor import compute_motor_positions
-
-positions, step_y, step_x = compute_motor_positions(
-    nx=3,                   # Number of tiles in X
-    ny=3,                   # Number of tiles in Y
-    tile_shape=(100, 512, 512),
-    overlap_fraction=0.2,
-    scale_factor=1.0,       # Scale step size (default: no scaling)
-    rotation_deg=0.0        # Global grid rotation
-)
-# positions: list of (row_pos, col_pos) pixel positions
-```
-
-### stacking.py - 3D Slice Stacking Utilities
-
-Z-overlap detection between consecutive slices using normalized cross-correlation.
-
-```python
-from linumpy.stitching.stacking import find_z_overlap
-
-best_overlap, best_corr = find_z_overlap(
-    fixed_vol,               # Bottom (fixed) slice volume (Z, Y, X)
-    moving_vol,              # Top (moving) slice volume (Z, Y, X)
-    slicing_interval_mm=0.05,
-    search_range_mm=0.1,
-    resolution_um=3.5
-)
-# best_overlap: optimal overlap in Z voxels
-# best_corr: correlation score at optimal overlap
-```
-
-### interpolation.py - Missing Slice Interpolation
-
-Z-aware morphing interpolation for missing serial sections. The primary entry
-point is `interpolate_z_morph(vol_before, vol_after)`, which warps the two
-boundary planes via fractional affine transforms (`T**alpha`) and cross-fades
-them. Falls back to `interpolate_weighted` when quality gates fail.
-
-```python
-from linumpy.stitching.interpolation import interpolate_z_morph
-
-volume, diagnostics = interpolate_z_morph(vol_before, vol_after)
-# vol_before, vol_after: 3D neighbours on either side of a gap, shape (Z, Y, X)
-# Returns: interpolated volume (shape matching min(nz_before, nz_after), H, W)
-#          and a JSON-serialisable diagnostics dict (method_used, pre/post
-#          NCC, affine_determinant, fallback_reason, ...).
-```
-
-See `docs/SLICE_INTERPOLATION_FEATURE.md` for the physical model.
-
-### manual_registration.py - Manual Registration
-
-GUI-based manual registration tools.
-
-```python
-from linumpy.stitching.manual_registration import ManualRegistrationGUI
-```
-
-### FileUtils.py - File Utilities
-
-File handling utilities for stitching.
-
-```python
-from linumpy.stitching.FileUtils import (
-    list_tiles,
-    parse_tile_name
-)
-```
-
-### mosaic_grid.py - Mosaic Grid Class
-
-The `MosaicGrid` class manages 2D mosaic grid images (a 2D image containing
-all tiles for a slice without overlap). Provides tile iteration, affine tile
-placement, and stitching utilities including diffusion-based blending.
-
-```python
-from linumpy.stitching.mosaic_grid import MosaicGrid, getDiffusionBlendingWeights
-
-mg = MosaicGrid(image, tile_shape=(512, 512), overlap_fraction=0.2)
-stitched = mg.stitch(blending_method='diffusion')
-
-# Blending weights helper (also used standalone)
-weights = getDiffusionBlendingWeights(mask_fixed, mask_moving, factor=2)
-```
-
----
-
-## Utilities Module (`linumpy.utils`)
-
-### io.py - I/O Utilities
-
-Command-line argument helpers.
-
-```python
-from linumpy.utils.io import (
-    add_overwrite_arg,
-    add_processes_arg,
-    assert_output_exists,
-    get_available_cpus,
-    parse_processes_arg
-)
-
-# Add standard arguments to parser
-parser = argparse.ArgumentParser()
-add_overwrite_arg(parser)
-add_processes_arg(parser)
-
-# Parse and validate
-args = parser.parse_args()
-n_processes = parse_processes_arg(args.n_processes)
-assert_output_exists(args.output, parser, args)
-
-# Get available CPUs (respects LINUMPY_MAX_CPUS and LINUMPY_RESERVED_CPUS env vars)
-available = get_available_cpus()
-```
-
-#### CPU Core Management
-
-The `get_available_cpus()` function respects environment variables for limiting CPU usage:
-
-```python
-import os
-from linumpy.utils.io import get_available_cpus
-
-# Default: uses all CPUs minus 1
-cpus = get_available_cpus()  # e.g., 15 on a 16-core system
-
-# With LINUMPY_RESERVED_CPUS=4
-os.environ['LINUMPY_RESERVED_CPUS'] = '4'
-cpus = get_available_cpus()  # e.g., 12 on a 16-core system
-
-# With LINUMPY_MAX_CPUS=8 (takes precedence)
-os.environ['LINUMPY_MAX_CPUS'] = '8'
-cpus = get_available_cpus()  # 8 (or total if less than 8)
-```
-
-### metrics.py - Pipeline Quality Metrics
-
-Collect, save, and aggregate quality metrics from pipeline steps.
-
-```python
-from linumpy.utils.metrics import (
+from linumpy.metrics import (
     PipelineMetrics,
     collect_normalization_metrics,
-    collect_xy_transform_metrics,
     collect_pairwise_registration_metrics,
-    collect_interface_crop_metrics,
-    collect_psf_compensation_metrics,
-    collect_stack_metrics,
-    collect_stitch_3d_metrics,
     aggregate_metrics,
-    compute_summary_statistics
-)
-
-# Manual metrics collection
-metrics = PipelineMetrics('my_step', output_dir)
-metrics.add_info('input', input_path, 'Input file path')
-metrics.add_metric('error', 0.05, unit='pixels', threshold_name='registration_error')
-metrics.save()
-
-# Use step-specific collectors (recommended - simpler)
-collect_normalization_metrics(vol, agarose_mask, otsu_thresh, bg_thresh, output_path)
-collect_pairwise_registration_metrics(error, tx, ty, rot, best_z, expected_z, output_path)
-
-# Aggregate metrics from pipeline run
-aggregated = aggregate_metrics('/path/to/pipeline/output')
-# Returns: {'step_name': [list of metrics dicts], ...}
-
-# Compute summary statistics
-summary = compute_summary_statistics(aggregated['pairwise_registration'])
-# Returns: {'count': N, 'status_counts': {...}, 'metric_name': {'mean': ..., 'std': ...}}
-```
-
-**Available Threshold Names:**
-| Name | Warning | Error | Higher is Better |
-|------|---------|-------|------------------|
-| `registration_error` | 0.05 | 0.15 | No |
-| `translation_magnitude` | 30.0 | 50.0 | No |
-| `rotation_degrees` | 1.0 | 2.0 | No |
-| `correlation` | 0.7 | 0.5 | Yes |
-| `mask_coverage` | 0.05 | 0.01 | Yes |
-| `agarose_coverage` | 0.05 | 0.01 | Yes |
-| `rms_residual` | 5.0 | 15.0 | No |
-| `z_offset_std` | 10.0 | 25.0 | No |
-| `z_offset_range` | 15.0 | 30.0 | No |
-
-## XY Shifts Module (`linumpy.shifts`)
-
-### shifts/utils.py - XY Shift Utilities
-
-Load and process XY shift CSV files for inter-slice alignment.
-
-```python
-from linumpy.shifts.utils import load_shifts_csv, detect_shift_units
-
-# Load shifts and compute cumulative positions
-cumsum, all_ids = load_shifts_csv("shifts_xy.csv")
-# cumsum: {slice_id: (cumulative_dx_mm, cumulative_dy_mm)}
-# all_ids: sorted list of all slice IDs
-
-# Detect resolution units (mm vs µm)
-res_x_um, res_y_um = detect_shift_units(resolution)
-```
-
-### orientation.py - Volume Orientation
-
-Parse 3-letter orientation codes and compute axis permutations/flips for RAS alignment.
-
-```python
-from linumpy.utils.orientation import parse_orientation_code
-
-# Parse orientation for RAS alignment
-axis_permutation, axis_flips = parse_orientation_code('PIR')
-# axis_permutation: source indices for each target dimension
-# axis_flips: +1 (keep) or -1 (flip) per axis after permutation
-
-# Example: PIR → (1, 2, 0), (-1, 1, -1)
-# Example: SRA → (0, 1, 2), (1, 1, 1)  # identity
-```
-
-**Supported letters:** R/L (Right/Left), A/P (Anterior/Posterior), S/I (Superior/Inferior)
-
-### image_quality.py - Image Quality Assessment
-
-CPU-based image quality metrics for slice analysis.
-
-```python
-from linumpy.utils.image_quality import (
-    compute_ssim_2d,
-    compute_ssim_3d,
-    compute_edge_score,
-    compute_variance_score,
-    assess_slice_quality,
-)
-
-# Compare two 3D volumes
-ssim = compute_ssim_3d(vol1, vol2)
-
-# Assess overall quality of a slice relative to its neighbors
-quality, metrics = assess_slice_quality(
-    vol,        # The slice to assess
-    vol_before, # Previous slice
-    vol_after   # Next slice
-)
-# quality: float in [0, 1]
-# metrics: dict with ssim, edge_score, variance_score, etc.
-```
-
-For GPU-accelerated versions see `linumpy.gpu.image_quality`.
-
-### visualization.py - Orthogonal View Screenshots
-
-Save orthogonal (XY, XZ, YZ) views of a 3D volume as a figure.
-
-```python
-from linumpy.utils.visualization import save_orthogonal_views, save_annotated_views
-
-# Basic orthogonal view
-save_orthogonal_views(
-    image,              # 3D volume (Z, X, Y)
-    "view.png",
-    z_slice=None,       # Default: center
-    x_slice=None,
-    y_slice=None,
-    cmap='magma',
-    percentile_max=99.9
-)
-
-# Annotated view with Z-slice index labels
-save_annotated_views(
-    image,
-    "annotated_view.png",
-    n_slices=50,        # Number of input slices (for label spacing)
-    slice_ids=None,     # Optional explicit slice IDs
-    font_size=7,
-    label_every=1,
-    show_lines=False
+    compute_summary_statistics,
 )
 ```
 
----
+See [Reconstruction Diagnostics](RECONSTRUCTION_DIAGNOSTICS.md).
 
-## Core Modules
+### `linumpy.geometry`
 
-### reconstruction.py - Core Reconstruction
+Pixel/world geometry, plus OCT-specific corrections:
 
-Core reconstruction functions.
+* `geometry.galvo` — `detect_galvo_shift`, `fix_galvo_shift`,
+  `detect_galvo_for_slice` (B-scan galvo artifact correction).
+* `geometry.interface` — tissue-surface detection.
+* `geometry.crop` — crop volumes around the tissue interface.
+* `geometry.resampling` — resample mosaic grids and 3D volumes to a target
+  isotropic resolution.
 
-```python
-from linumpy.reconstruction import (
-    get_tiles_ids,
-    get_mosaic_info,
-    getLargestCC
-)
+### `linumpy.intensity`
 
-# Get tile IDs from directory
-tiles, tile_ids = get_tiles_ids(directory, z=None)
-# tiles: list of Path objects
-# tile_ids: list of (mx, my, mz) tuples
+Intensity-domain corrections used during preprocessing.
 
-# Get mosaic information
-mosaic_info = get_mosaic_info(
-    directory, 
-    z=0, 
-    overlap_fraction=0.2,
-    use_stage_positions=True
-)
-# Returns dict with:
-# - mosaic_shape, tile_positions, etc.
-# - mosaic_xmin_mm, mosaic_ymin_mm
-# - tile_resolution
+* `intensity.attenuation` — depth-dependent attenuation modelling.
+* `intensity.bias_field` — N4 bias-field correction (CPU SimpleITK and the
+  GPU port; `n4_correct`, `n4_correct_per_section`, `compute_tissue_mask`).
+* `intensity.normalization` — per-slice histogram matching, Z-profile
+  smoothing, agarose flattening.
+* `intensity.psf_model` — `estimate_psf` and PSF-based deconvolution.
+* `intensity.vignette` — vignette/illumination flat-field correction.
 
-# Get largest connected component
-largest_cc = getLargestCC(binary_mask)
-```
+### `linumpy.mosaic`
 
-### segmentation.py - Segmentation
+Everything that turns a folder of tiles into a stacked 3D volume.
 
-Image segmentation tools.
+* `mosaic.grid` — `MosaicGrid` (pixel-space tile layout).
+* `mosaic.motor` — motor-position handling (`compute_motor_positions`).
+* `mosaic.stacking` — `find_z_overlap`, slab assembly utilities.
+* `mosaic.interpolation` — `interpolate_z_morph`, `interpolate_weighted`.
+* `mosaic.discovery` — discover tiles on disk.
+* `mosaic.overlap` — overlap-region utilities.
+* `mosaic.quick_stitch` — fast diagnostic stitching.
 
-```python
-from linumpy.segmentation import (
-    segment_tissue
-)
-```
+### `linumpy.registration`
 
-### utils_images.py - Image Utilities
+* `registration.phase_correlation` — masked phase correlation primitives.
+* `registration.sitk` — `register_2d_images_sitk`, `apply_transform`.
+* `registration.refinement` — `find_best_z`, `register_refinement`,
+  `gradient_magnitude_alignment`, `centre_of_mass_offset`.
+* `registration.transforms` — transform composition / decomposition / I/O.
+* `registration.manual` — manual landmark registration GUI.
 
-General image processing utilities.
+### `linumpy.gpu`
 
-```python
-from linumpy.utils_images import (
-    apply_xy_shift,
-    normalize_image
-)
+CuPy-backed versions of hot paths. Each public entry point either takes a
+`backend="cpu"|"gpu"|"auto"` flag or has an explicit `_gpu` suffix.
 
-# Apply XY shift to image
-shifted = apply_xy_shift(
-    image,       # Source image
-    reference,   # Reference (determines output shape)
-    dy,          # Y shift in pixels
-    dx           # X shift in pixels
-)
-```
+* `gpu.fft_ops`, `gpu.array_ops`, `gpu.morphology`, `gpu.interpolation`
+  — FFT, element-wise ops, morphology, interpolation primitives.
+* `gpu.bias_field`, `gpu.n4`, `gpu.bspline` — GPU N4 and B-spline grid.
+* `gpu.image_quality` — GPU image-quality metrics.
+* `gpu.registration`, `gpu.corrections` — GPU registration and correction
+  passes used by `linum_estimate_transform.py`,
+  `linum_normalize_intensities_per_slice.py`, etc.
+* `gpu.zarr_io` — high-level `read_zarr_to_gpu` dispatcher: picks the
+  fastest backend available (kvikio/GDS native → `zarr.config.enable_gpu`).
+* `gpu.kvikio_zarr` — kvikio / GPUDirect Storage backend for the dispatcher.
 
----
+See [GPU Acceleration](GPU_ACCELERATION.md) and [N4 GPU](N4_GPU.md).
 
-## Common Patterns
+### `linumpy.stack_alignment`
 
-### Reading and Processing a Mosaic Grid
+Shifts CSV utilities used to align serial sections.
 
 ```python
-from linumpy.io.zarr import read_omezarr, save_omezarr
-import numpy as np
-
-# Read
-image, resolution = read_omezarr("input.ome.zarr")
-
-# Process (example: normalize)
-data = image[:]  # Load into memory
-data = (data - np.min(data)) / (np.max(data) - np.min(data))
-
-# Save
-import dask.array as da
-save_omezarr(da.from_array(data), "output.ome.zarr", resolution)
+from linumpy.stack_alignment.io import load_shifts_csv, write_shifts_csv
+from linumpy.stack_alignment.units import detect_shift_units
+from linumpy.stack_alignment.filter import filter_outliers
 ```
 
-### Parallel Processing with Multiple Tiles
+See [Shifts File Format](SHIFTS_FILE_FORMAT.md).
 
-```python
-from linumpy.reconstruction import get_tiles_ids
-from linumpy.microscope.oct import OCT
-from tqdm.contrib.concurrent import process_map
+### `linumpy.imaging`
 
-def process_tile(tile_path):
-    tile = OCT(tile_path)
-    # Process tile...
-    return result
+Convenience helpers for figures and quick previews.
 
-tiles, tile_ids = get_tiles_ids(directory)
-results = process_map(process_tile, tiles, max_workers=8)
-```
+* `imaging.orientation` — anatomical-axis labelling.
+* `imaging.overlay` — overlay generation for diagnostics.
+* `imaging.transform` — 2D affine helpers.
+* `imaging.visualization` — matplotlib panels used by diagnostic scripts.
 
-### Registration Workflow
+### `linumpy.psf`
 
-```python
-from linumpy.io.zarr import read_omezarr
-from linumpy.stitching.registration import register_2d_images_sitk, apply_transform
+* `psf.extract` — extract PSF estimates from acquisitions.
+* `psf.synthetic` — synthetic PSF generators for tests.
 
-# Load images
-fixed, _ = read_omezarr("fixed.ome.zarr")
-moving, _ = read_omezarr("moving.ome.zarr")
+(Higher-level PSF model lives in `linumpy.intensity.psf_model`.)
 
-# Register
-transform, _, error = register_2d_images_sitk(
-    fixed[0],  # 2D slice
-    moving[0],
-    method='affine',
-    metric='MSE'
-)
+### `linumpy.reference`
 
-# Apply to full volume
-registered = apply_transform(moving, transform)
-```
+* `reference.allen` — download the Allen mouse atlas template, register a
+  3D volume to it, and produce RAS-aligned templates.
 
----
+### `linumpy.segmentation`
 
-## Type Hints
+* `segmentation.brain` — tissue / background segmentation in 3D OCT.
 
-Most functions include type hints for better IDE support:
+### `linumpy.microscope`
 
-```python
-def read_omezarr(path: str | Path) -> tuple[da.Array, tuple[float, ...]]:
-    ...
+* `microscope.oct.OCT` — OCT acquisition metadata wrapper.
 
-def apply_xy_shift(
-    image: np.ndarray,
-    reference: np.ndarray,
-    dy: float,
-    dx: float
-) -> np.ndarray:
-    ...
-```
+## How the pieces fit together
 
----
+A typical pipeline run wires these subpackages as follows:
 
-## Error Handling
+1. **Discovery** (`mosaic.discovery`) finds raw tiles on disk and reads
+   ThorLabs metadata via `io.thorlabs`.
+2. **Tile preprocessing** uses `geometry.galvo`, `intensity.vignette`,
+   `intensity.attenuation`, and `intensity.normalization`.
+3. **Mosaic assembly** builds 2D AIPs (`mosaic.grid`) and 3D mosaic grids
+   per slice, then writes OME-Zarr via `io.zarr`.
+4. **Stitching** uses `registration.phase_correlation` (CPU/GPU) plus
+   `stack_alignment` to compute and store shifts.
+5. **Stacking** matches consecutive slices with `registration.refinement`
+   and assembles the volume with `mosaic.stacking`.
+6. **Bias-field & global polish** run `intensity.bias_field` (with the
+   `gpu.n4` backend when CUDA is available) and `imaging.orientation` / RAS
+   alignment via `reference.allen`.
+7. **Diagnostics** use `metrics` collectors throughout; see
+   [Reconstruction Diagnostics](RECONSTRUCTION_DIAGNOSTICS.md).
 
-Functions typically raise standard Python exceptions:
+## See also
 
-```python
-try:
-    image, res = read_omezarr("nonexistent.ome.zarr")
-except FileNotFoundError:
-    print("File not found")
-except ValueError as e:
-    print(f"Invalid format: {e}")
-```
-
----
-
-## Dependencies
-
-Key dependencies used by the library:
-
-| Package | Purpose |
-|---------|---------|
-| `numpy` | Array operations |
-| `dask` | Lazy/parallel arrays |
-| `zarr` | Chunked array storage |
-| `SimpleITK` | Image registration |
-| `scikit-image` | Image processing |
-| `scipy` | Scientific computing |
-| `pandas` | Data manipulation |
-| `tqdm` | Progress bars |
+* Auto-generated API reference: [api/linumpy](api/linumpy/index.rst)
+* [Pipeline Overview](PIPELINE_OVERVIEW.md)
+* [Scripts Reference](SCRIPTS_REFERENCE.md)
+* [Nextflow Workflows](NEXTFLOW_WORKFLOWS.md)

--- a/linumpy/gpu/__init__.py
+++ b/linumpy/gpu/__init__.py
@@ -1,0 +1,430 @@
+"""
+GPU acceleration module for linumpy.
+
+This module provides GPU-accelerated versions of compute-intensive operations
+using CuPy. All functions have automatic fallback to CPU (NumPy) if:
+- CuPy is not installed
+- No CUDA-capable GPU is available
+- GPU memory is insufficient
+
+Usage::
+
+    from linumpy.gpu import GPU_AVAILABLE, get_array_module
+
+    # Check if GPU is available
+    if GPU_AVAILABLE:
+        print("GPU acceleration enabled")
+
+    # Get appropriate array module (cupy or numpy)
+    xp = get_array_module(use_gpu=True)
+
+    # Use GPU-accelerated functions
+    from linumpy.gpu.fft_ops import gpu_phase_correlation
+    from linumpy.gpu.interpolation import gpu_affine_transform
+    from linumpy.gpu.registration import GPUAcceleratedRegistration
+
+Configuration:
+    Set USE_GPU=false environment variable to disable GPU globally.
+"""
+
+import os
+import warnings
+from typing import Any
+
+# Check for GPU availability
+GPU_AVAILABLE = False
+CUPY_AVAILABLE = False
+GPU_DEVICE_NAME = "N/A"
+GPU_MEMORY_GB = 0
+
+# Allow disabling GPU via environment variable
+_USE_GPU_ENV = os.environ.get("LINUMPY_USE_GPU", "true").lower()
+_GPU_DISABLED_BY_ENV = _USE_GPU_ENV in ("false", "0", "no")
+
+if not _GPU_DISABLED_BY_ENV:
+    try:
+        import cupy as cp
+
+        # Test if CUDA is actually available
+        try:
+            # First, find the GPU with most free memory
+            n_devices = cp.cuda.runtime.getDeviceCount()
+
+            if n_devices > 0:
+                best_gpu_id = 0
+                best_free_memory = 0
+
+                for i in range(n_devices):
+                    with cp.cuda.Device(i):
+                        free, total = cp.cuda.runtime.memGetInfo()
+                        if free > best_free_memory:
+                            best_free_memory = free
+                            best_gpu_id = i
+
+                # Select the best GPU
+                cp.cuda.Device(best_gpu_id).use()
+
+                CUPY_AVAILABLE = True
+                GPU_AVAILABLE = True
+
+                # Get device info for selected GPU
+                device = cp.cuda.Device(best_gpu_id)
+                GPU_DEVICE_NAME = device.name if hasattr(device, "name") else f"GPU {device.id}"
+                mem_info = device.mem_info
+                GPU_MEMORY_GB = mem_info[1] / (1024**3)  # Total memory in GB
+
+                if n_devices > 1:
+                    # Only show message if there are multiple GPUs
+                    import sys
+
+                    print(
+                        f"Auto-selected GPU {best_gpu_id}: {GPU_DEVICE_NAME} ({best_free_memory / (1024**3):.1f} GB free)",
+                        file=sys.stderr,
+                    )
+            else:
+                CUPY_AVAILABLE = True
+                GPU_AVAILABLE = False
+
+        except cp.cuda.runtime.CUDARuntimeError as e:
+            warnings.warn(f"CuPy installed but CUDA not available: {e}", stacklevel=2)
+            CUPY_AVAILABLE = True
+            GPU_AVAILABLE = False
+
+    except ImportError:
+        pass
+else:
+    warnings.warn("GPU disabled via LINUMPY_USE_GPU environment variable", stacklevel=2)
+
+
+def get_array_module(use_gpu: bool = True) -> Any:
+    """
+    Get the appropriate array module (cupy or numpy).
+
+    Parameters
+    ----------
+    use_gpu : bool
+        Whether to use GPU if available.
+
+    Returns
+    -------
+    module
+        cupy if GPU available and use_gpu=True, else numpy
+    """
+    if use_gpu and GPU_AVAILABLE:
+        import cupy as cp
+
+        return cp
+    else:
+        import numpy as np
+
+        return np
+
+
+def to_gpu(array: Any) -> Any:
+    """
+    Transfer array to GPU if available.
+
+    Parameters
+    ----------
+    array : np.ndarray
+        Input array
+
+    Returns
+    -------
+    array
+        CuPy array if GPU available, else original numpy array
+    """
+    if GPU_AVAILABLE:
+        import cupy as cp
+
+        if isinstance(array, cp.ndarray):
+            return array
+        return cp.asarray(array)
+    return array
+
+
+def to_cpu(array: Any) -> Any:
+    """
+    Transfer array to CPU (numpy).
+
+    Parameters
+    ----------
+    array : array-like
+        Input array (numpy or cupy)
+
+    Returns
+    -------
+    np.ndarray
+        NumPy array
+    """
+    if GPU_AVAILABLE:
+        import cupy as cp
+
+        if isinstance(array, cp.ndarray):
+            return cp.asnumpy(array)
+    return array
+
+
+def is_cupy_array(array: Any) -> bool:
+    """Return True iff ``array`` is a CuPy ``ndarray``.
+
+    Importing CuPy is gated on availability so this stays cheap to call from
+    code paths that may be hit without CUDA.
+    """
+    if not GPU_AVAILABLE:
+        return False
+    try:
+        import cupy as cp
+    except ImportError:
+        return False
+    return isinstance(array, cp.ndarray)
+
+
+def gpu_info() -> Any:
+    """
+    Get information about GPU availability and configuration.
+
+    Returns
+    -------
+    dict
+        Dictionary with GPU information
+    """
+    return {
+        "gpu_available": GPU_AVAILABLE,
+        "cupy_installed": CUPY_AVAILABLE,
+        "device_name": GPU_DEVICE_NAME,
+        "memory_gb": GPU_MEMORY_GB,
+        "disabled_by_env": _GPU_DISABLED_BY_ENV,
+    }
+
+
+def print_gpu_info() -> None:
+    """Print GPU availability information."""
+    info = gpu_info()
+    print("=" * 50)
+    print("linumpy GPU Configuration")
+    print("=" * 50)
+    print(f"  GPU Available:     {info['gpu_available']}")
+    print(f"  CuPy Installed:    {info['cupy_installed']}")
+    print(f"  Device:            {info['device_name']}")
+    print(f"  Memory:            {info['memory_gb']:.1f} GB")
+    if info["disabled_by_env"]:
+        print("  NOTE: GPU disabled via environment variable")
+    print("=" * 50)
+
+
+def list_gpus() -> Any:
+    """
+    List all available GPUs with memory information.
+
+    Returns
+    -------
+    list of dict
+        List of GPU info dictionaries with keys:
+        - id: Device ID
+        - name: Device name
+        - total_gb: Total memory in GB
+        - free_gb: Free memory in GB
+        - used_gb: Used memory in GB
+        - utilization: Memory utilization (0-1)
+    """
+    if not CUPY_AVAILABLE:
+        return []
+
+    import cupy as cp
+
+    gpus = []
+    n_devices = cp.cuda.runtime.getDeviceCount()
+
+    for i in range(n_devices):
+        with cp.cuda.Device(i):
+            free, total = cp.cuda.runtime.memGetInfo()
+            device = cp.cuda.Device(i)
+            name = device.name if hasattr(device, "name") else f"GPU {i}"
+
+            gpus.append(
+                {
+                    "id": i,
+                    "name": name,
+                    "total_gb": total / (1024**3),
+                    "free_gb": free / (1024**3),
+                    "used_gb": (total - free) / (1024**3),
+                    "utilization": (total - free) / total,
+                }
+            )
+
+    return gpus
+
+
+def select_best_gpu(verbose: bool = True) -> Any:
+    """
+    Select the GPU with the most free memory.
+
+    This function queries all available GPUs and switches to the one
+    with the most free memory. Useful when running on multi-GPU systems
+    where one GPU may already be in use.
+
+    Parameters
+    ----------
+    verbose : bool
+        Print selection information
+
+    Returns
+    -------
+    int or None
+        Selected GPU ID, or None if no GPU available
+
+    Examples
+    --------
+    >>> from linumpy.gpu import select_best_gpu
+    >>> select_best_gpu()
+    Selected GPU 1: NVIDIA RTX A6000 (45.2 GB free / 48.0 GB total)
+    1
+    """
+    global GPU_AVAILABLE, GPU_DEVICE_NAME, GPU_MEMORY_GB
+
+    if not CUPY_AVAILABLE:
+        if verbose:
+            print("No GPU available (CuPy not installed)")
+        return None
+
+    import cupy as cp
+
+    gpus = list_gpus()
+
+    if not gpus:
+        if verbose:
+            print("No GPUs found")
+        return None
+
+    # Find GPU with most free memory
+    best_gpu = max(gpus, key=lambda g: g["free_gb"])
+    best_id = best_gpu["id"]
+
+    # Switch to best GPU
+    cp.cuda.Device(best_id).use()
+
+    # Update module globals
+    GPU_AVAILABLE = True
+    GPU_DEVICE_NAME = best_gpu["name"]
+    GPU_MEMORY_GB = best_gpu["total_gb"]
+
+    if verbose:
+        print(
+            f"Selected GPU {best_id}: {best_gpu['name']} "
+            f"({best_gpu['free_gb']:.1f} GB free / {best_gpu['total_gb']:.1f} GB total)"
+        )
+
+        if len(gpus) > 1:
+            print(f"  (Selected from {len(gpus)} available GPUs)")
+
+    return best_id
+
+
+def select_gpu(device_id: int, verbose: bool = True) -> Any:
+    """
+    Select a specific GPU by device ID.
+
+    Parameters
+    ----------
+    device_id : int
+        GPU device ID (0, 1, 2, ...)
+    verbose : bool
+        Print selection information
+
+    Returns
+    -------
+    int or None
+        Selected GPU ID, or None if invalid
+
+    Examples
+    --------
+    >>> from linumpy.gpu import select_gpu
+    >>> select_gpu(1)
+    Selected GPU 1: NVIDIA RTX A6000 (48.0 GB total)
+    1
+    """
+    global GPU_AVAILABLE, GPU_DEVICE_NAME, GPU_MEMORY_GB
+
+    if not CUPY_AVAILABLE:
+        if verbose:
+            print("No GPU available (CuPy not installed)")
+        return None
+
+    import cupy as cp
+
+    n_devices = cp.cuda.runtime.getDeviceCount()
+
+    if device_id < 0 or device_id >= n_devices:
+        if verbose:
+            print(f"Invalid GPU ID {device_id}. Available: 0-{n_devices - 1}")
+        return None
+
+    # Switch to specified GPU
+    cp.cuda.Device(device_id).use()
+
+    # Update module globals
+    with cp.cuda.Device(device_id):
+        _free, total = cp.cuda.runtime.memGetInfo()
+        device = cp.cuda.Device(device_id)
+        name = device.name if hasattr(device, "name") else f"GPU {device_id}"
+
+        GPU_AVAILABLE = True
+        GPU_DEVICE_NAME = name
+        GPU_MEMORY_GB = total / (1024**3)
+
+    if verbose:
+        print(f"Selected GPU {device_id}: {name} ({GPU_MEMORY_GB:.1f} GB total)")
+
+    return device_id
+
+
+def print_gpu_status() -> None:
+    """
+    Print detailed status of all available GPUs.
+
+    Shows memory usage for each GPU, highlighting the currently selected one.
+    """
+    if not CUPY_AVAILABLE:
+        print("No GPU available (CuPy not installed)")
+        return
+
+    import cupy as cp
+
+    gpus = list_gpus()
+    current_device = cp.cuda.Device().id
+
+    print("=" * 60)
+    print("GPU Status")
+    print("=" * 60)
+
+    for gpu in gpus:
+        marker = " *" if gpu["id"] == current_device else "  "
+        bar_width = 30
+        used_bars = int(gpu["utilization"] * bar_width)
+        bar = "█" * used_bars + "░" * (bar_width - used_bars)
+
+        print(f"{marker}GPU {gpu['id']}: {gpu['name']}")
+        print(f"    Memory: [{bar}] {gpu['utilization'] * 100:.1f}%")
+        print(f"    {gpu['used_gb']:.1f} GB used / {gpu['total_gb']:.1f} GB total ({gpu['free_gb']:.1f} GB free)")
+
+    print("=" * 60)
+    print("  * = currently selected")
+
+
+# Expose key components
+__all__ = [
+    "CUPY_AVAILABLE",
+    "GPU_AVAILABLE",
+    "GPU_DEVICE_NAME",
+    "GPU_MEMORY_GB",
+    "get_array_module",
+    "gpu_info",
+    "list_gpus",
+    "print_gpu_info",
+    "print_gpu_status",
+    "select_best_gpu",
+    "select_gpu",
+    "to_cpu",
+    "to_gpu",
+]

--- a/linumpy/gpu/bspline.py
+++ b/linumpy/gpu/bspline.py
@@ -1,0 +1,369 @@
+"""Tensor-product cubic B-spline scattered-data approximation.
+
+Provides a simple GPU/CPU primitive for fitting a smooth 3-D field to
+scattered (weighted) voxel samples on a regular control-point lattice
+and evaluating the resulting field at arbitrary voxel grids.
+
+Used by :mod:`linumpy.gpu.n4` for the bias-field B-spline update step,
+but kept generic so other smoothing/warp primitives can reuse it.
+
+The fit implements the single-level Lee-Wolberg-Shin (1997) B-spline
+approximation that ITK uses inside ``BSplineScatteredDataPointSetToImageFilter``
+(the engine of N4).  For each scattered sample p with value v_p the
+locally-optimal value at surrounding control point c is
+
+    phi_c(p) = w_c(p) * v_p / sum_d w_d(p)^2
+
+and the per-control-point coefficient is the squared-weight average
+
+    coeff[c] = sum_p w_c(p)^2 * phi_c(p) / sum_p w_c(p)^2
+             = sum_p gamma_p * w_c(p)^3 * v_p / S(p)
+               -------------------------------------
+                       sum_p gamma_p * w_c(p)^2
+
+where ``S(p) = sum_d w_d(p)^2`` and gamma_p folds in the per-voxel
+mask/weight.  Because the tensor-product basis is separable,
+``w_c(p)^k`` factorises across axes and S(p) factorises into a product
+of per-axis sums of squared basis weights, so the fit reduces to three
+contiguous tensor contractions — one through ``B^3`` for the numerator
+and one through ``B^2`` for the denominator.  This matches the ITK
+behaviour while remaining a single GPU-friendly tensordot chain.
+
+An earlier implementation used a Nadaraya-Watson kernel regression
+(``coeff[c] = sum_p w_c(p) * v_p / sum_p w_c(p)``).  That form has no
+implicit smoothness penalty and, at the dense control grids reached by
+later N4 fitting levels, lets the fit absorb tissue-scale features
+(e.g. white-matter contrast) into the bias estimate.  PSDB's squared
+weights regularise short-range support and recover the contrast.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from linumpy.gpu import GPU_AVAILABLE, get_array_module
+
+
+def _is_gpu_array(arr: Any) -> bool:
+    """Return True if *arr* is a CuPy ndarray (so callers can keep results on GPU)."""
+    try:
+        import cupy as cp
+    except ImportError:
+        return False
+    return isinstance(arr, cp.ndarray)
+
+
+# ---------------------------------------------------------------------------
+# Cubic B-spline basis
+# ---------------------------------------------------------------------------
+
+
+def _cubic_bspline_basis(t: Any, xp: Any) -> Any:
+    """Return the four uniform cubic B-spline basis weights at offset *t*.
+
+    Parameters
+    ----------
+    t : array-like
+        Fractional offset(s) in [0, 1).  Any shape.
+    xp : module
+        Array module (numpy or cupy).
+
+    Returns
+    -------
+    array
+        Stack of shape ``t.shape + (4,)`` with weights ``[B0, B1, B2, B3]``.
+        Weights sum to 1 along the last axis.
+    """
+    t = xp.asarray(t, dtype=xp.float32)
+    t2 = t * t
+    t3 = t2 * t
+    one_m_t = 1.0 - t
+    b0 = (one_m_t * one_m_t * one_m_t) / 6.0
+    b1 = (3.0 * t3 - 6.0 * t2 + 4.0) / 6.0
+    b2 = (-3.0 * t3 + 3.0 * t2 + 3.0 * t + 1.0) / 6.0
+    b3 = t3 / 6.0
+    return xp.stack([b0, b1, b2, b3], axis=-1)
+
+
+# ---------------------------------------------------------------------------
+# Coordinate mapping
+# ---------------------------------------------------------------------------
+
+
+def _voxel_to_control_coords(n_voxels: int, n_control: int, xp: Any) -> Any:
+    """Map ``[0, n_voxels-1]`` voxel indices to control-grid coordinates.
+
+    Voxel 0 maps to control coordinate 0; voxel ``n_voxels - 1`` maps to
+    ``n_control - 3``.  This leaves one control-point of padding on each
+    side so the 4-tap cubic B-spline kernel has full support at the
+    boundaries.
+    """
+    if n_voxels == 1:
+        return xp.zeros(1, dtype=xp.float32)
+    span = float(n_control - 3)
+    if span <= 0:
+        raise ValueError(f"n_control={n_control} too small; need at least 4 control points to host a cubic B-spline.")
+    return xp.arange(n_voxels, dtype=xp.float32) * (span / float(n_voxels - 1))
+
+
+# ---------------------------------------------------------------------------
+# Per-axis basis matrix
+# ---------------------------------------------------------------------------
+
+
+def _build_axis_basis(n_voxels: int, n_control: int, xp: Any) -> Any:
+    """Return the dense (n_voxels, n_control) cubic-B-spline basis matrix.
+
+    Row ``i`` contains exactly four non-zero entries — the four basis
+    weights at offsets ``-1, 0, 1, 2`` around ``floor(u_i)``, with OOB
+    stencil indices clamped to ``[0, n_control - 1]`` (boundary
+    partition-of-unity preservation, matching the original scattered
+    formulation).
+
+    The matrix is small (axes are at most a few hundred voxels by a few
+    dozen control points) so a dense layout is cheap and lets us turn
+    the fit/evaluate into three contiguous tensor contractions.
+    """
+    u = _voxel_to_control_coords(n_voxels, n_control, xp)
+    iu = xp.floor(u).astype(xp.int32)
+    t = u - iu.astype(xp.float32)
+    b = _cubic_bspline_basis(t, xp)  # (n_voxels, 4)
+
+    M = xp.zeros((n_voxels, n_control), dtype=xp.float32)
+    rows = xp.arange(n_voxels, dtype=xp.int32)
+    for d in range(4):
+        cols = xp.clip(iu + (d - 1), 0, n_control - 1)
+        # Multiple stencil offsets may map to the same column at the
+        # boundary; accumulate so partition-of-unity is preserved.
+        if xp is np:
+            np.add.at(M, (rows, cols), b[:, d])
+        else:
+            xp.add.at(M, (rows, cols), b[:, d])
+    return M
+
+
+# ---------------------------------------------------------------------------
+# Fit
+# ---------------------------------------------------------------------------
+
+
+def bspline_fit_precompute(
+    bases: tuple[Any, Any, Any],
+    *,
+    eps: float = 1e-8,
+) -> tuple[Any, Any, Any, Any, Any, Any, Any]:
+    """Build the iteration-invariant constants used by :func:`bspline_fit`.
+
+    The squared/cubed per-axis basis matrices and the separable per-voxel
+    denominator ``S(p) = (sum_c M_z[z,c]^2)(sum_c M_y[y,c]^2)(sum_c M_x[x,c]^2)``
+    depend only on *bases*, so callers that issue many fits at the same shape
+    (e.g. the N4 fitting loop) can build them once and pass them in via
+    :func:`bspline_fit`'s ``precomputed`` argument.
+
+    Returns ``(M_z2, M_y2, M_x2, M_z3, M_y3, M_x3, S_safe)`` where
+    ``S_safe = maximum(S, eps)`` -- the per-iteration ``maximum`` against
+    *eps* is folded into the precompute.
+    """
+    M_z, M_y, M_x = bases
+    xp = get_array_module(use_gpu=_is_gpu_array(M_z))
+    M_z2 = M_z * M_z
+    M_y2 = M_y * M_y
+    M_x2 = M_x * M_x
+    M_z3 = M_z2 * M_z
+    M_y3 = M_y2 * M_y
+    M_x3 = M_x2 * M_x
+    s_z = M_z2.sum(axis=1)
+    s_y = M_y2.sum(axis=1)
+    s_x = M_x2.sum(axis=1)
+    # Pre-clamp S to >= eps so :func:`bspline_fit` skips a per-call
+    # full-volume ``maximum`` op.
+    S_safe = xp.maximum(
+        s_z[:, None, None] * s_y[None, :, None] * s_x[None, None, :],
+        eps,
+    ).astype(xp.float32)
+    return M_z2, M_y2, M_x2, M_z3, M_y3, M_x3, S_safe
+
+
+def bspline_fit(
+    values: np.ndarray,
+    weights: np.ndarray | None,
+    mask: np.ndarray | None,
+    n_control_points: tuple[int, int, int],
+    *,
+    use_gpu: bool = True,
+    eps: float = 1e-8,
+    bases: tuple[Any, Any, Any] | None = None,
+    precomputed: tuple[Any, Any, Any, Any, Any, Any, Any] | None = None,
+) -> np.ndarray:
+    """Fit a tensor-product cubic B-spline to scattered voxel samples.
+
+    Parameters
+    ----------
+    values : np.ndarray
+        Sample values, shape (Z, Y, X), float32.
+    weights : np.ndarray or None
+        Per-voxel non-negative weights (same shape).  ``None`` = all ones.
+    mask : np.ndarray or None
+        Boolean mask selecting which voxels participate in the fit.
+        ``None`` = all voxels.
+    n_control_points : tuple of int
+        Control-grid size ``(Cz, Cy, Cx)``.  Each value must be ``>= 4``.
+    use_gpu : bool
+        Use CuPy when available; falls back to NumPy.
+    eps : float
+        Floor on the kernel-weight denominator to avoid division by zero
+        for control points with no support.
+    bases : tuple of arrays, optional
+        Pre-built per-axis basis matrices ``(M_z, M_y, M_x)`` from
+        :func:`_build_axis_basis` matching ``values.shape`` and
+        ``n_control_points``.  When provided, skips the per-call build;
+        useful when the caller (e.g. an N4 fitting level) issues many
+        fits at the same shape.
+    precomputed : tuple of arrays, optional
+        Output of :func:`bspline_fit_precompute` for the same *bases*.
+        When provided, skips rebuilding the squared/cubed bases and the
+        separable denominator ``S`` -- a per-iteration full-volume
+        allocation in the N4 fit loop.
+
+    Returns
+    -------
+    np.ndarray
+        Control coefficients, shape ``n_control_points``, float32 NumPy
+        array (always returned on the host).
+    """
+    if values.ndim != 3:
+        raise ValueError(f"values must be 3-D, got shape {values.shape}")
+    cz, cy, cx = n_control_points
+    if min(cz, cy, cx) < 4:
+        raise ValueError(f"n_control_points must each be >= 4, got {n_control_points}")
+
+    xp = get_array_module(use_gpu=use_gpu and GPU_AVAILABLE)
+
+    vals = xp.asarray(values, dtype=xp.float32)
+    w = xp.ones_like(vals) if weights is None else xp.asarray(weights, dtype=xp.float32)
+    if mask is not None:
+        w = w * xp.asarray(mask, dtype=xp.float32)
+
+    z_n, y_n, x_n = vals.shape
+
+    # Build dense per-axis basis matrices: M_axis[i, c] is the cubic
+    # B-spline weight that voxel ``i`` deposits onto control point ``c``.
+    # The 3-D scattered-data fit factorises along axes because the basis
+    # is separable, so the whole accumulation is three contiguous tensor
+    # contractions instead of 64 scatter-adds.  Bases can be precomputed
+    # by the caller (e.g. once per N4 level) and reused across many
+    # fit/evaluate calls to avoid rebuilding the same small matrices.
+    if bases is None:
+        M_z = _build_axis_basis(z_n, cz, xp)
+        M_y = _build_axis_basis(y_n, cy, xp)
+        M_x = _build_axis_basis(x_n, cx, xp)
+    else:
+        M_z, M_y, M_x = bases
+
+    # PSDB: separable tensor-product implementation of the Lee-Wolberg-Shin
+    # single-level scattered-data B-spline approximation.
+    #
+    #   coeff[c] = sum_p gamma_p * w_c(p)^3 * v_p / S(p)
+    #             ------------------------------------------
+    #                      sum_p gamma_p * w_c(p)^2
+    #
+    # Squared and cubed per-axis basis matrices fold the per-control-point
+    # weight powers into separable contractions.  S(p) factorises as the
+    # product of per-axis sums of squared basis weights.  These derive only
+    # from the bases, so an N4 fitting loop can build them once via
+    # :func:`bspline_fit_precompute` and pass them in.
+    if precomputed is None:
+        M_z2, M_y2, M_x2, M_z3, M_y3, M_x3, S_safe = bspline_fit_precompute((M_z, M_y, M_x), eps=eps)
+    else:
+        M_z2, M_y2, M_x2, M_z3, M_y3, M_x3, S_safe = precomputed
+
+    psi = (w * vals) / S_safe  # (Z, Y, X)
+
+    # num[Cz, Cy, Cx] = sum_{z,y,x} M_z3[z,Cz] M_y3[y,Cy] M_x3[x,Cx] * psi
+    num = xp.tensordot(psi, M_x3, axes=([2], [0]))  # (Nz, Ny, Cx)
+    num = xp.tensordot(num, M_y3, axes=([1], [0]))  # (Nz, Cx, Cy)
+    num = xp.tensordot(num, M_z3, axes=([0], [0]))  # (Cx, Cy, Cz)
+    num = xp.transpose(num, (2, 1, 0))  # (Cz, Cy, Cx)
+
+    # den[Cz, Cy, Cx] = sum_{z,y,x} M_z2[z,Cz] M_y2[y,Cy] M_x2[x,Cx] * w
+    den = xp.tensordot(w, M_x2, axes=([2], [0]))
+    den = xp.tensordot(den, M_y2, axes=([1], [0]))
+    den = xp.tensordot(den, M_z2, axes=([0], [0]))
+    den = xp.transpose(den, (2, 1, 0))
+
+    coeff = (num / xp.maximum(den, eps)).astype(xp.float32)
+
+    # Preserve caller's array module: cupy in -> cupy out, numpy in -> numpy out.
+    if _is_gpu_array(values):
+        return coeff
+    if xp is np:
+        return coeff
+    import cupy as cp
+
+    return cp.asnumpy(coeff).astype(np.float32)
+
+
+# ---------------------------------------------------------------------------
+# Evaluate
+# ---------------------------------------------------------------------------
+
+
+def bspline_evaluate(
+    control_coeffs: np.ndarray,
+    target_shape: tuple[int, int, int],
+    *,
+    use_gpu: bool = True,
+    bases: tuple[Any, Any, Any] | None = None,
+) -> np.ndarray:
+    """Evaluate a cubic B-spline given control coefficients on a regular grid.
+
+    Inverse of :func:`bspline_fit`'s coordinate mapping: target voxel 0
+    maps to control coordinate 0; target voxel ``N - 1`` maps to
+    ``Cn - 3``.
+
+    Parameters
+    ----------
+    control_coeffs : np.ndarray
+        Control-grid coefficients, shape ``(Cz, Cy, Cx)``.
+    target_shape : tuple of int
+        Output volume shape ``(Z, Y, X)``.
+    use_gpu : bool
+        Use CuPy when available.
+    bases : tuple of arrays, optional
+        Pre-built per-axis basis matrices ``(M_z, M_y, M_x)`` matching
+        ``target_shape`` and ``control_coeffs.shape``.  When provided,
+        skips the per-call build.
+
+    Returns
+    -------
+    np.ndarray
+        Evaluated field, shape ``target_shape``, float32.
+    """
+    xp = get_array_module(use_gpu=use_gpu and GPU_AVAILABLE)
+
+    coeff = xp.asarray(control_coeffs, dtype=xp.float32)
+    cz, cy, cx = coeff.shape
+    z_n, y_n, x_n = target_shape
+
+    if bases is None:
+        M_z = _build_axis_basis(z_n, cz, xp)  # (Nz, Cz)
+        M_y = _build_axis_basis(y_n, cy, xp)
+        M_x = _build_axis_basis(x_n, cx, xp)
+    else:
+        M_z, M_y, M_x = bases
+
+    # out[z, y, x] = sum_{Z,Y,X} M_z[z,Z] M_y[y,Y] M_x[x,X] * coeff[Z,Y,X]
+    out = xp.tensordot(coeff, M_x, axes=([2], [1]))  # (Cz, Cy, Nx)
+    out = xp.tensordot(out, M_y, axes=([1], [1]))  # (Cz, Nx, Ny)
+    out = xp.tensordot(out, M_z, axes=([0], [1]))  # (Nx, Ny, Nz)
+    out = xp.transpose(out, (2, 1, 0)).astype(xp.float32)  # (Nz, Ny, Nx)
+
+    if _is_gpu_array(control_coeffs):
+        return out
+    if xp is np:
+        return out
+    import cupy as cp
+
+    return cp.asnumpy(out).astype(np.float32)

--- a/linumpy/gpu/interface.py
+++ b/linumpy/gpu/interface.py
@@ -1,0 +1,50 @@
+"""GPU implementation of tissue interface detection.
+
+Mirrors the CPU path in :func:`linumpy.geometry.interface.find_tissue_interface`
+but routes the heavy filters through ``cupyx.scipy.ndimage`` to avoid
+host-device round trips when the caller already holds GPU data or when
+the volume is large enough that the transfer cost is amortised.
+"""
+
+from typing import Any
+
+import numpy as np
+
+from . import to_cpu
+
+
+def find_tissue_interface_gpu(
+    vol: Any,
+    s_xy: int = 15,
+    s_z: int = 2,
+    use_log: bool = True,
+    order: int = 1,
+    detect_cutting_errors: bool = False,
+) -> np.ndarray:
+    """GPU equivalent of ``find_tissue_interface`` (no mask path).
+
+    Always returns a NumPy array of integer depths so callers do not need
+    to be aware of the device.
+    """
+    import cupy as cp
+    from cupyx.scipy.ndimage import gaussian_filter1d, uniform_filter
+
+    vol_gpu = cp.asarray(vol)
+    if use_log:
+        vol_p = vol_gpu.astype(cp.float32, copy=True)
+        positive = vol_gpu > 0
+        vol_p[positive] = cp.log(vol_gpu[positive])
+    else:
+        vol_p = vol_gpu
+
+    vol_p = uniform_filter(vol_p, (s_xy, s_xy, 0))
+    vol_g = gaussian_filter1d(vol_p, s_z, axis=2, order=order)
+    z0 = cp.ceil(vol_g.argmax(axis=2) + s_z * 0.5).astype(cp.int64)
+
+    if detect_cutting_errors:
+        vol_p = gaussian_filter1d(vol_p, s_z, axis=2, order=0)
+        z0_p = cp.abs(vol_p).argmax(axis=2)
+        mask_max = z0_p < z0
+        z0 = cp.where(mask_max, z0_p, z0)
+
+    return to_cpu(z0)

--- a/linumpy/gpu/interpolation.py
+++ b/linumpy/gpu/interpolation.py
@@ -1,0 +1,252 @@
+"""
+GPU-accelerated interpolation and resampling operations for linumpy.
+
+Provides GPU versions of image resampling, affine transforms, and
+coordinate mapping operations.
+"""
+
+from typing import Any
+
+import numpy as np
+
+from . import GPU_AVAILABLE, is_cupy_array, to_cpu
+
+
+def affine_transform(image: Any, matrix: Any, output_shape: Any = None, order: Any = 1, use_gpu: Any = True) -> Any:
+    """
+    GPU-accelerated affine transformation.
+
+    Parameters
+    ----------
+    image : np.ndarray
+        Input image (2D or 3D)
+    matrix : np.ndarray
+        Affine transformation matrix
+    output_shape : tuple, optional
+        Shape of output image. If None, uses input shape.
+    order : int
+        Interpolation order (0=nearest, 1=linear, 3=cubic)
+    use_gpu : bool
+        Whether to use GPU acceleration
+
+    Returns
+    -------
+    np.ndarray
+        Transformed image
+    """
+    if output_shape is None:
+        output_shape = image.shape
+
+    if use_gpu and GPU_AVAILABLE:
+        return _affine_transform_gpu(image, matrix, output_shape, order)
+    else:
+        return _affine_transform_cpu(image, matrix, output_shape, order)
+
+
+def _affine_transform_gpu(image: Any, matrix: Any, output_shape: Any, order: Any) -> Any:
+    """GPU implementation of affine transform. Device-preserving."""
+    import cupy as cp
+    from cupyx.scipy.ndimage import affine_transform as cp_affine
+
+    input_was_gpu = is_cupy_array(image)
+    img_gpu = cp.asarray(image.astype(np.float32))
+    matrix_gpu = cp.asarray(matrix.astype(np.float32))
+
+    result = cp_affine(img_gpu, matrix_gpu, output_shape=output_shape, order=order)
+
+    if input_was_gpu:
+        return result
+    return to_cpu(result)
+
+
+def _affine_transform_cpu(image: Any, matrix: Any, output_shape: Any, order: Any) -> Any:
+    """CPU fallback for affine transform."""
+    from scipy.ndimage import affine_transform as scipy_affine
+
+    return scipy_affine(image, matrix, output_shape=output_shape, order=order)
+
+
+def map_coordinates(image: Any, coordinates: Any, order: Any = 1, use_gpu: Any = True) -> Any:
+    """
+    GPU-accelerated coordinate mapping (general interpolation).
+
+    Parameters
+    ----------
+    image : np.ndarray
+        Input image
+    coordinates : np.ndarray
+        Coordinates to sample at, shape (ndim, ...)
+    order : int
+        Interpolation order
+    use_gpu : bool
+        Whether to use GPU
+
+    Returns
+    -------
+    np.ndarray
+        Interpolated values
+    """
+    if use_gpu and GPU_AVAILABLE:
+        return _map_coordinates_gpu(image, coordinates, order)
+    else:
+        return _map_coordinates_cpu(image, coordinates, order)
+
+
+def _map_coordinates_gpu(image: Any, coordinates: Any, order: Any) -> Any:
+    """GPU implementation of map_coordinates. Device-preserving."""
+    import cupy as cp
+    from cupyx.scipy.ndimage import map_coordinates as cp_map
+
+    input_was_gpu = is_cupy_array(image)
+    img_gpu = cp.asarray(image.astype(np.float32))
+    coords_gpu = cp.asarray(coordinates.astype(np.float32))
+
+    result = cp_map(img_gpu, coords_gpu, order=order)
+
+    if input_was_gpu:
+        return result
+    return to_cpu(result)
+
+
+def _map_coordinates_cpu(image: Any, coordinates: Any, order: Any) -> Any:
+    """CPU fallback for map_coordinates."""
+    from scipy.ndimage import map_coordinates as scipy_map
+
+    return scipy_map(image, coordinates, order=order)
+
+
+def resize(image: Any, output_shape: Any, order: Any = 1, anti_aliasing: Any = True, use_gpu: Any = True) -> Any:
+    """
+    GPU-accelerated image resize.
+
+    Parameters
+    ----------
+    image : np.ndarray
+        Input image
+    output_shape : tuple
+        Desired output shape
+    order : int
+        Interpolation order
+    anti_aliasing : bool
+        Whether to apply anti-aliasing filter before downsampling
+    use_gpu : bool
+        Whether to use GPU
+
+    Returns
+    -------
+    np.ndarray
+        Resized image
+    """
+    if use_gpu and GPU_AVAILABLE:
+        return _resize_gpu(image, output_shape, order, anti_aliasing)
+    else:
+        return _resize_cpu(image, output_shape, order, anti_aliasing)
+
+
+def _resize_gpu(image: Any, output_shape: Any, order: Any, anti_aliasing: Any) -> Any:
+    """GPU implementation of resize using zoom.
+
+    Device-preserving: returns a CuPy array if *image* was already on device,
+    a NumPy array if *image* was on host. This avoids forcing a D->H copy when
+    callers want to keep tiles resident for downstream GPU compute / writes.
+    """
+    import cupy as cp
+    from cupyx.scipy.ndimage import gaussian_filter as cp_gaussian
+    from cupyx.scipy.ndimage import zoom as cp_zoom
+
+    input_was_gpu = is_cupy_array(image)
+    img_gpu = cp.asarray(image if image.dtype == np.float32 else image.astype(np.float32))
+
+    # Scale factors: input/output for Gaussian sigma, output/input for zoom.
+    scale_factors = tuple(i / o for i, o in zip(image.shape, output_shape, strict=False))
+    zoom_factors = tuple(o / i for i, o in zip(image.shape, output_shape, strict=False))
+
+    # Anti-aliasing: single fused Gaussian call with per-axis sigma vector,
+    # replacing N sequential per-axis kernel launches.
+    if anti_aliasing:
+        sigmas = [(f - 1) / 2 if f > 1 else 0.0 for f in scale_factors]
+        if any(s > 0 for s in sigmas):
+            img_gpu = cp_gaussian(img_gpu, sigma=sigmas)
+
+    result = cp_zoom(img_gpu, zoom_factors, order=order)
+
+    if input_was_gpu:
+        return result
+    return to_cpu(result)
+
+
+def _resize_cpu(image: Any, output_shape: Any, order: Any, anti_aliasing: Any) -> Any:
+    """CPU fallback for resize using zoom."""
+    from scipy.ndimage import gaussian_filter as scipy_gaussian
+    from scipy.ndimage import zoom as scipy_zoom
+
+    img = image if image.dtype == np.float32 else image.astype(np.float32)
+
+    scale_factors = tuple(i / o for i, o in zip(image.shape, output_shape, strict=False))
+    zoom_factors = tuple(o / i for i, o in zip(image.shape, output_shape, strict=False))
+
+    if anti_aliasing:
+        sigmas = [(f - 1) / 2 if f > 1 else 0.0 for f in scale_factors]
+        if any(s > 0 for s in sigmas):
+            img = scipy_gaussian(img, sigma=sigmas)
+
+    return scipy_zoom(img, zoom_factors, order=order)
+
+
+def apply_displacement_field(image: Any, displacement_field: Any, use_gpu: Any = True) -> Any:
+    """
+    Apply a displacement field to warp an image.
+
+    Parameters
+    ----------
+    image : np.ndarray
+        Input image (2D or 3D)
+    displacement_field : np.ndarray
+        Displacement field with shape ``(ndim, *image.shape)``
+    use_gpu : bool
+        Whether to use GPU
+
+    Returns
+    -------
+    np.ndarray
+        Warped image
+    """
+    _ndim = image.ndim
+
+    # Create coordinate grid
+    coords = np.meshgrid(*[np.arange(s) for s in image.shape], indexing="ij")
+    coords = np.array(coords)
+
+    # Add displacement
+    new_coords = coords + displacement_field
+
+    return map_coordinates(image, new_coords, order=1, use_gpu=use_gpu)
+
+
+def resample_volume(volume: Any, current_spacing: Any, target_spacing: Any, order: Any = 1, use_gpu: Any = True) -> Any:
+    """
+    Resample a volume to a new spacing.
+
+    Parameters
+    ----------
+    volume : np.ndarray
+        Input volume
+    current_spacing : tuple
+        Current voxel spacing
+    target_spacing : tuple
+        Target voxel spacing
+    order : int
+        Interpolation order
+    use_gpu : bool
+        Whether to use GPU
+
+    Returns
+    -------
+    np.ndarray
+        Resampled volume
+    """
+    # Compute new shape
+    scale_factors = tuple(c / t for c, t in zip(current_spacing, target_spacing, strict=False))
+    new_shape = tuple(int(s * f) for s, f in zip(volume.shape, scale_factors, strict=False))
+
+    return resize(volume, new_shape, order=order, anti_aliasing=True, use_gpu=use_gpu)

--- a/linumpy/gpu/kvikio_zarr.py
+++ b/linumpy/gpu/kvikio_zarr.py
@@ -1,0 +1,228 @@
+"""kvikio / GPUDirect Storage reader for uncompressed zarr arrays.
+
+This module implements the :func:`read_zarr_via_kvikio` backend used by
+:mod:`linumpy.gpu.zarr_io`. It reads zarr v2 *or* zarr v3 chunks directly
+into GPU memory using ``kvikio.CuFile``. The version is auto-detected from
+the on-disk metadata file (``zarr.json`` for v3, ``.zarray`` for v2).
+
+Most callers should use :func:`linumpy.gpu.zarr_io.read_zarr_to_gpu`, which
+dispatches to this backend only when GDS native mode is available and the
+array is uncompressed; otherwise it falls back to ``zarr.config.enable_gpu``.
+
+Supported on-disk formats
+-------------------------
+
+* zarr v3: ``codecs=[{"name": "bytes"}]`` only (or empty) — raw little/big-
+  endian bytes. Any compression codec (blosc, gzip, zstd, ...) is rejected
+  because GDS reads bytes verbatim and on-device decompression would require
+  nvCOMP.
+* zarr v2: ``compressor=None``, ``filters=None``, ``order='C'``.
+
+Notes
+-----
+* Requires ``kvikio`` and ``cupy``. Both are imported lazily so the rest of
+  linumpy is unaffected if they are not installed.
+* For the GDS fast path the source filesystem must support GDS natively
+  (ext4 on local NVMe, IOMMU disabled or in passthrough, and
+  ``properties.use_compat_mode=false`` in ``/etc/cufile.json``). Otherwise
+  kvikio falls back to a posix bounce-buffer path with no speed-up.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from itertools import product
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Iterator
+
+
+def _require_kvikio() -> tuple[Any, Any]:
+    """Import kvikio + cupy lazily and return (kvikio, cupy)."""
+    try:
+        import cupy
+        import kvikio
+    except ImportError as exc:  # pragma: no cover - hardware-dependent
+        raise RuntimeError(
+            "kvikio + cupy are required for the GDS prototype. Install with:\n"
+            "    pip install kvikio-cu13 cupy-cuda13x  # or matching your CUDA"
+        ) from exc
+    return kvikio, cupy
+
+
+def _parse_v3_dtype(dt: Any) -> np.dtype:
+    """Map a zarr v3 ``data_type`` field to a numpy dtype."""
+    if isinstance(dt, str):
+        return np.dtype(dt)
+    raise NotImplementedError(f"unsupported v3 data_type: {dt!r}")
+
+
+def _v3_chunk_path(array_path: Path, idx: tuple[int, ...], encoding: dict) -> Path:
+    """Build the on-disk chunk path for a zarr v3 array."""
+    name = encoding.get("name", "default")
+    sep = encoding.get("configuration", {}).get("separator", "/")
+    parts = sep.join(str(i) for i in idx)
+    if name == "default":
+        return array_path / "c" / parts if sep == "/" else array_path / f"c{sep}{parts}"
+    if name == "v2":
+        return array_path / parts
+    raise NotImplementedError(f"unsupported chunk_key_encoding: {name!r}")
+
+
+def _v2_chunk_path(array_path: Path, idx: tuple[int, ...], dim_separator: str) -> Path:
+    return array_path / dim_separator.join(str(i) for i in idx)
+
+
+class _ArraySpec:
+    """Resolved, format-agnostic view of a zarr array on disk."""
+
+    __slots__ = ("_v2_dim_sep", "_v3_encoding", "chunks", "dtype", "fill_value", "format", "path", "shape")
+
+    def __init__(
+        self,
+        *,
+        path: Path,
+        shape: tuple[int, ...],
+        chunks: tuple[int, ...],
+        dtype: np.dtype,
+        fill_value: Any,
+        format: int,
+        v3_encoding: dict | None = None,
+        v2_dim_sep: str | None = None,
+    ) -> None:
+        self.path = path
+        self.shape = shape
+        self.chunks = chunks
+        self.dtype = dtype
+        self.fill_value = fill_value
+        self.format = format
+        self._v3_encoding = v3_encoding
+        self._v2_dim_sep = v2_dim_sep
+
+    def chunk_path(self, idx: tuple[int, ...]) -> Path:
+        if self.format == 3:
+            assert self._v3_encoding is not None
+            return _v3_chunk_path(self.path, idx, self._v3_encoding)
+        assert self._v2_dim_sep is not None
+        return _v2_chunk_path(self.path, idx, self._v2_dim_sep)
+
+
+def _load_array_spec(array_path: Path) -> _ArraySpec:
+    """Inspect ``array_path`` and return a normalized spec for v2 or v3."""
+    v3_meta = array_path / "zarr.json"
+    v2_meta = array_path / ".zarray"
+
+    if v3_meta.exists():
+        meta = json.loads(v3_meta.read_text())
+        if meta.get("zarr_format") != 3:
+            raise ValueError(f"{array_path}: zarr.json has zarr_format != 3")
+        if meta.get("node_type") != "array":
+            raise ValueError(f"{array_path}: zarr.json is not an array node")
+        codecs = meta.get("codecs", [])
+        non_bytes = [c for c in codecs if c.get("name") != "bytes"]
+        if non_bytes:
+            raise NotImplementedError(
+                f"{array_path}: codecs={[c.get('name') for c in codecs]!r}; this prototype "
+                "requires raw bytes only (no compression). On-device decompression needs nvCOMP."
+            )
+        host_endian = "big" if sys.byteorder == "big" else "little"
+        for c in codecs:
+            endian = c.get("configuration", {}).get("endian", "little")
+            if endian != host_endian:
+                raise NotImplementedError(f"{array_path}: endian={endian!r} differs from host")
+        chunk_grid = meta.get("chunk_grid", {})
+        if chunk_grid.get("name") != "regular":
+            raise NotImplementedError(f"{array_path}: chunk_grid={chunk_grid.get('name')!r}")
+        return _ArraySpec(
+            path=array_path,
+            shape=tuple(meta["shape"]),
+            chunks=tuple(chunk_grid["configuration"]["chunk_shape"]),
+            dtype=_parse_v3_dtype(meta["data_type"]),
+            fill_value=meta.get("fill_value", 0),
+            format=3,
+            v3_encoding=meta.get("chunk_key_encoding", {"name": "default", "configuration": {"separator": "/"}}),
+        )
+
+    if v2_meta.exists():
+        meta = json.loads(v2_meta.read_text())
+        if meta.get("zarr_format") != 2:
+            raise ValueError(f"{array_path}: .zarray has zarr_format != 2")
+        if meta.get("compressor") is not None:
+            raise NotImplementedError(
+                f"{array_path}: compressor={meta['compressor']!r}; this prototype "
+                "requires uncompressed chunks. On-device decompression needs nvCOMP."
+            )
+        if meta.get("order", "C") != "C":
+            raise NotImplementedError(f"{array_path}: order={meta['order']!r} unsupported")
+        if meta.get("filters"):
+            raise NotImplementedError(f"{array_path}: filters unsupported in prototype")
+        return _ArraySpec(
+            path=array_path,
+            shape=tuple(meta["shape"]),
+            chunks=tuple(meta["chunks"]),
+            dtype=np.dtype(meta["dtype"]),
+            fill_value=meta.get("fill_value", 0),
+            format=2,
+            v2_dim_sep=meta.get("dimension_separator", "."),
+        )
+
+    raise FileNotFoundError(f"{array_path}: no zarr.json (v3) or .zarray (v2) found")
+
+
+def _iter_chunk_indices(shape: Iterable[int], chunks: Iterable[int]) -> Iterator[tuple[int, ...]]:
+    n = [(s + c - 1) // c for s, c in zip(shape, chunks, strict=True)]
+    yield from product(*[range(k) for k in n])
+
+
+def read_zarr_via_kvikio(array_path: str | Path) -> Any:
+    """Load a full uncompressed zarr (v2 or v3) array into a CuPy array via GDS.
+
+    Parameters
+    ----------
+    array_path
+        Path to the zarr array directory (containing ``zarr.json`` for v3 or
+        ``.zarray`` for v2).
+
+    Returns
+    -------
+    cupy.ndarray
+        Device-resident array of shape and dtype matching the zarr metadata.
+    """
+    kvikio, cupy = _require_kvikio()
+    spec = _load_array_spec(Path(array_path))
+
+    out = cupy.full(spec.shape, spec.fill_value, dtype=spec.dtype)
+    chunk_nbytes_full = int(np.prod(spec.chunks) * spec.dtype.itemsize)
+    scratch = cupy.empty(spec.chunks, dtype=spec.dtype)
+
+    for idx in _iter_chunk_indices(spec.shape, spec.chunks):
+        cf_path = spec.chunk_path(idx)
+        if not cf_path.exists():
+            continue  # zarr fill-value semantics
+
+        slices: list[slice] = []
+        edge_shape: list[int] = []
+        for k, c, s in zip(idx, spec.chunks, spec.shape, strict=True):
+            start = k * c
+            stop = min(start + c, s)
+            slices.append(slice(start, stop))
+            edge_shape.append(stop - start)
+        edge_shape_t = tuple(edge_shape)
+
+        # kvikio.CuFile.pread requires a contiguous device buffer; a slice
+        # into ``out`` is generally not contiguous, so we read into a
+        # chunk-shaped scratch and copy the valid region into ``out``.
+        with kvikio.CuFile(str(cf_path), "r") as f:
+            f.pread(scratch, chunk_nbytes_full).get()
+        if edge_shape_t == spec.chunks:
+            out[tuple(slices)] = scratch
+        else:
+            sub = tuple(slice(0, e) for e in edge_shape_t)
+            out[tuple(slices)] = scratch[sub]
+
+    return out

--- a/linumpy/gpu/n4.py
+++ b/linumpy/gpu/n4.py
@@ -1,0 +1,458 @@
+"""GPU N4 bias field correction.
+
+Implements the Tustison 2010 N4 algorithm using the B-spline primitive
+in :mod:`linumpy.gpu.bspline` and a CuPy/NumPy-shared histogram
+sharpening routine.
+
+Each fitting level loops over:
+
+1.  Compute the log-residual ``r = log(v) - log_bias`` on masked voxels.
+2.  Sharpen the residual histogram by Wiener-deconvolving it with a
+    Gaussian PSF (Sled 1998 / Tustison 2010), producing a LUT mapping
+    observed log-intensity to expected (unbiased) log-intensity.
+3.  Voxel-wise, compute the per-voxel log-bias update
+    ``delta = log(v) - LUT(log(v) - log_bias)``.
+4.  Fit a tensor-product cubic B-spline to ``delta`` on a regular
+    control grid, evaluate at full resolution, and add to ``log_bias``.
+
+The next fitting level doubles the number of control points per axis.
+
+Memory budget (per N4 call):
+
+    ~6 x volume_size x 4 bytes
+
+i.e. ~12 GB for a (256, 1024, 1024) float32 volume.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from linumpy.gpu import GPU_AVAILABLE, get_array_module
+from linumpy.gpu.bspline import (
+    _build_axis_basis,
+    _is_gpu_array,
+    bspline_evaluate,
+    bspline_fit,
+    bspline_fit_precompute,
+)
+
+# ---------------------------------------------------------------------------
+# Histogram sharpening
+# ---------------------------------------------------------------------------
+
+
+def _build_log_psf(n_bins: int, bin_width: float, fwhm: float, xp: Any) -> Any:
+    """Return a centred Gaussian PSF over *n_bins* bins.
+
+    Parameters
+    ----------
+    n_bins : int
+        Histogram bin count.
+    bin_width : float
+        Histogram bin width in log-intensity units.
+    fwhm : float
+        Full-width-half-maximum of the Gaussian PSF, log-intensity units.
+    xp : module
+        Array module.
+    """
+    sigma = fwhm / 2.3548200450309493  # 2 sqrt(2 ln 2)
+    centre = n_bins // 2
+    x = (xp.arange(n_bins, dtype=xp.float32) - centre) * bin_width
+    psf = xp.exp(-0.5 * (x / sigma) ** 2)
+    psf = psf / psf.sum()
+    return psf
+
+
+def sharpen_residual(
+    log_v: np.ndarray,
+    mask: np.ndarray | None,
+    *,
+    n_bins: int = 200,
+    fwhm_log: float = 0.15,
+    wiener_noise: float = 0.01,
+    use_gpu: bool = True,
+    mask_weights: np.ndarray | None = None,
+) -> np.ndarray:
+    """Return the per-voxel sharpened log-intensity (LUT-mapped).
+
+    Implements the Sled/Tustison histogram sharpening: build the
+    weighted log-intensity histogram restricted to *mask*, deconvolve
+    it by a Gaussian PSF (Wiener-regularised), and return the LUT
+    ``E[v_true | v_obs]`` evaluated at every voxel in *log_v*.
+
+    Parameters
+    ----------
+    log_v : np.ndarray
+        Log-intensity volume (any shape, float32).
+    mask : np.ndarray or None
+        Boolean mask; only masked voxels contribute to the histogram.
+        When ``None``, all voxels are used.
+    n_bins : int
+        Histogram bin count.
+    fwhm_log : float
+        Full-width-half-maximum of the Gaussian PSF in log-intensity
+        units.  Controls how much sharpening is applied (smaller FWHM
+        means less sharpening, since the deconvolution kernel is
+        narrower).  N4 default is approximately 0.15.
+    wiener_noise : float
+        Wiener regularisation term.  Larger values stabilise the
+        deconvolution at the expense of sharpening.
+    use_gpu : bool
+        Use CuPy when available.
+    mask_weights : np.ndarray, optional
+        Float32 view of *mask* (``mask.astype(float32)``).  When provided,
+        skips the per-call cast -- a full-volume allocation that the N4
+        fit loop otherwise repeats every iteration.
+
+    Returns
+    -------
+    np.ndarray
+        Sharpened log-intensity, same shape and dtype as *log_v*.
+        Outside the mask, the input log-intensity is returned unchanged.
+    """
+    xp = get_array_module(use_gpu=use_gpu and GPU_AVAILABLE)
+
+    log_v_xp = xp.asarray(log_v, dtype=xp.float32)
+    mask_xp = xp.ones_like(log_v_xp, dtype=xp.bool_) if mask is None else xp.asarray(mask, dtype=xp.bool_)
+
+    # Compute masked min/max without materialising the masked subset
+    # (boolean indexing is a slow scatter-gather on GPU).  We use
+    # +/-inf sentinels outside the mask so reductions ignore them.
+    pos_inf = xp.float32(np.inf)
+    neg_inf = xp.float32(-np.inf)
+    r_min = float(xp.where(mask_xp, log_v_xp, pos_inf).min())
+    r_max = float(xp.where(mask_xp, log_v_xp, neg_inf).max())
+    if not np.isfinite(r_min) or not np.isfinite(r_max):
+        return log_v_xp if _is_gpu_array(log_v) else np.asarray(log_v).astype(np.float32)
+    if r_max - r_min < 1e-8:
+        # Degenerate distribution — no sharpening possible.
+        return log_v_xp if _is_gpu_array(log_v) else np.asarray(log_v).astype(np.float32)
+
+    bin_width = (r_max - r_min) / float(n_bins - 1)
+    bin_centres = xp.linspace(r_min, r_max, n_bins, dtype=xp.float32)
+
+    # Quantise the FULL volume once.  bin_idx_full feeds both the
+    # weighted histogram (via bincount) AND the per-voxel LUT lookup,
+    # so we avoid a second pass over the volume and the
+    # boolean-indexed copy of the masked subset.
+    bin_idx_full = xp.clip(((log_v_xp - r_min) / bin_width + 0.5).astype(xp.int64), 0, n_bins - 1)
+    mask_w = mask_xp.astype(xp.float32) if mask_weights is None else mask_weights
+    hist = xp.bincount(bin_idx_full.reshape(-1), weights=mask_w.reshape(-1), minlength=n_bins).astype(xp.float32)
+
+    # Gaussian PSF (centred); FFT-shift to align with FFT convention.
+    # Zero-pad histogram and PSF to ``n_pad = 2 * n_bins`` so the FFT
+    # convolutions are linear, not circular.  Without padding, mass in
+    # the top bins (typically white matter for OCT) wraps into the
+    # bottom-bin LUT entries (and vice-versa), pulling WM intensities
+    # downward and visibly muting bright tissue.
+    n_pad = 2 * n_bins
+    psf = _build_log_psf(n_bins, bin_width, fwhm_log, xp)
+    psf_padded = xp.zeros(n_pad, dtype=xp.float32)
+    psf_padded[:n_bins] = psf
+    psf_shifted = xp.roll(psf_padded, -(n_bins // 2))
+
+    hist_padded = xp.zeros(n_pad, dtype=xp.float32)
+    hist_padded[:n_bins] = hist
+
+    psf_fft = xp.fft.rfft(psf_shifted)
+    hist_fft = xp.fft.rfft(hist_padded)
+
+    # Wiener deconvolution: H_sharp = H * conj(G) / (|G|^2 + noise).
+    psf_mag2 = (psf_fft * xp.conj(psf_fft)).real
+    sharp_fft = hist_fft * xp.conj(psf_fft) / (psf_mag2 + wiener_noise)
+    hist_sharp = xp.fft.irfft(sharp_fft, n=n_pad)[:n_bins]
+    hist_sharp = xp.maximum(hist_sharp, 0.0)
+
+    # LUT: for each output bin i, E[r | r_obs = bin_centres[i]]
+    #   = sum_j r_j * hist_sharp[j] * G(i - j) / sum_j hist_sharp[j] * G(i - j)
+    # i.e. (bin_centres * hist_sharp) (*) G  /  hist_sharp (*) G.
+    # Pad to n_pad as well so the LUT convolution is linear.
+    weighted = bin_centres * hist_sharp
+    weighted_padded = xp.zeros(n_pad, dtype=xp.float32)
+    weighted_padded[:n_bins] = weighted
+    hist_sharp_padded = xp.zeros(n_pad, dtype=xp.float32)
+    hist_sharp_padded[:n_bins] = hist_sharp
+    num_fft = xp.fft.rfft(weighted_padded)
+    den_fft = xp.fft.rfft(hist_sharp_padded)
+    num = xp.fft.irfft(num_fft * psf_fft, n=n_pad)[:n_bins]
+    den = xp.fft.irfft(den_fft * psf_fft, n=n_pad)[:n_bins]
+    lut = num / xp.maximum(den, 1e-12)
+
+    # Apply LUT to every voxel; outside mask, leave intensity unchanged.
+    sharpened = lut[bin_idx_full]
+    sharpened = xp.where(mask_xp, sharpened, log_v_xp).astype(xp.float32)
+
+    if _is_gpu_array(log_v):
+        return sharpened
+    if xp is np:
+        return sharpened
+    import cupy as cp
+
+    return cp.asnumpy(sharpened).astype(np.float32)
+
+
+# ---------------------------------------------------------------------------
+# N4 driver
+# ---------------------------------------------------------------------------
+
+
+def n4_correct_gpu(
+    vol: np.ndarray,
+    mask: np.ndarray | None = None,
+    *,
+    shrink_factor: int = 4,
+    n_iterations: list[int] | None = None,
+    spline_distance_mm: float = 10.0,
+    voxel_size_mm: tuple[float, float, float] = (1.0, 1.0, 1.0),
+    n_bins: int = 200,
+    fwhm_log: float = 0.15,
+    wiener_noise: float = 0.01,
+    convergence_tol: float = 1e-3,
+    use_gpu: bool = True,
+) -> tuple[np.ndarray, np.ndarray]:
+    """GPU-accelerated N4 bias field correction.
+
+    Faithful CuPy/NumPy port of the Tustison 2010 N4 algorithm: at each
+    fitting level, alternate Sled-style histogram sharpening and tensor
+    cubic B-spline scattered-data fitting until convergence.  The
+    B-spline control mesh is fixed across levels (matching SimpleITK's
+    behaviour); ``n_iterations`` only controls per-level iteration
+    counts and the residual is composed across levels.
+
+    Parameters mirror :func:`linumpy.intensity.bias_field.n4_correct` so the
+    two backends are interchangeable.  Extra knobs (``n_bins``,
+    ``fwhm_log``, ``wiener_noise``) tune the sharpening histogram.
+
+    Parameters
+    ----------
+    vol : np.ndarray
+        Float32 input volume (Z, Y, X).
+    mask : np.ndarray or None
+        Boolean tissue mask.  ``None`` = full volume.
+    shrink_factor : int
+        Isotropic spatial subsampling factor for the fit (>=1).
+    n_iterations : list of int or None
+        Max iterations per fitting level.  Length sets the number of
+        levels.  Default ``[20, 20, 20]``.  Fewer iterations than the
+        SimpleITK CPU backend because the GPU PSDB residual update has
+        no internal multilevel dampening, so each iteration has full
+        effect; more than ~20 per level causes the bias field to absorb
+        true tissue contrast (verified empirically on live OCT).
+    spline_distance_mm : float
+        Approximate distance between B-spline control knots at level 0.
+    voxel_size_mm : 3-tuple of float
+        Voxel size (z, y, x) in mm.
+    n_bins, fwhm_log, wiener_noise : sharpening parameters
+        See :func:`sharpen_residual`.
+    convergence_tol : float
+        Per-iteration convergence threshold on the relative L2 change of
+        ``log_bias``.  Iterations stop early when the change drops below
+        this value.
+    use_gpu : bool
+        Use CuPy when available.
+
+    Returns
+    -------
+    corrected : np.ndarray
+        Bias-corrected float32 volume (Z, Y, X), full resolution.
+    bias_field : np.ndarray
+        Estimated multiplicative bias field, float32, full resolution.
+    """
+    if n_iterations is None:
+        n_iterations = [25, 25, 25]
+    n_levels = len(n_iterations)
+
+    xp = get_array_module(use_gpu=use_gpu and GPU_AVAILABLE)
+    on_gpu = xp is not np
+
+    # Single host -> device transfer.  All intermediates remain on `xp`.
+    vol_xp = xp.asarray(vol, dtype=xp.float32)
+    full_shape: tuple[int, int, int] = (int(vol_xp.shape[0]), int(vol_xp.shape[1]), int(vol_xp.shape[2]))
+    mask_xp = xp.ones(full_shape, dtype=xp.bool_) if mask is None else xp.asarray(mask, dtype=xp.bool_)
+
+    # Spatial subsampling for fit (stride-subsample, on device).
+    if shrink_factor > 1:
+        # Materialise the subsampled volume/mask as contiguous copies so we
+        # can release the full-resolution `mask_xp` (and any temporaries
+        # that share storage with it) during the fit loop.  The fit only
+        # touches the small arrays; `vol_xp` is kept live for the
+        # full-resolution evaluation pass at the bottom of the function.
+        vol_small = xp.ascontiguousarray(vol_xp[::shrink_factor, ::shrink_factor, ::shrink_factor])
+        mask_small = xp.ascontiguousarray(mask_xp[::shrink_factor, ::shrink_factor, ::shrink_factor])
+    else:
+        vol_small = vol_xp
+        mask_small = mask_xp
+
+    # Free the full-resolution mask now -- only `mask_small` is used in the
+    # fit loop, and a fresh full mask is not needed for the evaluation pass.
+    del mask_xp
+    if on_gpu:
+        import cupy as _cp_free
+
+        _cp_free.get_default_memory_pool().free_all_blocks()
+
+    log_v = xp.log(xp.maximum(vol_small, 1e-6)).astype(xp.float32)
+
+    # Base control-point grid sized to physical extent.  ITK's spline order is
+    # 3, so we need at least 4 control points per axis.  We keep this grid
+    # FIXED across all fitting levels: SimpleITK's N4 reuses one B-spline
+    # mesh and accumulates residual composition across levels.  Doubling the
+    # grid per level (as earlier versions did) yields an effectively
+    # per-voxel control mesh at level 2-3 on typical OCT slabs, which
+    # absorbs true tissue contrast and produces a visibly jagged bias
+    # estimate.
+    extents_mm = tuple(full_shape[i] * float(voxel_size_mm[i]) for i in range(3))
+    n_ctrl_base = tuple(max(4, round(e / spline_distance_mm)) for e in extents_mm)
+    small_shape: tuple[int, int, int] = (
+        int(vol_small.shape[0]),
+        int(vol_small.shape[1]),
+        int(vol_small.shape[2]),
+    )
+    n_ctrl: tuple[int, int, int] = (
+        max(4, min(n_ctrl_base[0], small_shape[0])),
+        max(4, min(n_ctrl_base[1], small_shape[1])),
+        max(4, min(n_ctrl_base[2], small_shape[2])),
+    )
+
+    # Build the three (n_voxels, n_control) cubic-B-spline basis matrices
+    # once and reuse them across every level/iteration for both the fit
+    # (forward) and evaluate (transpose-shaped) contractions.
+    bases = (
+        _build_axis_basis(small_shape[0], n_ctrl[0], xp),
+        _build_axis_basis(small_shape[1], n_ctrl[1], xp),
+        _build_axis_basis(small_shape[2], n_ctrl[2], xp),
+    )
+
+    log_bias = xp.zeros_like(vol_small, dtype=xp.float32)
+    weights = mask_small.astype(xp.float32)
+    # Accumulate control coefficients so the final full-resolution bias
+    # field can be obtained by a single B-spline evaluation rather than
+    # by upsampling the coarse field with a different kernel.
+    coeff_total = xp.zeros(n_ctrl, dtype=xp.float32)
+
+    # The B-spline fit denominator S(p) and the squared/cubed per-axis basis
+    # matrices depend only on `bases`, which we hold fixed across all
+    # fitting levels.  Precompute them once so each iteration's
+    # bspline_fit call skips a small_vol-sized allocation of S plus six
+    # basis-power multiplies.
+    fit_precomputed = bspline_fit_precompute(bases)
+    # Reuse the float32 mask cast across iterations of sharpen_residual
+    # (it is identical every iter for a given level).
+    sharpen_mask_weights = weights
+
+    for level in range(n_levels):
+        for _ in range(n_iterations[level]):
+            # current = log_v - log_bias  (small_vol-sized intermediate; the
+            # CuPy memory pool reuses the slot every iteration).
+            current = log_v - log_bias
+            sharpened = sharpen_residual(
+                current,
+                mask_small,
+                n_bins=n_bins,
+                fwhm_log=fwhm_log,
+                wiener_noise=wiener_noise,
+                use_gpu=use_gpu,
+                mask_weights=sharpen_mask_weights,
+            )
+            # `weights == mask_small.astype(float32)`, so multiplying by it
+            # zeros the residual outside the mask without an extra
+            # ``xp.where`` call.
+            current -= sharpened
+            current *= weights
+            del sharpened
+
+            coeffs = bspline_fit(
+                current,
+                weights=weights,
+                mask=None,  # weights already encodes the mask
+                n_control_points=n_ctrl,
+                use_gpu=use_gpu,
+                bases=bases,
+                precomputed=fit_precomputed,
+            )
+            del current
+            update = bspline_evaluate(
+                coeffs,
+                target_shape=small_shape,
+                use_gpu=use_gpu,
+                bases=bases,
+            ).astype(xp.float32)
+
+            log_bias += update
+            coeff_total += coeffs
+            del coeffs
+
+            # Convergence: ||update|| / ||log_bias|| < tol.  Compute on
+            # device and issue a single D2H sync so each iteration of the
+            # fit loop has at most one host round-trip (instead of two
+            # ``float(xp.linalg.norm(...))`` calls).
+            update_sq = (update * update).sum()
+            del update
+            bias_sq = (log_bias * log_bias).sum()
+            converged = bool(xp.logical_and(bias_sq > 0, update_sq < (convergence_tol * convergence_tol) * bias_sq))
+            if converged:
+                break
+
+    # Evaluate the accumulated B-spline at full resolution directly,
+    # using the same cubic basis as the coarse-grid fits.  This replaces
+    # the previous separable Catmull-Rom upsample of the coarse log-bias
+    # field (different kernel -> ~2-3% spatial mismatch vs the ITK
+    # reference, which evaluates the spline analytically on the fine
+    # grid).
+    #
+    # The final stage materializes (log_bias_full, bias_field, corrected)
+    # at full volume size.  For large volumes that dwarfs GPU memory, so
+    # we drop the fit-time intermediates first and stream the evaluation
+    # in Z-tiles back to host.
+    del log_v, log_bias, weights, mask_small, vol_small, bases, fit_precomputed, sharpen_mask_weights
+    if on_gpu:
+        import cupy as cp
+
+        cp.get_default_memory_pool().free_all_blocks()
+    else:
+        cp = None
+
+    full_bases = (
+        _build_axis_basis(full_shape[0], n_ctrl[0], xp),
+        _build_axis_basis(full_shape[1], n_ctrl[1], xp),
+        _build_axis_basis(full_shape[2], n_ctrl[2], xp),
+    )
+    M_z_full, M_y_full, M_x_full = full_bases
+
+    # Pick a Z-tile that keeps the per-tile working set small relative to
+    # vol_xp (which we keep on device for the per-voxel division).  Each
+    # tile allocates ~3x its float32 size on GPU (log_bias_chunk, bias,
+    # corrected).  Aim for ~2 GB total per tile.
+    tile_bytes_target = 2 * 1024**3
+    bytes_per_z = full_shape[1] * full_shape[2] * 4 * 3
+    z_tile = max(1, min(full_shape[0], tile_bytes_target // max(bytes_per_z, 1)))
+
+    corrected_host = np.empty(full_shape, dtype=np.float32)
+    bias_host = np.empty(full_shape, dtype=np.float32)
+
+    for z0 in range(0, full_shape[0], z_tile):
+        z1 = min(z0 + z_tile, full_shape[0])
+        log_bias_chunk = bspline_evaluate(
+            coeff_total,
+            target_shape=(z1 - z0, full_shape[1], full_shape[2]),
+            use_gpu=use_gpu,
+            bases=(M_z_full[z0:z1], M_y_full, M_x_full),
+        )
+        bias_chunk = xp.exp(log_bias_chunk).astype(xp.float32)
+        del log_bias_chunk
+        corrected_chunk = (vol_xp[z0:z1] / xp.maximum(bias_chunk, 1e-6)).astype(xp.float32)
+
+        if on_gpu:
+            corrected_host[z0:z1] = cp.asnumpy(corrected_chunk)
+            bias_host[z0:z1] = cp.asnumpy(bias_chunk)
+        else:
+            corrected_host[z0:z1] = corrected_chunk
+            bias_host[z0:z1] = bias_chunk
+        del bias_chunk, corrected_chunk
+        if on_gpu:
+            cp.get_default_memory_pool().free_all_blocks()
+
+    return corrected_host, bias_host

--- a/linumpy/gpu/nvcomp_zstd.py
+++ b/linumpy/gpu/nvcomp_zstd.py
@@ -1,0 +1,218 @@
+"""GPU-accelerated zstd codec for zarr-python, backed by nvCOMP.
+
+This is a vendored stand-in for upstream zarr-python PR #2863 (`zarr.codecs.gpu.NvcompZstdCodec`),
+which is approved but not yet released. The codec implementation matches that PR closely so we
+can swap to the upstream class once it lands without changing call sites.
+
+Why this exists
+---------------
+With ``zarr.config.enable_gpu()``, zarr-python (≤3.2) reads zstd-compressed chunks by:
+
+1. ``GDSStore`` (or any store) yields a CPU buffer.
+2. The default ``zarr.codecs.zstd.ZstdCodec`` decodes on the CPU (numcodecs).
+3. The decoded chunk is copied H→D into a ``cupy`` buffer.
+
+That CPU decode + H→D copy is the bottleneck for compressed tiles. This module replaces step 2:
+chunks are uploaded to the GPU and decoded with ``nvidia.nvcomp.Codec("Zstd")``, so the result
+already lives on device.
+
+Usage
+-----
+The codec is registered under the name ``"zstd"`` (same as the default), so any existing zarr
+file with zstd-compressed chunks will use it once registered. Registration happens lazily from
+:mod:`linumpy.gpu.zarr_io` whenever a GPU read path is taken, so CPU-only workflows are
+unaffected.
+
+References
+----------
+* https://github.com/zarr-developers/zarr-python/pull/2863
+* https://docs.nvidia.com/cuda/nvcomp/
+"""
+
+import asyncio
+from dataclasses import dataclass
+from functools import cached_property
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+from zarr.abc.codec import BytesBytesCodec
+from zarr.core.common import JSON, parse_named_configuration
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from typing import Self
+
+    from zarr.core.array_spec import ArraySpec
+    from zarr.core.buffer import Buffer
+
+
+def _parse_zstd_level(data: JSON) -> int:
+    if isinstance(data, int):
+        if data >= 23:
+            raise ValueError(f"Value must be less than or equal to 22. Got {data} instead.")
+        return data
+    raise TypeError(f"Got value with type {type(data)}, but expected an int.")
+
+
+def _parse_checksum(data: JSON) -> bool:
+    if isinstance(data, bool):
+        return data
+    raise TypeError(f"Expected bool. Got {type(data)}.")
+
+
+@dataclass(frozen=True)
+class NvcompZstdCodec(BytesBytesCodec):
+    """zstd codec that decodes/encodes on an NVIDIA GPU via nvCOMP."""
+
+    is_fixed_size = True
+
+    level: int = 0
+    checksum: bool = False
+
+    def __init__(self, *, level: int = 0, checksum: bool = False) -> None:
+        level_parsed = _parse_zstd_level(level)
+        checksum_parsed = _parse_checksum(checksum)
+        object.__setattr__(self, "level", level_parsed)
+        object.__setattr__(self, "checksum", checksum_parsed)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, JSON]) -> Self:
+        """Construct codec from its serialised metadata representation."""
+        _, configuration_parsed = parse_named_configuration(data, "zstd")
+        cfg: dict[str, Any] = dict(configuration_parsed)  # type: ignore[arg-type]
+        level = cfg.get("level", 0)
+        checksum = cfg.get("checksum", False)
+        if not isinstance(level, int):
+            raise TypeError(f"zstd codec level must be int, got {type(level).__name__}")
+        if not isinstance(checksum, bool):
+            raise TypeError(f"zstd codec checksum must be bool, got {type(checksum).__name__}")
+        return cls(level=level, checksum=checksum)
+
+    def to_dict(self) -> dict[str, JSON]:
+        """Return the codec's metadata dict (named ``zstd`` for on-disk compatibility)."""
+        return {
+            "name": "zstd",
+            "configuration": {"level": self.level, "checksum": self.checksum},
+        }
+
+    @cached_property
+    def _zstd_codec(self) -> Any:
+        import cupy as cp
+        from nvidia import nvcomp
+
+        device = cp.cuda.Device()
+        stream = cp.cuda.get_current_stream()
+        return nvcomp.Codec(
+            algorithm="Zstd",
+            bitstream_kind=nvcomp.BitstreamKind.RAW,
+            device_id=device.id,
+            cuda_stream=stream.ptr,
+        )
+
+    def _convert_to_nvcomp_arrays(
+        self,
+        chunks_and_specs: Iterable[tuple[Buffer | None, ArraySpec]],
+    ) -> tuple[list[Any], list[int]]:
+        from nvidia import nvcomp
+
+        none_indices = [i for i, (b, _) in enumerate(chunks_and_specs) if b is None]
+        filtered_inputs = [b.as_array_like() for b, _ in chunks_and_specs if b is not None]
+        return nvcomp.as_arrays(filtered_inputs), none_indices
+
+    def _convert_from_nvcomp_arrays(
+        self,
+        arrays: Iterable[Any],
+        chunks_and_specs: Iterable[tuple[Buffer | None, ArraySpec]],
+    ) -> Iterable[Buffer | None]:
+        import cupy as cp
+
+        result: list[Buffer | None] = []
+        for a, (_, spec) in zip(arrays, chunks_and_specs, strict=True):
+            if a is None:
+                result.append(None)
+            else:
+                a2 = cp.array(a, dtype=a.dtype, copy=False)
+                if a2.dtype != np.dtype("B"):
+                    a2 = a2.view(dtype=np.dtype("B"))
+                result.append(spec.prototype.buffer.from_array_like(a2))
+        return result
+
+    async def decode(
+        self,
+        chunks_and_specs: Iterable[tuple[Buffer | None, ArraySpec]],
+    ) -> Iterable[Buffer | None]:
+        """Decode a batch of zstd-compressed chunks on the GPU via nvCOMP."""
+        import cupy as cp
+
+        chunks_and_specs = list(chunks_and_specs)
+        filtered_inputs, none_indices = self._convert_to_nvcomp_arrays(chunks_and_specs)
+        outputs = self._zstd_codec.decode(filtered_inputs) if len(filtered_inputs) > 0 else []
+        event = cp.cuda.Event()
+        event.record()
+        await asyncio.to_thread(event.synchronize)
+        outputs = list(outputs)
+        for index in none_indices:
+            outputs.insert(index, None)
+        return self._convert_from_nvcomp_arrays(outputs, chunks_and_specs)
+
+    async def encode(
+        self,
+        chunks_and_specs: Iterable[tuple[Buffer | None, ArraySpec]],
+    ) -> Iterable[Buffer | None]:
+        """Encode a batch of chunks with zstd on the GPU via nvCOMP."""
+        import cupy as cp
+
+        chunks_and_specs = list(chunks_and_specs)
+        filtered_inputs, none_indices = self._convert_to_nvcomp_arrays(chunks_and_specs)
+        outputs = self._zstd_codec.encode(filtered_inputs) if len(filtered_inputs) > 0 else []
+        event = cp.cuda.Event()
+        event.record()
+        await asyncio.to_thread(event.synchronize)
+        outputs = list(outputs)
+        for index in none_indices:
+            outputs.insert(index, None)
+        return self._convert_from_nvcomp_arrays(outputs, chunks_and_specs)
+
+    def compute_encoded_size(self, input_byte_length: int, chunk_spec: ArraySpec) -> int:
+        """Raise NotImplementedError — encoded size is data-dependent for zstd."""
+        del input_byte_length, chunk_spec
+        raise NotImplementedError
+
+
+_REGISTERED = False
+
+
+def register_nvcomp_zstd() -> bool:
+    """Register :class:`NvcompZstdCodec` under the name ``zstd``.
+
+    Idempotent. Returns True if registration succeeded (or was already done), False if the
+    required GPU dependencies (``cupy``, ``nvidia.nvcomp``) are not importable.
+
+    Note that registration alone is not enough to make zarr use the GPU codec — zarr 3.2
+    selects the concrete class via ``zarr.config["codecs.zstd"]`` and the default points at
+    the CPU codec. Use :func:`gpu_zstd_config` (or rely on
+    :func:`linumpy.gpu.zarr_io.gpu_zarr_context`) to flip the config for a scoped block.
+    """
+    global _REGISTERED
+    if _REGISTERED:
+        return True
+    try:
+        import cupy  # noqa: F401
+        from nvidia import nvcomp  # noqa: F401
+    except ImportError:
+        return False
+    from zarr.registry import register_codec
+
+    register_codec("zstd", NvcompZstdCodec)
+    _REGISTERED = True
+    return True
+
+
+def gpu_zstd_config() -> dict[str, str]:
+    """Return the zarr config overrides that route the ``zstd`` codec through nvCOMP.
+
+    Pass the result to ``zarr.config.set(...)`` to enable GPU-side zstd decoding for the
+    duration of the ``set`` context. Caller is responsible for calling
+    :func:`register_nvcomp_zstd` first (otherwise zarr cannot resolve the class name).
+    """
+    return {"codecs.zstd": "linumpy.gpu.nvcomp_zstd.NvcompZstdCodec"}

--- a/linumpy/gpu/zarr_io.py
+++ b/linumpy/gpu/zarr_io.py
@@ -1,0 +1,202 @@
+"""High-level zarr → GPU loading with automatic backend selection.
+
+Public entry points:
+
+* :func:`read_zarr_to_gpu` — load an entire zarr array onto the GPU using the
+  fastest available path (kvikio / GDS, falling back to ``zarr.config.enable_gpu``).
+* :func:`gpu_zarr_context` — context manager that flips zarr into GPU mode for
+  its duration, so subsequent ``zarr.open_array(...)`` calls return arrays whose
+  slicing materialises directly into ``cupy.ndarray``. Use this for tile-by-tile
+  / per-slab access patterns where loading the whole volume at once is wasteful.
+
+Selection order (when ``prefer='auto'``):
+
+1. **kvikio (GPUDirect Storage, native mode)** — chunks DMA'd directly from
+   NVMe into GPU memory. Requires ``kvikio`` installed, GDS in native mode,
+   and an uncompressed zarr v2/v3.
+2. **zarr.config.enable_gpu()** — host I/O with on-host decode then a single
+   H→D copy. Works for any zarr (compressed or not). The fallback when GDS
+   is unavailable, in compat mode, or the array is compressed.
+
+Backend implementations live in their own modules:
+
+* :mod:`linumpy.gpu.kvikio_zarr` — kvikio / GDS reader.
+
+Reference numbers on a 16 GiB float32 zarr v3 (RTX A6000, ext4, GDS native)
+warm cache: kvikio ~9.9 GiB/s, zarr-gpu ~7.1 GiB/s.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Literal
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+Backend = Literal["auto", "kvikio", "zarr-gpu"]
+
+
+def _kvikio_native_mode_available() -> bool:
+    """Return True iff kvikio is importable and not stuck in compat mode.
+
+    kvikio always succeeds at import; the relevant question is whether
+    ``cufile.json`` (or env vars) allow native GDS. The API moved in kvikio
+    25.x → 26.x:
+
+    * Older: ``kvikio.defaults.compat_mode()`` → ``CompatMode`` enum
+      (``OFF``/``ON``/``AUTO``).
+    * 26.04+: ``kvikio.defaults.is_compat_mode_preferred()`` → ``bool``
+      (``True`` means kvikio will use the POSIX bounce-buffer path).
+    """
+    try:
+        import kvikio  # noqa: F401
+        from kvikio import defaults
+    except ImportError:
+        return False
+    # Newer API first.
+    is_compat_pref = getattr(defaults, "is_compat_mode_preferred", None)
+    if callable(is_compat_pref):
+        try:
+            return not bool(is_compat_pref())
+        except Exception:  # pragma: no cover - hardware-dependent
+            return False
+    # Legacy enum API.
+    compat_mode = getattr(defaults, "compat_mode", None)
+    if callable(compat_mode):
+        try:
+            mode = compat_mode()
+        except Exception:  # pragma: no cover - older kvikio variants
+            return False
+        name = getattr(mode, "name", str(mode)).upper()
+        return name in {"OFF", "AUTO"}
+    return False
+
+
+def _array_is_kvikio_compatible(array_path: Path) -> bool:
+    """Return True iff the on-disk array meets kvikio's raw-bytes constraints."""
+    from linumpy.gpu.kvikio_zarr import _load_array_spec
+
+    try:
+        _load_array_spec(array_path)
+    except (NotImplementedError, FileNotFoundError, ValueError):
+        return False
+    return True
+
+
+def read_zarr_via_zarr_gpu(array_path: str | Path) -> Any:
+    """Load a zarr array onto the GPU using ``zarr.config.enable_gpu()``.
+
+    Host I/O with on-host decode, then a single H→D copy. Works for any zarr
+    array (including compressed) and is the recommended fallback when GDS is
+    unavailable or stuck in compat mode.
+
+    Parameters
+    ----------
+    array_path
+        Path to the zarr array directory.
+
+    Returns
+    -------
+    cupy.ndarray
+        Device-resident array.
+    """
+    try:
+        import cupy
+        import zarr
+    except ImportError as exc:  # pragma: no cover - hardware-dependent
+        raise RuntimeError("cupy + zarr are required for the zarr-gpu fallback path.") from exc
+
+    from linumpy.gpu.nvcomp_zstd import gpu_zstd_config, register_nvcomp_zstd
+
+    extra_cfg = gpu_zstd_config() if register_nvcomp_zstd() else {}
+
+    with zarr.config.enable_gpu(), zarr.config.set(extra_cfg):
+        z = zarr.open_array(str(array_path), mode="r")
+        dev = z[:]
+    cupy.cuda.Stream.null.synchronize()
+    return dev
+
+
+def read_zarr_to_gpu(array_path: str | Path, *, prefer: Backend = "auto") -> Any:
+    """Load a zarr array onto the GPU using the fastest available path.
+
+    Selection order (when ``prefer='auto'``):
+
+    1. kvikio / GDS — only if kvikio is in native or auto mode AND the array
+       is uncompressed v2/v3.
+    2. ``zarr.config.enable_gpu()`` — works for any zarr.
+
+    Parameters
+    ----------
+    array_path
+        Path to the zarr array directory.
+    prefer
+        ``'auto'`` (default), ``'kvikio'``, or ``'zarr-gpu'``. Forcing a path
+        will raise if that path is unavailable for this array.
+
+    Returns
+    -------
+    cupy.ndarray
+        Device-resident array of shape and dtype matching the zarr metadata.
+    """
+    path = Path(array_path)
+
+    if prefer == "kvikio":
+        from linumpy.gpu.kvikio_zarr import read_zarr_via_kvikio
+
+        return read_zarr_via_kvikio(path)
+    if prefer == "zarr-gpu":
+        return read_zarr_via_zarr_gpu(path)
+    if prefer != "auto":
+        raise ValueError(f"unknown prefer={prefer!r}; expected 'auto', 'kvikio', or 'zarr-gpu'")
+
+    if _kvikio_native_mode_available() and _array_is_kvikio_compatible(path):
+        from linumpy.gpu.kvikio_zarr import read_zarr_via_kvikio
+
+        try:
+            return read_zarr_via_kvikio(path)
+        except (RuntimeError, OSError, NotImplementedError):
+            pass
+
+    return read_zarr_via_zarr_gpu(path)
+
+
+@contextmanager
+def gpu_zarr_context() -> Iterator[None]:
+    """Context manager that puts zarr into GPU mode for arbitrary slice reads.
+
+    Inside this context, any subsequent ``zarr.open_array(...)`` returns an
+    array whose slicing produces ``cupy.ndarray`` results — chunks are decoded
+    on host then transferred to device on each ``vol[slice]`` operation. This
+    is the right pattern for tile-by-tile or per-slab work where loading the
+    full volume at once is wasteful.
+
+    Outside this context, zarr falls back to its normal numpy-backed mode.
+
+    Examples
+    --------
+    >>> from linumpy.gpu.zarr_io import gpu_zarr_context
+    >>> from linumpy.io.zarr import read_omezarr
+    >>> with gpu_zarr_context():
+    ...     vol, _ = read_omezarr(path, level=0)
+    ...     for tile_region in regions:
+    ...         tile_gpu = vol[tile_region]  # already cupy
+
+    Raises
+    ------
+    RuntimeError
+        If zarr is unavailable.
+    """
+    try:
+        import zarr
+    except ImportError as exc:  # pragma: no cover - zarr is a hard dep
+        raise RuntimeError("zarr is required for gpu_zarr_context().") from exc
+
+    from linumpy.gpu.nvcomp_zstd import gpu_zstd_config, register_nvcomp_zstd
+
+    extra_cfg = gpu_zstd_config() if register_nvcomp_zstd() else {}
+
+    with zarr.config.enable_gpu(), zarr.config.set(extra_cfg):
+        yield

--- a/linumpy/intensity/bias_field.py
+++ b/linumpy/intensity/bias_field.py
@@ -1,0 +1,499 @@
+"""N4 bias field correction for serial OCT stacks.
+
+Provides CPU-based N4 correction via SimpleITK and helpers to run it
+per serial section in parallel via :mod:`multiprocessing`.
+
+Typical two-pass usage::
+
+    from linumpy.intensity.bias_field import compute_tissue_mask, n4_correct_per_section, n4_correct
+
+    mask = compute_tissue_mask(vol)
+    vol_ps, _ = n4_correct_per_section(vol, n_serial_slices=50, mask=mask, n_processes=48)
+    vol_out, _ = n4_correct(vol_ps, mask)
+"""
+
+from __future__ import annotations
+
+import multiprocessing
+from typing import Any
+
+import numpy as np
+import SimpleITK as sitk
+
+from linumpy.intensity.normalization import _chunk_boundaries
+
+# ---------------------------------------------------------------------------
+# Tissue mask
+# ---------------------------------------------------------------------------
+
+
+def _compute_tissue_mask_gpu(
+    vol: np.ndarray,
+    smoothing_sigma: float,
+    smoothing_sigma_z: float,
+    n_serial_slices: int,
+    closing_radius: int,
+    z_closing_sections: int,
+) -> np.ndarray:
+    """GPU implementation of :func:`compute_tissue_mask`.
+
+    Keeps the full pipeline (gaussian → Otsu → threshold → per-Z hole
+    fill + closing → final Z-closing) resident on GPU. Only the final
+    bool mask crosses PCIe (8x smaller than a float32 D2H of the
+    smoothed volume). One section per H2D round trip; if a single
+    section exceeds GPU memory, we fall back to the CPU path.
+    """
+    import cupy as cp
+    from cupyx.scipy.ndimage import (
+        binary_closing as cp_binary_closing,
+    )
+    from cupyx.scipy.ndimage import (
+        binary_fill_holes as cp_binary_fill_holes,
+    )
+    from cupyx.scipy.ndimage import (
+        gaussian_filter as cp_gaussian_filter,
+    )
+    from skimage.morphology import disk
+
+    sigma_zyx = (smoothing_sigma_z, smoothing_sigma, smoothing_sigma)
+    structuring_g = cp.asarray(disk(closing_radius), dtype=bool) if closing_radius > 0 else None
+
+    bounds = _chunk_boundaries(vol.shape[0], n_serial_slices)
+    mask = np.zeros(vol.shape, dtype=bool)
+
+    for s, e in bounds:
+        section_g = cp.asarray(vol[s:e], dtype=cp.float32)
+        smoothed_g = cp_gaussian_filter(section_g, sigma=sigma_zyx)
+        del section_g
+
+        # Otsu on the GPU section using cupy.histogram on nonzero voxels.
+        nonzero_g = smoothed_g[smoothed_g > 0]
+        if nonzero_g.size < 100:
+            mask[s:e] = True
+            del smoothed_g, nonzero_g
+            cp.get_default_memory_pool().free_all_blocks()
+            continue
+        thresh = float(_otsu_threshold_gpu(nonzero_g))
+        del nonzero_g
+
+        section_mask_g = smoothed_g > thresh
+        del smoothed_g
+
+        # Per-Z hole filling and closing (oblique masks differ across Z).
+        for z in range(section_mask_g.shape[0]):
+            plane_g = cp_binary_fill_holes(section_mask_g[z])
+            if structuring_g is not None:
+                plane_g = cp_binary_closing(plane_g, structure=structuring_g)
+            section_mask_g[z] = plane_g
+
+        mask[s:e] = cp.asnumpy(section_mask_g)
+        del section_mask_g
+        cp.get_default_memory_pool().free_all_blocks()
+
+    # Bridge step artifacts at section boundaries by closing along Z.
+    if z_closing_sections > 0 and n_serial_slices > 1:
+        z_struct = np.ones((2 * z_closing_sections + 1, 1, 1), dtype=bool)
+        # The full bool mask is 8x smaller than vol; usually fits on a single
+        # GPU. If it does not, fall back to CPU for this final step.
+        mask_bytes = int(mask.size)
+        free_mem, _ = cp.cuda.runtime.memGetInfo()
+        if mask_bytes * 4 < free_mem:  # 4x headroom for kernel scratch
+            mask_g = cp.asarray(mask)
+            struct_g = cp.asarray(z_struct)
+            mask_g = cp_binary_closing(mask_g, structure=struct_g)
+            mask = cp.asnumpy(mask_g)
+            del mask_g, struct_g
+            cp.get_default_memory_pool().free_all_blocks()
+        else:
+            from scipy.ndimage import binary_closing as np_binary_closing
+
+            mask = np_binary_closing(mask, structure=z_struct)
+
+    return mask
+
+
+def _otsu_threshold_gpu(values: Any, nbins: int = 256) -> float:
+    """Compute Otsu's threshold on a 1-D CuPy array via histogram search."""
+    import cupy as cp
+
+    lo = float(values.min().item())
+    hi = float(values.max().item())
+    if hi <= lo:
+        return lo
+    hist, edges = cp.histogram(values, bins=nbins, range=(lo, hi))
+    # Mirror skimage.filters.threshold_otsu: minimize within-class variance
+    # equivalent to maximizing between-class variance.
+    centers = 0.5 * (edges[:-1] + edges[1:])
+    hist = hist.astype(cp.float64)
+    weight1 = cp.cumsum(hist)
+    weight2 = cp.cumsum(hist[::-1])[::-1]
+    mean1 = cp.cumsum(hist * centers) / cp.maximum(weight1, 1.0)
+    mean2 = (cp.cumsum((hist * centers)[::-1]) / cp.maximum(weight2[::-1], 1.0))[::-1]
+    variance12 = weight1[:-1] * weight2[1:] * (mean1[:-1] - mean2[1:]) ** 2
+    idx = int(cp.argmax(variance12).item())
+    return float(centers[idx].item())
+
+
+def compute_tissue_mask(
+    vol: np.ndarray,
+    smoothing_sigma: float = 2.0,
+    n_serial_slices: int = 1,
+    closing_radius: int = 3,
+    z_closing_sections: int = 2,
+    smoothing_sigma_z: float = 1.0,
+    use_gpu: bool = False,
+) -> np.ndarray:
+    """Return a 3-D boolean mask where *True* indicates tissue (not agarose).
+
+    The volume is lightly smoothed with an anisotropic 3-D Gaussian
+    (``smoothing_sigma`` in XY, ``smoothing_sigma_z`` in Z) and a single
+    Otsu threshold is computed per serial section from the smoothed
+    voxel histogram (background-zero voxels excluded).  The threshold is
+    then applied per voxel, so the mask follows tissue shape through Z
+    and correctly handles oblique sections (e.g. 45° acquisitions),
+    where the tissue footprint shifts across Z within a section.
+
+    Each Z-plane is post-processed with hole-filling and morphological
+    closing to remove internal speckle (e.g. dark white-matter or
+    ventricle voxels falling below the Otsu threshold).  Finally the
+    stacked 3-D mask is closed along Z to bridge step artifacts at
+    section boundaries.
+
+    Parameters
+    ----------
+    vol : np.ndarray
+        3-D volume (Z, Y, X), any float dtype.
+    smoothing_sigma : float
+        Gaussian smoothing sigma in XY (pixels) before thresholding.
+    n_serial_slices : int
+        Number of serial sections in the volume.  When 1 (default), one
+        global Otsu threshold is used.
+    closing_radius : int
+        Radius (pixels) of the 2-D disk used for morphological closing
+        on each Z-plane mask.  0 disables 2-D closing.
+    z_closing_sections : int
+        Number of adjacent sections to bridge with a 3-D closing pass on
+        the stacked mask.  0 disables Z-direction closing.
+    smoothing_sigma_z : float
+        Gaussian smoothing sigma along Z (voxels) before thresholding.
+        Small values (1-2) denoise without blurring oblique edges.
+    use_gpu : bool
+        If True, run the dominant 3-D ``gaussian_filter`` on GPU via
+        CuPy (Z-chunked for memory safety). Falls back to CPU silently
+        if CuPy is unavailable. Otsu and morphology stay on CPU. When
+        *vol* is already a ``cupy.ndarray`` the GPU path is used
+        regardless and slabs are read with no host round-trip.
+
+    Returns
+    -------
+    np.ndarray
+        Boolean array of shape (Z, Y, X) -- True where tissue is present.
+    """
+    from scipy.ndimage import binary_closing, binary_fill_holes, gaussian_filter
+    from skimage.filters import threshold_otsu
+    from skimage.morphology import disk
+
+    from linumpy.gpu import is_cupy_array
+
+    # Cupy input always goes through the GPU path; the CPU fallback uses
+    # numpy/scipy ops that don't accept cupy arrays.
+    if use_gpu or is_cupy_array(vol):
+        try:
+            return _compute_tissue_mask_gpu(
+                vol,
+                smoothing_sigma=smoothing_sigma,
+                smoothing_sigma_z=smoothing_sigma_z,
+                n_serial_slices=n_serial_slices,
+                closing_radius=closing_radius,
+                z_closing_sections=z_closing_sections,
+            )
+        except ImportError:
+            if is_cupy_array(vol):
+                raise  # cupy installed but cupyx missing — surface clearly
+            # CuPy missing -- fall back to CPU below.
+
+    # Anisotropic 3-D smoothing: stronger in XY, light in Z to preserve
+    # oblique tissue boundaries without per-Z Otsu noise.
+    sigma_zyx = (smoothing_sigma_z, smoothing_sigma, smoothing_sigma)
+    smoothed = gaussian_filter(vol.astype(np.float32), sigma=sigma_zyx)
+
+    bounds = _chunk_boundaries(vol.shape[0], n_serial_slices)
+    mask = np.zeros(vol.shape, dtype=bool)
+    structuring = disk(closing_radius) if closing_radius > 0 else None
+    for s, e in bounds:
+        section_smooth = smoothed[s:e]
+        nonzero = section_smooth[section_smooth > 0]
+        if nonzero.size < 100:
+            mask[s:e] = True
+            continue
+        thresh = threshold_otsu(nonzero)
+        section_mask = section_smooth > thresh
+        # Per-Z hole filling and closing (oblique masks differ across Z).
+        for z in range(section_mask.shape[0]):
+            plane = binary_fill_holes(section_mask[z])
+            if structuring is not None:
+                plane = binary_closing(plane, structure=structuring)
+            section_mask[z] = plane
+        mask[s:e] = section_mask
+
+    # Bridge step artifacts at section boundaries by closing along Z.
+    if z_closing_sections > 0 and n_serial_slices > 1:
+        z_struct = np.ones((2 * z_closing_sections + 1, 1, 1), dtype=bool)
+        mask = binary_closing(mask, structure=z_struct)
+
+    return mask
+
+
+# ---------------------------------------------------------------------------
+# N4 core
+# ---------------------------------------------------------------------------
+
+
+def n4_correct(
+    vol: np.ndarray,
+    mask: np.ndarray | None = None,
+    *,
+    shrink_factor: int = 4,
+    n_iterations: list[int] | None = None,
+    spline_distance_mm: float = 10.0,
+    voxel_size_mm: tuple[float, float, float] = (1.0, 1.0, 1.0),
+    backend: str = "cpu",
+    out: np.ndarray | None = None,
+    bias_out: np.ndarray | None = None,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Run N4 bias field correction on a 3-D volume.
+
+    The N4 fit is performed on a spatially downsampled copy (``shrink_factor``);
+    the bias field is then upsampled back to full resolution before division.
+
+    Parameters
+    ----------
+    vol : np.ndarray
+        Float32 input volume (Z, Y, X).
+    mask : np.ndarray or None
+        Boolean tissue mask (Z, Y, X) -- same shape as *vol*.  A full-volume
+        mask is used when *None*.
+    shrink_factor : int
+        Isotropic spatial downsampling factor for the N4 fit.
+    n_iterations : list of int or None
+        Max iterations per fitting level; its length sets the number of fitting
+        levels.  Defaults to ``[50, 50, 50, 50]`` (4 levels).
+    spline_distance_mm : float
+        Approximate distance (in mm) between B-spline control-point knots.
+    voxel_size_mm : 3-tuple of float
+        Voxel size (z, y, x) in mm -- sets physical spacing for SimpleITK.
+    backend : {"cpu", "gpu", "auto"}
+        Backend selector.  ``"cpu"`` (default) uses SimpleITK's N4
+        implementation.  ``"gpu"`` dispatches to
+        :func:`linumpy.gpu.n4.n4_correct_gpu` (CuPy-accelerated when CUDA is
+        available, NumPy fallback otherwise).  ``"auto"`` picks ``"gpu"`` when
+        CuPy + CUDA are available and ``"cpu"`` otherwise.
+    out, bias_out : np.ndarray, optional
+        Destination buffers (GPU backend only).  When provided, the
+        N4 driver writes its full-resolution outputs directly into
+        these buffers instead of allocating fresh arrays, saving up to
+        two full-volume float32 allocations.  ``out`` may safely alias
+        the input ``vol`` -- the host buffer is not read after the
+        initial H2D upload.
+
+    Returns
+    -------
+    corrected : np.ndarray
+        Bias-corrected float32 volume, same shape as *vol*.
+    bias_field : np.ndarray
+        Estimated bias field (multiplicative), float32, same shape as *vol*.
+    """
+    if backend not in ("cpu", "gpu", "auto"):
+        raise ValueError(f"backend must be 'cpu', 'gpu', or 'auto', got {backend!r}")
+
+    if backend == "auto":
+        from linumpy.gpu import GPU_AVAILABLE
+
+        backend = "gpu" if GPU_AVAILABLE else "cpu"
+
+    if backend == "gpu":
+        from linumpy.gpu.n4 import n4_correct_gpu
+
+        return n4_correct_gpu(
+            vol,
+            mask,
+            shrink_factor=shrink_factor,
+            n_iterations=n_iterations,
+            spline_distance_mm=spline_distance_mm,
+            voxel_size_mm=voxel_size_mm,
+            use_gpu=True,
+            out=out,
+            bias_out=bias_out,
+        )
+
+    if out is not None or bias_out is not None:
+        raise ValueError("out / bias_out are only supported with backend='gpu'")
+
+    vol_f32 = vol.astype(np.float32)
+
+    if n_iterations is None:
+        n_iterations = [50, 50, 50, 50]
+
+    # Build SimpleITK images -- ITK convention is (x, y, z), so transpose (Z,Y,X)→(X,Y,Z)
+    sitk_vol = sitk.GetImageFromArray(vol_f32.transpose(2, 1, 0))
+    sitk_vol.SetSpacing((float(voxel_size_mm[2]), float(voxel_size_mm[1]), float(voxel_size_mm[0])))
+
+    if mask is not None:
+        sitk_mask = sitk.GetImageFromArray(mask.astype(np.uint8).transpose(2, 1, 0))
+        sitk_mask.CopyInformation(sitk_vol)
+    else:
+        sitk_mask = None
+
+    # Shrink for fast fit
+    shrinker = sitk.ShrinkImageFilter()
+    shrinker.SetShrinkFactors([shrink_factor] * 3)
+    sitk_vol_shrunk = shrinker.Execute(sitk_vol)
+    sitk_mask_shrunk = shrinker.Execute(sitk_mask) if sitk_mask is not None else None
+
+    corrector = sitk.N4BiasFieldCorrectionImageFilter()
+    corrector.SetMaximumNumberOfIterations(n_iterations)
+
+    # Per-axis control points = physical extent (mm) / spline_distance (mm).
+    # SimpleITK expects (x, y, z) order while voxel_size_mm / vol.shape are (z, y, x).
+    min_control_points = corrector.GetSplineOrder() + 1  # ITK requires n_pts > spline_order
+    extents_mm_zyx = [vol_f32.shape[i] * float(voxel_size_mm[i]) for i in range(3)]
+    n_pts_zyx = [max(min_control_points, round(e / spline_distance_mm)) for e in extents_mm_zyx]
+    corrector.SetNumberOfControlPoints([n_pts_zyx[2], n_pts_zyx[1], n_pts_zyx[0]])
+
+    if sitk_mask_shrunk is not None:
+        corrector.Execute(sitk_vol_shrunk, sitk_mask_shrunk)
+    else:
+        corrector.Execute(sitk_vol_shrunk)
+
+    # Reconstruct full-resolution bias field
+    log_bias_shrunk = corrector.GetLogBiasFieldAsImage(sitk_vol_shrunk)
+    log_bias_full = sitk.Resample(
+        log_bias_shrunk,
+        sitk_vol,
+        sitk.Transform(),
+        sitk.sitkLinear,
+        0.0,
+        sitk.sitkFloat32,
+    )
+    log_bias_arr = sitk.GetArrayFromImage(log_bias_full).transpose(2, 1, 0)  # back to (Z,Y,X)
+    bias_field = np.exp(log_bias_arr).astype(np.float32)
+
+    corrected = apply_bias_field(vol_f32, bias_field)
+    return corrected, bias_field
+
+
+# ---------------------------------------------------------------------------
+# Bias field application
+# ---------------------------------------------------------------------------
+
+
+def apply_bias_field(vol: np.ndarray, bias_field: np.ndarray, floor: float = 1e-6) -> np.ndarray:
+    """Divide *vol* element-wise by *bias_field*, guarding against near-zero divisors.
+
+    Parameters
+    ----------
+    vol : np.ndarray
+        Input volume, any shape.
+    bias_field : np.ndarray
+        Multiplicative bias field, same shape as *vol*.
+    floor : float
+        Minimum divisor value (prevents division by zero).
+
+    Returns
+    -------
+    np.ndarray
+        Corrected float32 array.
+    """
+    divisor = np.maximum(bias_field.astype(np.float32), floor)
+    return (vol.astype(np.float32) / divisor).astype(np.float32)
+
+
+# ---------------------------------------------------------------------------
+# Per-section parallel N4
+# ---------------------------------------------------------------------------
+
+
+def _n4_section_worker(args: tuple[Any, ...]) -> tuple[np.ndarray, np.ndarray]:
+    """Worker function for :func:`n4_correct_per_section` (picklable top-level)."""
+    chunk_vol, chunk_mask, kwargs = args
+    return n4_correct(chunk_vol, chunk_mask, **kwargs)
+
+
+def n4_correct_per_section(
+    vol: np.ndarray,
+    n_serial_slices: int,
+    mask: np.ndarray | None = None,
+    *,
+    n_processes: int = 1,
+    **kwargs: Any,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Run N4 bias field correction independently on each serial section.
+
+    Splits the volume along Z into *n_serial_slices* chunks and corrects each
+    chunk independently (serial sections have independent optical attenuation).
+    Chunks are dispatched to a :class:`multiprocessing.Pool` when
+    *n_processes* > 1.
+
+    Parameters
+    ----------
+    vol : np.ndarray
+        Float32 3-D volume (Z, Y, X).
+    n_serial_slices : int
+        Number of serial tissue sections stacked along Z.
+    mask : np.ndarray or None
+        Boolean tissue mask (Z, Y, X).  Sliced alongside *vol*.
+    n_processes : int
+        Number of parallel worker processes.  1 runs serially.
+    **kwargs
+        Extra keyword arguments forwarded to :func:`n4_correct`
+        (e.g. ``shrink_factor``, ``spline_distance_mm``).
+
+    Returns
+    -------
+    corrected : np.ndarray
+        Bias-corrected float32 volume, same shape as *vol*.
+    bias_field : np.ndarray
+        Per-section bias field stitched into a single (Z, Y, X) array.
+    """
+    bounds = _chunk_boundaries(vol.shape[0], n_serial_slices)
+
+    # GPU backend cannot be parallelised across processes (single device);
+    # force serial execution.
+    backend = kwargs.get("backend", "cpu")
+    if backend == "auto":
+        from linumpy.gpu import GPU_AVAILABLE
+
+        effective_gpu = GPU_AVAILABLE
+    else:
+        effective_gpu = backend == "gpu"
+
+    if effective_gpu and n_processes != 1:
+        import logging
+
+        logging.getLogger(__name__).warning(
+            "GPU N4 backend cannot be parallelised across processes (single device); "
+            "forcing n_processes=1 (was %d). Per-section sections will run serially on GPU.",
+            n_processes,
+        )
+        n_processes = 1
+
+    work_items = [
+        (
+            vol[s:e].copy(),
+            mask[s:e].copy() if mask is not None else None,
+            kwargs,
+        )
+        for s, e in bounds
+    ]
+
+    if n_processes == 1:
+        results = [_n4_section_worker(item) for item in work_items]
+    else:
+        with multiprocessing.Pool(processes=n_processes) as pool:
+            results = pool.map(_n4_section_worker, work_items)
+
+    corrected_chunks, bias_chunks = zip(*results, strict=True)
+
+    corrected = np.concatenate(corrected_chunks, axis=0)
+    bias_field = np.concatenate(bias_chunks, axis=0)
+    return corrected, bias_field

--- a/linumpy/tests/test_gpu_bspline.py
+++ b/linumpy/tests/test_gpu_bspline.py
@@ -1,0 +1,176 @@
+"""Tests for linumpy.gpu.bspline."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from linumpy.gpu import GPU_AVAILABLE
+from linumpy.gpu.bspline import (
+    _cubic_bspline_basis,
+    bspline_evaluate,
+    bspline_fit,
+)
+
+# ---------------------------------------------------------------------------
+# Basis function sanity
+# ---------------------------------------------------------------------------
+
+
+def test_basis_partition_of_unity():
+    """The four cubic B-spline weights must sum to 1 for any t in [0, 1)."""
+    t = np.linspace(0.0, 0.999, 50, dtype=np.float32)
+    weights = _cubic_bspline_basis(t, np)
+    assert weights.shape == (50, 4)
+    np.testing.assert_allclose(weights.sum(axis=1), 1.0, atol=1e-6)
+
+
+def test_basis_nonnegative():
+    t = np.linspace(0.0, 0.999, 50, dtype=np.float32)
+    weights = _cubic_bspline_basis(t, np)
+    assert (weights >= 0).all()
+
+
+# ---------------------------------------------------------------------------
+# bspline_fit + bspline_evaluate (CPU path)
+# ---------------------------------------------------------------------------
+
+
+def _iterative_fit(
+    vals: np.ndarray,
+    n_control_points: tuple[int, int, int],
+    *,
+    mask: np.ndarray | None = None,
+    n_iter: int = 8,
+) -> np.ndarray:
+    """Fit ``vals`` by iterative residual PSDB fitting.
+
+    A single :func:`bspline_fit` call uses the Lee-Wolberg-Shin
+    pseudo-squared-distance-based form, which regularises short-range
+    support but does **not** reproduce smooth inputs in one pass. Real
+    callers (e.g. :mod:`linumpy.gpu.n4`) recover smooth fields by fitting
+    the residual at each iteration. This helper mirrors that pattern so
+    the tests exercise the primitive in its actual usage.
+    """
+    field = np.zeros_like(vals)
+    weights = mask.astype(np.float32) if mask is not None else None
+    for _ in range(n_iter):
+        residual = vals - field
+        if mask is not None:
+            residual = np.where(mask, residual, 0.0).astype(np.float32)
+        coeffs = bspline_fit(
+            residual,
+            weights=weights,
+            mask=mask,
+            n_control_points=n_control_points,
+            use_gpu=False,
+        )
+        field = field + bspline_evaluate(coeffs, vals.shape, use_gpu=False)
+    return field
+
+
+def test_bspline_constant_field():
+    """Iterative residual fits on a constant volume must converge to the constant.
+
+    PSDB single-grid convergence is geometric but slow (squared-weight
+    regularisation shrinks each update); 8 iterations on a coarse 6x8x8
+    control grid leave a few-percent residual which is the realistic
+    envelope for the way N4 uses the primitive.
+    """
+    shape = (12, 16, 16)
+    vals = np.full(shape, 0.7, dtype=np.float32)
+    field = _iterative_fit(vals, n_control_points=(6, 8, 8))
+    assert np.max(np.abs(field - 0.7)) < 0.1
+
+
+def test_bspline_linear_gradient():
+    """A linear gradient should be reproduced (approximately) in the interior."""
+    shape = (24, 24, 24)
+    z = np.arange(shape[0], dtype=np.float32)[:, None, None]
+    vals = np.broadcast_to(0.5 + 0.1 * z, shape).astype(np.float32)
+    field = _iterative_fit(vals, n_control_points=(8, 8, 8))
+
+    # Check interior (away from boundary smoothing).  Cubic B-spline kernel
+    # regression introduces small bias near boundaries; require the slope
+    # in the central region to match within 5%.
+    interior = field[6:-6]
+    means = interior.mean(axis=(1, 2))
+    slope = float(means[-1] - means[0]) / (interior.shape[0] - 1)
+    expected_slope = 0.1
+    assert abs(slope - expected_slope) / expected_slope < 0.05
+
+
+def test_bspline_smooth_recovery():
+    """A smooth field (sum of Gaussians) should be approximated within 10% rel error."""
+    shape = (20, 32, 32)
+    zz, yy, xx = np.meshgrid(
+        np.arange(shape[0], dtype=np.float32),
+        np.arange(shape[1], dtype=np.float32),
+        np.arange(shape[2], dtype=np.float32),
+        indexing="ij",
+    )
+    centre = (10.0, 16.0, 16.0)
+    sigma = 8.0
+    vals = (
+        1.0
+        + 0.3 * np.exp(-((zz - centre[0]) ** 2 + (yy - centre[1]) ** 2 + (xx - centre[2]) ** 2) / (2 * sigma**2))
+    ).astype(np.float32)
+
+    field = _iterative_fit(vals, n_control_points=(8, 12, 12))
+
+    rel_err = np.max(np.abs(field - vals) / vals)
+    assert rel_err < 0.10, f"Max relative error {rel_err:.4f} exceeds 10%"
+
+
+def test_bspline_mask_respected():
+    """Masked-out voxels must not influence the fit."""
+    shape = (12, 16, 16)
+    vals = np.zeros(shape, dtype=np.float32)
+    vals[:, :8, :] = 0.4  # left half: tissue
+    vals[:, 8:, :] = 1e6  # right half: should be ignored
+
+    mask = np.zeros(shape, dtype=bool)
+    mask[:, :8, :] = True
+
+    field = _iterative_fit(vals, n_control_points=(6, 8, 8), mask=mask)
+    # In the masked region, fitted value must be near 0.4 (not contaminated by 1e6).
+    assert np.max(np.abs(field[:, :8, :] - 0.4)) < 0.1
+
+
+def test_bspline_evaluate_resampling_shape():
+    """Evaluate at a different resolution than the fit; output shape must match."""
+    coeffs = np.ones((6, 8, 8), dtype=np.float32) * 0.5
+    field = bspline_evaluate(coeffs, target_shape=(20, 32, 32), use_gpu=False)
+    assert field.shape == (20, 32, 32)
+    np.testing.assert_allclose(field, 0.5, atol=1e-5)
+
+
+def test_bspline_invalid_control_points():
+    """Fewer than 4 control points on any axis should raise."""
+    vals = np.ones((10, 10, 10), dtype=np.float32)
+    with pytest.raises(ValueError):
+        bspline_fit(vals, None, None, n_control_points=(3, 5, 5), use_gpu=False)
+
+
+# ---------------------------------------------------------------------------
+# CPU/GPU agreement
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not GPU_AVAILABLE, reason="GPU not available")
+def test_bspline_cpu_gpu_agree_fit():
+    rng = np.random.default_rng(0)
+    shape = (16, 24, 24)
+    vals = rng.random(shape, dtype=np.float32)
+    cpu = bspline_fit(vals, None, None, n_control_points=(6, 8, 8), use_gpu=False)
+    gpu = bspline_fit(vals, None, None, n_control_points=(6, 8, 8), use_gpu=True)
+    assert np.max(np.abs(cpu - gpu)) < 1e-4
+
+
+@pytest.mark.skipif(not GPU_AVAILABLE, reason="GPU not available")
+def test_bspline_cpu_gpu_agree_evaluate():
+    rng = np.random.default_rng(1)
+    coeffs = rng.random((6, 8, 8), dtype=np.float32)
+    cpu = bspline_evaluate(coeffs, target_shape=(16, 24, 24), use_gpu=False)
+    gpu = bspline_evaluate(coeffs, target_shape=(16, 24, 24), use_gpu=True)
+    assert np.max(np.abs(cpu - gpu)) < 1e-4

--- a/scripts/linum_analyze_shifts.py
+++ b/scripts/linum_analyze_shifts.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+"""
+Analyze XY shifts from a shifts file and generate a drift analysis report.
+
+Produces:
+- Summary statistics of pairwise shifts
+- Outlier detection using IQR method
+- Cumulative drift analysis
+- Visualization of drift patterns
+
+Useful for debugging alignment issues and understanding sample drift during acquisition.
+"""
+
+import linumpy.config.threads  # noqa: F401
+
+import argparse
+import logging
+from pathlib import Path
+from typing import Any
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+from linumpy.cli.args import add_overwrite_arg, assert_output_exists
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+logger = logging.getLogger(__name__)
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
+    p.add_argument("in_shifts", help="Input shifts CSV file (shifts_xy.csv)")
+    p.add_argument("out_directory", help="Output directory for analysis results")
+
+    p.add_argument(
+        "--resolution", type=float, default=10.0, help="Resolution in µm/pixel for converting mm to pixels [%(default)s]"
+    )
+    p.add_argument("--iqr_multiplier", type=float, default=1.5, help="IQR multiplier for outlier detection [%(default)s]")
+    p.add_argument("--slice_config", default=None, help="Optional slice config file to mark excluded slices")
+
+    add_overwrite_arg(p)
+    return p
+
+
+def load_shifts(shifts_path: Path) -> Any:
+    """Load shifts CSV file.
+
+    Rows are sorted by ``moving_id`` so that every ``cumsum`` downstream
+    reflects slice order rather than CSV row order.
+    """
+    df = pd.read_csv(shifts_path)
+    required_cols = ["fixed_id", "moving_id", "x_shift_mm", "y_shift_mm"]
+    for col in required_cols:
+        if col not in df.columns:
+            raise ValueError(f"Missing required column: {col}")
+    return df.sort_values("moving_id").reset_index(drop=True)
+
+
+def detect_outliers(df: Any, iqr_multiplier: float = 1.5) -> Any:
+    """Detect outliers using IQR method on shift magnitude."""
+    shift_mag = np.sqrt(df["x_shift_mm"] ** 2 + df["y_shift_mm"] ** 2)
+    q1 = shift_mag.quantile(0.25)
+    q3 = shift_mag.quantile(0.75)
+    iqr = q3 - q1
+    upper_bound = q3 + iqr_multiplier * iqr
+    outlier_mask = shift_mag > upper_bound
+    return outlier_mask, upper_bound, q1, q3, iqr
+
+
+def filter_with_local_median(df: Any, outlier_mask: Any) -> Any:
+    """Replace outliers with local median of neighbors."""
+    df_filtered = df.copy()
+    for idx in df[outlier_mask].index:
+        pos = df.index.get_loc(idx)
+        neighbors_x, neighbors_y = [], []
+        for offset in [-2, -1, 1, 2]:
+            neighbor_pos = pos + offset
+            if 0 <= neighbor_pos < len(df):
+                neighbor_idx = df.index[neighbor_pos]
+                if not outlier_mask[neighbor_idx]:
+                    neighbors_x.append(df.loc[neighbor_idx, "x_shift_mm"])
+                    neighbors_y.append(df.loc[neighbor_idx, "y_shift_mm"])
+        if neighbors_x:
+            df_filtered.loc[idx, "x_shift_mm"] = np.median(neighbors_x)
+            df_filtered.loc[idx, "y_shift_mm"] = np.median(neighbors_y)
+    return df_filtered
+
+
+def generate_report(df: Any, df_filtered: Any, outlier_mask: Any, stats: Any, resolution: Any, output_dir: Path) -> str:
+    """Generate text report."""
+    px_per_mm = 1000 / resolution
+
+    report_lines = [
+        "=" * 60,
+        "SHIFTS ANALYSIS REPORT",
+        "=" * 60,
+        "",
+        "OVERVIEW",
+        "-" * 40,
+        f"Total shift pairs: {len(df)}",
+        f"Resolution: {resolution} µm/pixel",
+        "",
+        "PAIRWISE SHIFT STATISTICS",
+        "-" * 40,
+        f"X shift (mm): Mean={df['x_shift_mm'].mean():.4f}, Std={df['x_shift_mm'].std():.4f}",
+        f"Y shift (mm): Mean={df['y_shift_mm'].mean():.4f}, Std={df['y_shift_mm'].std():.4f}",
+        "",
+        "OUTLIER DETECTION (IQR Method)",
+        "-" * 40,
+        f"Q1={stats['q1']:.4f}, Q3={stats['q3']:.4f}, IQR={stats['iqr']:.4f}",
+        f"Upper bound: {stats['upper_bound']:.4f} mm",
+        f"Outliers detected: {outlier_mask.sum()}",
+    ]
+
+    if outlier_mask.sum() > 0:
+        report_lines.append("")
+        report_lines.append("Outlier shifts:")
+        shift_mag = np.sqrt(df["x_shift_mm"] ** 2 + df["y_shift_mm"] ** 2)
+        for idx in df[outlier_mask].index:
+            row = df.loc[idx]
+            mag = shift_mag[idx]
+            report_lines.append(
+                f"  {int(row['fixed_id'])}->{int(row['moving_id'])}: "
+                f"({row['x_shift_mm']:.3f}, {row['y_shift_mm']:.3f}) mm, mag={mag:.3f} mm"
+            )
+
+    # Cumulative drift
+    cumsum_x_orig = df["x_shift_mm"].cumsum()
+    cumsum_y_orig = df["y_shift_mm"].cumsum()
+    cumsum_x_filt = df_filtered["x_shift_mm"].cumsum()
+    cumsum_y_filt = df_filtered["y_shift_mm"].cumsum()
+
+    report_lines.extend(
+        [
+            "",
+            "CUMULATIVE DRIFT",
+            "-" * 40,
+            f"Before filtering: X={cumsum_x_orig.iloc[-1]:.3f} mm, Y={cumsum_y_orig.iloc[-1]:.3f} mm",
+            f"After filtering:  X={cumsum_x_filt.iloc[-1]:.3f} mm, Y={cumsum_y_filt.iloc[-1]:.3f} mm",
+            "",
+            f"In pixels (at {resolution} µm/pixel):",
+            f"  Before: X={cumsum_x_orig.iloc[-1] * px_per_mm:.0f} px, Y={cumsum_y_orig.iloc[-1] * px_per_mm:.0f} px",
+            f"  After:  X={cumsum_x_filt.iloc[-1] * px_per_mm:.0f} px, Y={cumsum_y_filt.iloc[-1] * px_per_mm:.0f} px",
+        ]
+    )
+
+    # Centered drift
+    mid_idx = len(cumsum_x_filt) // 2
+    centered_x = cumsum_x_filt - cumsum_x_filt.iloc[mid_idx]
+    centered_y = cumsum_y_filt - cumsum_y_filt.iloc[mid_idx]
+
+    report_lines.extend(
+        [
+            "",
+            f"CENTERED DRIFT (around slice {mid_idx})",
+            "-" * 40,
+            f"X range: {centered_x.min() * px_per_mm:.0f} to {centered_x.max() * px_per_mm:.0f} px",
+            f"Y range: {centered_y.min() * px_per_mm:.0f} to {centered_y.max() * px_per_mm:.0f} px",
+            "",
+            "=" * 60,
+        ]
+    )
+
+    report_text = "\n".join(report_lines)
+
+    # Save report
+    report_path = Path(output_dir) / "shifts_analysis.txt"
+    with report_path.open("w") as f:
+        f.write(report_text)
+
+    return report_text
+
+
+def generate_plots(df: Any, df_filtered: Any, _outlier_mask: Any, stats: Any, resolution: Any, output_dir: Path) -> Path:
+    """Generate visualization plots."""
+    px_per_mm = 1000 / resolution
+    upper_bound = stats["upper_bound"]
+
+    # Calculate cumulative drift
+    cumsum_x_orig = df["x_shift_mm"].cumsum()
+    cumsum_y_orig = df["y_shift_mm"].cumsum()
+    cumsum_x_filt = df_filtered["x_shift_mm"].cumsum()
+    cumsum_y_filt = df_filtered["y_shift_mm"].cumsum()
+
+    mid_idx = len(cumsum_x_filt) // 2
+    centered_x = cumsum_x_filt - cumsum_x_filt.iloc[mid_idx]
+    centered_y = cumsum_y_filt - cumsum_y_filt.iloc[mid_idx]
+
+    # Create figure
+    fig, axes = plt.subplots(2, 2, figsize=(14, 10))
+
+    # Plot 1: Pairwise shifts
+    ax = axes[0, 0]
+    ax.plot(df["moving_id"], df["x_shift_mm"], "b.-", label="X shift (original)", alpha=0.7)
+    ax.plot(df["moving_id"], df["y_shift_mm"], "r.-", label="Y shift (original)", alpha=0.7)
+    ax.plot(df["moving_id"], df_filtered["x_shift_mm"], "b-", label="X shift (filtered)", linewidth=2)
+    ax.plot(df["moving_id"], df_filtered["y_shift_mm"], "r-", label="Y shift (filtered)", linewidth=2)
+    ax.axhline(y=0, color="k", linestyle="--", alpha=0.3)
+    ax.axhline(y=upper_bound, color="g", linestyle=":", label=f"IQR threshold ({upper_bound:.2f}mm)")
+    ax.axhline(y=-upper_bound, color="g", linestyle=":")
+    ax.set_xlabel("Slice ID")
+    ax.set_ylabel("Shift (mm)")
+    ax.set_title("Pairwise Shifts")
+    ax.legend(fontsize=8)
+    ax.grid(True, alpha=0.3)
+
+    # Plot 2: Cumulative drift
+    ax = axes[0, 1]
+    ax.plot(df["moving_id"], cumsum_x_orig, "b--", label="X original", alpha=0.5)
+    ax.plot(df["moving_id"], cumsum_y_orig, "r--", label="Y original", alpha=0.5)
+    ax.plot(df["moving_id"], cumsum_x_filt, "b-", label="X filtered", linewidth=2)
+    ax.plot(df["moving_id"], cumsum_y_filt, "r-", label="Y filtered", linewidth=2)
+    ax.axhline(y=0, color="k", linestyle="--", alpha=0.3)
+    ax.set_xlabel("Slice ID")
+    ax.set_ylabel("Cumulative Drift (mm)")
+    ax.set_title("Cumulative Drift")
+    ax.legend()
+    ax.grid(True, alpha=0.3)
+
+    # Plot 3: Centered cumulative drift in pixels
+    ax = axes[1, 0]
+    ax.plot(df["moving_id"], centered_x * px_per_mm, "b-", label="X (centered)", linewidth=2)
+    ax.plot(df["moving_id"], centered_y * px_per_mm, "r-", label="Y (centered)", linewidth=2)
+    ax.axhline(y=0, color="k", linestyle="--", alpha=0.3)
+    ax.set_xlabel("Slice ID")
+    ax.set_ylabel(f"Centered Drift (pixels at {resolution}µm)")
+    ax.set_title("Centered Cumulative Drift")
+    ax.legend()
+    ax.grid(True, alpha=0.3)
+
+    # Plot 4: Drift trajectory
+    ax = axes[1, 1]
+    ax.plot(cumsum_x_filt * px_per_mm, cumsum_y_filt * px_per_mm, "g-", linewidth=2)
+    ax.plot(cumsum_x_filt.iloc[0] * px_per_mm, cumsum_y_filt.iloc[0] * px_per_mm, "go", markersize=10, label="Start")
+    ax.plot(cumsum_x_filt.iloc[-1] * px_per_mm, cumsum_y_filt.iloc[-1] * px_per_mm, "ro", markersize=10, label="End")
+    ax.plot(
+        cumsum_x_filt.iloc[mid_idx] * px_per_mm, cumsum_y_filt.iloc[mid_idx] * px_per_mm, "ko", markersize=10, label="Middle"
+    )
+    ax.set_xlabel("X position (pixels)")
+    ax.set_ylabel("Y position (pixels)")
+    ax.set_title("Drift Trajectory (filtered)")
+    ax.legend()
+    ax.grid(True, alpha=0.3)
+    ax.axis("equal")
+
+    plt.tight_layout()
+
+    # Save plot
+    plot_path = Path(output_dir) / "drift_analysis.png"
+    fig.savefig(plot_path, dpi=150, bbox_inches="tight")
+    plt.close(fig)
+
+    logger.info("Saved plot: %s", plot_path)
+    return plot_path
+
+
+def main() -> None:
+    """Run function."""
+    parser = _build_arg_parser()
+    args = parser.parse_args()
+
+    # Create output directory
+    assert_output_exists(args.out_directory, parser, args)
+    Path(args.out_directory).mkdir(parents=True)
+
+    # Load shifts
+    logger.info("Loading shifts from %s", args.in_shifts)
+    df = load_shifts(args.in_shifts)
+    logger.info("Loaded %s shift pairs", len(df))
+
+    # Detect outliers
+    outlier_mask, upper_bound, q1, q3, iqr = detect_outliers(df, args.iqr_multiplier)
+    logger.info("Detected %s outliers (IQR bound: %.3f mm)", outlier_mask.sum(), upper_bound)
+
+    # Filter outliers
+    df_filtered = filter_with_local_median(df, outlier_mask)
+
+    # Statistics
+    stats = {"q1": q1, "q3": q3, "iqr": iqr, "upper_bound": upper_bound}
+
+    # Generate report
+    report = generate_report(df, df_filtered, outlier_mask, stats, args.resolution, args.out_directory)
+    print(report)
+
+    # Generate plots
+    generate_plots(df, df_filtered, outlier_mask, stats, args.resolution, args.out_directory)
+
+    # Save filtered shifts (useful for debugging)
+    filtered_path = Path(args.out_directory) / "shifts_filtered.csv"
+    df_filtered.to_csv(filtered_path, index=False)
+    logger.info("Saved filtered shifts: %s", filtered_path)
+
+    logger.info("Analysis complete. Results saved to %s", args.out_directory)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/linum_assess_slice_quality.py
+++ b/scripts/linum_assess_slice_quality.py
@@ -1,0 +1,400 @@
+#!/usr/bin/env python3
+"""
+Assess slice quality for 3D mosaic grids and optionally update slice configuration.
+
+This script analyzes mosaic grid slices to detect quality issues that might affect
+reconstruction. It uses multiple metrics to identify problematic slices:
+
+1. **SSIM (Structural Similarity)**: Compares each slice to its neighbors
+2. **Edge Preservation**: Detects if edge structures are preserved compared to neighbors
+3. **Variance Consistency**: Checks for unusual signal variance (data loss/corruption)
+4. **First Slice Detection**: Automatically identifies calibration slices (thicker/different)
+
+GPU acceleration is used when available (--use_gpu, default on) for SSIM and
+edge-detection computations. Falls back to CPU automatically if no GPU is detected.
+
+The output can be:
+- A new slice_config.csv with quality scores and recommendations
+- An update to an existing slice_config.csv with quality assessments
+- A quality report for review
+
+Example usage:
+    # Assess quality and create/update slice config
+    linum_assess_slice_quality.py /path/to/mosaics slice_config.csv
+
+    # Assess and exclude low-quality slices automatically
+    linum_assess_slice_quality.py /path/to/mosaics slice_config.csv --min_quality 0.3
+
+    # Exclude first N calibration slices
+    linum_assess_slice_quality.py /path/to/mosaics slice_config.csv --exclude_first 1
+
+    # Update existing config with quality info
+    linum_assess_slice_quality.py /path/to/mosaics slice_config.csv --update_existing
+
+    # Force CPU fallback
+    linum_assess_slice_quality.py /path/to/mosaics slice_config.csv --no-use_gpu
+"""
+
+from __future__ import annotations
+
+# Configure thread limits before numpy/scipy imports
+import linumpy.config.threads  # noqa: F401
+
+import argparse
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from tqdm.auto import tqdm
+
+if TYPE_CHECKING:
+    import numpy as np
+
+from linumpy.cli.args import add_overwrite_arg, assert_output_exists
+from linumpy.gpu import GPU_AVAILABLE
+from linumpy.gpu.image_quality import (
+    assess_slice_quality_gpu,
+    clear_gpu_memory,
+)
+from linumpy.io import slice_config as slice_config_io
+from linumpy.io.zarr import read_omezarr
+from linumpy.metrics.image_quality import (
+    assess_slice_quality,
+    detect_calibration_slice,
+)
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
+    p.add_argument("input", help="Input directory containing mosaic grids (*.ome.zarr)")
+    p.add_argument("output_file", help="Output slice configuration CSV file")
+
+    gpu_group = p.add_argument_group("GPU Options")
+    gpu_group.add_argument(
+        "--use_gpu",
+        default=True,
+        action=argparse.BooleanOptionalAction,
+        help="Use GPU acceleration if available. [%(default)s]",
+    )
+    gpu_group.add_argument("--gpu_id", type=int, default=0, help="GPU device ID to use. [%(default)s]")
+
+    quality_group = p.add_argument_group("Quality Assessment")
+    quality_group.add_argument(
+        "--min_quality",
+        type=float,
+        default=0.0,
+        help="Minimum quality score to include slice (0-1). Default: 0.0 (include all, just report)",
+    )
+    quality_group.add_argument(
+        "--sample_depth",
+        type=int,
+        default=5,
+        help="Number of z-planes to sample per slice for faster assessment. Default: 5 (0=all)",
+    )
+    quality_group.add_argument(
+        "--pyramid_level",
+        type=int,
+        default=0,
+        help="Pyramid level to use for assessment (0=full res). Higher levels are faster but less accurate. Default: 0",
+    )
+    quality_group.add_argument(
+        "--roi_size",
+        type=int,
+        default=0,
+        help="Side length of center crop in XY (pixels) used for "
+        "all quality metrics. 0 = full plane (slow for large "
+        "single-resolution mosaics). Recommended: 1024.",
+    )
+    quality_group.add_argument(
+        "--processes",
+        type=int,
+        default=1,
+        help="Number of parallel workers for slice assessment (CPU mode only).\n"
+        "Each worker reads its own zarr planes concurrently.\n"
+        "Default: 1 (sequential). Set to params.processes.",
+    )
+
+    calib_group = p.add_argument_group("Calibration Slice Handling")
+    calib_group.add_argument(
+        "--exclude_first",
+        type=int,
+        default=1,
+        help="Exclude first N slices as calibration slices. Default: 1 (first slice is usually calibration)",
+    )
+    calib_group.add_argument(
+        "--detect_calibration",
+        action="store_true",
+        help="Automatically detect calibration slices by their different thickness/structure",
+    )
+    calib_group.add_argument(
+        "--calibration_thickness_ratio",
+        type=float,
+        default=1.5,
+        help="Slices with thickness ratio > this are flagged as calibration. Default: 1.5",
+    )
+
+    update_group = p.add_argument_group("Update Existing Config")
+    update_group.add_argument(
+        "--update_existing", action="store_true", help="Update an existing slice_config.csv with quality info"
+    )
+    update_group.add_argument("--existing_config", type=str, default=None, help="Path to existing slice config to update")
+
+    output_group = p.add_argument_group("Output Options")
+    output_group.add_argument("--report_only", action="store_true", help="Only print report, don't write config file")
+    output_group.add_argument("-v", "--verbose", action="store_true", help="Print detailed quality metrics per slice")
+
+    add_overwrite_arg(p)
+    return p
+
+
+def get_mosaic_files(directory: Path) -> dict[int, Path]:
+    """Find all mosaic grid files and extract slice IDs."""
+    pattern = r".*z(\d+).*\.ome\.zarr$"
+    mosaics = {}
+
+    for f in directory.iterdir():
+        if f.is_dir() and f.suffix == ".zarr":
+            match = re.match(pattern, f.name)
+            if match:
+                slice_id = int(match.group(1))
+                mosaics[slice_id] = f
+
+    return dict(sorted(mosaics.items()))
+
+
+def read_existing_config(config_path: Path) -> dict[int, dict[str, Any]]:
+    """Read an existing slice configuration file keyed by integer ``slice_id``."""
+    rows = slice_config_io.read(config_path)
+    return {int(sid): dict(row) for sid, row in rows.items()}
+
+
+def write_slice_config_with_quality(
+    output_file: Path,
+    slice_ids: list[int],
+    quality_results: dict[int, dict[str, Any]],
+    exclude_ids: list[int],
+    existing_config: dict[int, dict[str, Any]] | None = None,
+) -> None:
+    """Write ``slice_config.csv`` with the decision columns set from the quality.
+
+    assessment. Raw per-metric scores (ssim_mean / edge_score / variance_score /
+    depth) intentionally stay out of the CSV — they live in the pipeline report
+    and per-stage diagnostics JSON, not in the per-slice decision trace.
+    """
+    out_rows: list[dict[str, object]] = []
+    for slice_id in slice_ids:
+        quality = quality_results.get(slice_id, {})
+        use = "true"
+        reason = ""
+        if slice_id in exclude_ids:
+            use = "false"
+            if quality.get("is_calibration", False):
+                reason = "calibration_slice"
+            elif quality.get("overall", 1.0) < quality.get("min_threshold", 0):
+                reason = "low_quality"
+            elif quality.get("exclude_first", False):
+                reason = "first_slice_excluded"
+            else:
+                reason = "manually_excluded"
+
+        existing = existing_config.get(slice_id, {}) if existing_config else {}
+        if existing.get("use", "true").lower() in ["false", "0", "no"]:
+            use = "false"
+            if not reason:
+                reason = existing.get("exclude_reason") or existing.get("notes") or "previously_excluded"
+
+        row: dict[str, object] = {
+            "slice_id": f"{slice_id:02d}",
+            "use": use,
+            "quality_score": f"{float(quality.get('overall', 0.0)):.3f}",
+            "exclude_reason": reason,
+        }
+        if existing.get("galvo_confidence", ""):
+            row["galvo_confidence"] = existing["galvo_confidence"]
+        if existing.get("galvo_fix", ""):
+            row["galvo_fix"] = existing["galvo_fix"]
+        for carry in ("notes",):
+            val = existing.get(carry)
+            if val:
+                row[carry] = val
+        out_rows.append(row)
+
+    slice_config_io.write(output_file, out_rows)
+
+
+def main() -> None:
+    """Run function operation."""
+    p = _build_arg_parser()
+    args = p.parse_args()
+
+    input_path = Path(args.input)
+    output_file = Path(args.output_file)
+
+    if not args.report_only:
+        assert_output_exists(output_file, p, args)
+
+    if not input_path.is_dir():
+        p.error(f"Input directory not found: {input_path}")
+
+    use_gpu = args.use_gpu and GPU_AVAILABLE
+    if args.use_gpu and not GPU_AVAILABLE:
+        print("Warning: GPU requested but not available. Using CPU.")
+    elif use_gpu:
+        try:
+            import cupy as cp
+
+            cp.cuda.Device(args.gpu_id).use()
+            print(f"Using GPU device {args.gpu_id}")
+        except Exception as e:
+            print(f"Warning: Could not select GPU {args.gpu_id}: {e}. Using default.")
+
+    print(f"Scanning for mosaic grids in: {input_path}")
+    mosaic_files = get_mosaic_files(input_path)
+
+    if not mosaic_files:
+        p.error(f"No mosaic grid files found in {input_path}")
+
+    slice_ids = sorted(mosaic_files.keys())
+    print(f"Found {len(slice_ids)} slices: {[f'{s:02d}' for s in slice_ids]}")
+
+    existing_config = None
+    if args.update_existing:
+        config_to_load = args.existing_config if args.existing_config else output_file
+        if Path(config_to_load).exists():
+            existing_config = read_existing_config(Path(config_to_load))
+            print(f"Loaded existing config with {len(existing_config)} entries")
+
+    exclude_ids = set()
+
+    if args.exclude_first > 0:
+        first_slices = slice_ids[: args.exclude_first]
+        exclude_ids.update(first_slices)
+        print(f"Excluding first {args.exclude_first} slice(s) as calibration: {first_slices}")
+
+    print(f"\nLoading slices (pyramid_level={args.pyramid_level})...")
+    volumes: dict[int, np.ndarray | None] = {}
+    for slice_id in tqdm(slice_ids, desc="Loading slices"):
+        try:
+            vol, _ = read_omezarr(mosaic_files[slice_id], level=args.pyramid_level)
+            volumes[slice_id] = vol
+        except Exception as e:
+            print(f"  Warning: Could not load slice {slice_id:02d}: {e}")
+            volumes[slice_id] = None
+
+    calibration_slices = []
+    if args.detect_calibration:
+        print(f"Detecting calibration slices (thickness ratio > {args.calibration_thickness_ratio})...")
+        valid_volumes = {sid: vol for sid, vol in volumes.items() if vol is not None}
+        calibration_slices = detect_calibration_slice(valid_volumes, args.calibration_thickness_ratio)
+        if calibration_slices:
+            exclude_ids.update(calibration_slices)
+            print(f"Detected calibration slices: {calibration_slices}")
+
+    print(f"\nAssessing slice quality (GPU={'enabled' if use_gpu else 'disabled'}, sample_depth={args.sample_depth})...")
+    quality_results: dict[int, dict[str, Any]] = {}
+
+    if use_gpu:
+        for i, slice_id in enumerate(tqdm(slice_ids, desc="Assessing quality")):
+            vol = volumes.get(slice_id)
+            if vol is None:
+                quality_results[slice_id] = {
+                    "overall": 0.0,
+                    "ssim_mean": 0.0,
+                    "edge_score": 0.0,
+                    "variance_score": 0.0,
+                    "depth": 0,
+                    "has_data": False,
+                    "error": "load_failed",
+                }
+                continue
+            vol_before = volumes.get(slice_ids[i - 1]) if i > 0 else None
+            vol_after = volumes.get(slice_ids[i + 1]) if i < len(slice_ids) - 1 else None
+            overall, metrics = assess_slice_quality_gpu(vol, vol_before, vol_after, args.sample_depth)
+            metrics["is_calibration"] = slice_id in calibration_slices
+            metrics["exclude_first"] = slice_id in slice_ids[: args.exclude_first]
+            metrics["min_threshold"] = args.min_quality
+            quality_results[slice_id] = metrics
+            if args.min_quality > 0 and overall < args.min_quality:
+                exclude_ids.add(slice_id)
+        clear_gpu_memory()
+    else:
+        from concurrent.futures import ThreadPoolExecutor, as_completed
+
+        def _assess_one(idx_and_id: tuple) -> Any:
+            i, slice_id = idx_and_id
+            vol = volumes.get(slice_id)
+            if vol is None:
+                return slice_id, {
+                    "overall": 0.0,
+                    "ssim_mean": 0.0,
+                    "edge_score": 0.0,
+                    "variance_score": 0.0,
+                    "depth": 0,
+                    "has_data": False,
+                    "error": "load_failed",
+                }
+            vol_before = volumes.get(slice_ids[i - 1]) if i > 0 else None
+            vol_after = volumes.get(slice_ids[i + 1]) if i < len(slice_ids) - 1 else None
+            _overall, metrics = assess_slice_quality(vol, vol_before, vol_after, args.sample_depth, xy_roi=args.roi_size)
+            metrics["is_calibration"] = slice_id in calibration_slices
+            metrics["exclude_first"] = slice_id in slice_ids[: args.exclude_first]
+            metrics["min_threshold"] = args.min_quality
+            return slice_id, metrics
+
+        tasks = list(enumerate(slice_ids))
+        with ThreadPoolExecutor(max_workers=args.processes) as executor:
+            futures = {executor.submit(_assess_one, t): t for t in tasks}
+            for future in tqdm(as_completed(futures), total=len(futures), desc="Assessing quality"):
+                slice_id, metrics = future.result()
+                quality_results[slice_id] = metrics
+                if args.min_quality > 0 and metrics.get("overall", 0.0) < args.min_quality:
+                    exclude_ids.add(slice_id)
+
+    print("\n" + "=" * 70)
+    print(f"SLICE QUALITY REPORT{' (GPU-accelerated)' if use_gpu else ' (CPU)'}")
+    print("=" * 70)
+    print(f"{'Slice':<8} {'Quality':<10} {'SSIM':<10} {'Edge':<10} {'Var':<10} {'Depth':<8} {'Status':<15}")
+    print("-" * 70)
+
+    for slice_id in slice_ids:
+        q = quality_results.get(slice_id, {})
+        status = []
+        if slice_id in exclude_ids:
+            if q.get("is_calibration"):
+                status.append("CALIBRATION")
+            elif q.get("exclude_first"):
+                status.append("FIRST_SLICE")
+            elif q.get("overall", 1.0) < args.min_quality:
+                status.append("LOW_QUALITY")
+            else:
+                status.append("EXCLUDED")
+        else:
+            status.append("OK")
+
+        status_str = ",".join(status)
+        print(
+            f"{slice_id:02d}      {q.get('overall', 0):.3f}      "
+            f"{q.get('ssim_mean', 0):.3f}      {q.get('edge_score', 0):.3f}      "
+            f"{q.get('variance_score', 0):.3f}      {q.get('depth', 0):<8} {status_str}"
+        )
+
+    print("-" * 70)
+    print(f"Total slices: {len(slice_ids)}")
+    print(f"Excluded: {len(exclude_ids)}")
+    print(f"Included: {len(slice_ids) - len(exclude_ids)}")
+
+    if args.min_quality > 0:
+        low_quality = [s for s in slice_ids if quality_results.get(s, {}).get("overall", 1.0) < args.min_quality]
+        if low_quality:
+            print(f"Low quality slices (< {args.min_quality}): {low_quality}")
+
+    if not args.report_only:
+        write_slice_config_with_quality(output_file, slice_ids, quality_results, list(exclude_ids), existing_config)
+        print(f"\nSlice configuration written to: {output_file}")
+
+    if exclude_ids:
+        print(f"\nExcluded slice IDs: {sorted(exclude_ids)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/linum_benchmark_kvikio_zarr.py
+++ b/scripts/linum_benchmark_kvikio_zarr.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+r"""Benchmark zarr → GPU loading: kvikio (GDS) vs zarr+cupy vs zarr.enable_gpu.
+
+Three paths to get an uncompressed zarr v3 array onto the GPU are compared:
+
+  A) ``zarr.open(...)[:]`` → ``np.asarray`` → ``cupy.asarray`` (legacy path).
+  B) ``zarr.config.enable_gpu(); arr[:]`` returns a ``cupy.ndarray`` directly,
+     but the codec pipeline still decodes on the CPU before the H→D copy.
+  C) ``linumpy.gpu.kvikio_zarr.read_zarr_via_kvikio`` — kvikio CuFile / GDS.
+  D) ``linumpy.gpu.zarr_io.read_zarr_to_gpu`` — auto-dispatch (kvikio if GDS
+     native + uncompressed, else zarr-gpu).
+
+Reference numbers on a 16 GiB float32 zarr v3 (256³ chunks) on /scratch_nvme,
+RTX A6000, ext4, GDS native mode (warm cache):
+
+* kvikio (GDS native):     ~9.9 GiB/s
+* zarr.config.enable_gpu:  ~7.1 GiB/s
+* zarr → numpy → cupy:     ~2.8 GiB/s
+
+For production code, prefer :func:`linumpy.gpu.zarr_io.read_zarr_to_gpu`
+which picks the best available path at runtime.
+
+Examples
+--------
+Generate a 16 GiB random uncompressed zarr v3 on /scratch_nvme and bench::
+
+    linum_benchmark_kvikio_zarr.py \
+        --generate /scratch_nvme/bench.zarr \
+        --shape 2048 2048 1024 --chunks 256 256 128 --dtype float32 \
+        --runs 3
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+
+
+def _human_bytes(n: float) -> str:
+    units = ["B", "KiB", "MiB", "GiB", "TiB"]
+    i = 0
+    while n >= 1024 and i < len(units) - 1:
+        n /= 1024
+        i += 1
+    return f"{n:.2f} {units[i]}"
+
+
+def _generate_dataset(path: Path, shape: tuple[int, ...], chunks: tuple[int, ...], dtype: str) -> None:
+    import zarr
+
+    print(f"[generate] shape={shape} chunks={chunks} dtype={dtype} path={path}")
+    if path.exists():
+        raise SystemExit(f"refusing to overwrite existing {path}")
+
+    # zarr v3 with raw bytes only (no compression) so the kvikio path works.
+    arr = zarr.create_array(
+        store=str(path),
+        shape=shape,
+        chunks=chunks,
+        dtype=dtype,
+        compressors=None,
+        zarr_format=3,
+        fill_value=0,
+    )
+    rng = np.random.default_rng(0)
+    z_step = chunks[0]
+    for z0 in range(0, shape[0], z_step):
+        z1 = min(z0 + z_step, shape[0])
+        block = rng.standard_normal((z1 - z0, *shape[1:])).astype(dtype, copy=False)
+        arr[z0:z1] = block
+    print(f"[generate] done: {_human_bytes(arr.nbytes)} written")
+
+
+def _bench_zarr_cupy(array_path: Path) -> tuple[float, int]:
+    import cupy
+    import zarr
+
+    t0 = time.perf_counter()
+    z = zarr.open_array(str(array_path), mode="r")
+    host = np.asarray(z[:])
+    dev = cupy.asarray(host)
+    cupy.cuda.Stream.null.synchronize()
+    t1 = time.perf_counter()
+    return t1 - t0, dev.nbytes
+
+
+def _bench_zarr_gpu(array_path: Path) -> tuple[float, int]:
+    """zarr.config.enable_gpu(): host I/O, host decode, final buffer is CuPy."""
+    import cupy
+    import zarr
+
+    with zarr.config.enable_gpu():
+        t0 = time.perf_counter()
+        z = zarr.open_array(str(array_path), mode="r")
+        dev = z[:]
+        cupy.cuda.Stream.null.synchronize()
+        t1 = time.perf_counter()
+    nbytes = int(np.prod(z.shape)) * np.dtype(z.dtype).itemsize
+    del dev  # keep reference alive through synchronize
+    return t1 - t0, nbytes
+
+
+def _bench_kvikio(array_path: Path) -> tuple[float, int]:
+    import cupy
+
+    from linumpy.gpu.kvikio_zarr import read_zarr_via_kvikio
+
+    t0 = time.perf_counter()
+    dev = read_zarr_via_kvikio(array_path)
+    cupy.cuda.Stream.null.synchronize()
+    t1 = time.perf_counter()
+    return t1 - t0, dev.nbytes
+
+
+def _bench_auto(array_path: Path) -> tuple[float, int]:
+    import cupy
+
+    from linumpy.gpu.zarr_io import read_zarr_to_gpu
+
+    t0 = time.perf_counter()
+    dev = read_zarr_to_gpu(array_path)
+    cupy.cuda.Stream.null.synchronize()
+    t1 = time.perf_counter()
+    return t1 - t0, dev.nbytes
+
+
+def _drop_caches() -> None:
+    """Best-effort page-cache drop (requires root). Silently skipped otherwise."""
+    with contextlib.suppress(PermissionError, FileNotFoundError, OSError):
+        Path("/proc/sys/vm/drop_caches").write_text("3\n")
+
+
+PATHS = {
+    "zarr+cupy": _bench_zarr_cupy,
+    "zarr-gpu": _bench_zarr_gpu,
+    "kvikio": _bench_kvikio,
+    "auto": _bench_auto,
+}
+
+
+def main() -> None:
+    """Run the benchmark from the command line."""
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("array_path", type=Path, nargs="?", help="zarr array directory")
+    p.add_argument("--generate", type=Path, help="create a synthetic uncompressed zarr v3 at this path")
+    p.add_argument("--shape", type=int, nargs="+", default=[2048, 2048, 512])
+    p.add_argument("--chunks", type=int, nargs="+", default=[256, 256, 128])
+    p.add_argument("--dtype", default="float32")
+    p.add_argument("--runs", type=int, default=3)
+    p.add_argument("--skip-cache-drop", action="store_true", help="don't try to drop page cache between runs")
+    p.add_argument("--only", action="append", choices=list(PATHS), help="only benchmark these paths (repeatable)")
+    args = p.parse_args()
+
+    if args.generate is not None:
+        _generate_dataset(args.generate, tuple(args.shape), tuple(args.chunks), args.dtype)
+        if args.array_path is None:
+            args.array_path = args.generate
+
+    if args.array_path is None:
+        p.error("array_path is required (unless --generate also gives one)")
+
+    selected = args.only or list(PATHS)
+    print(f"[bench] array={args.array_path} runs={args.runs}")
+    for name in selected:
+        fn = PATHS[name]
+        times: list[float] = []
+        nbytes = 0
+        for r in range(args.runs):
+            if not args.skip_cache_drop:
+                _drop_caches()
+            try:
+                dt, nbytes = fn(args.array_path)
+            except Exception as exc:
+                print(f"  [{name}] run {r}: ERROR {exc!r}")
+                break
+            tput = nbytes / dt / (1024**3)
+            times.append(dt)
+            print(f"  [{name}] run {r}: {dt:.3f}s  {tput:.2f} GiB/s")
+        if times:
+            best = min(times)
+            print(f"  [{name}] best: {best:.3f}s  {nbytes / best / (1024**3):.2f} GiB/s")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/linum_correct_bias_field.py
+++ b/scripts/linum_correct_bias_field.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python3
+"""Apply N4 bias field correction to an OME-Zarr OCT volume.
+
+Three correction modes are supported.
+
+* ``per_section`` -- independently correct each serial tissue section
+  (removes depth-dependent attenuation per section).
+* ``global`` -- correct the whole stack as one volume (removes slow
+  large-scale intensity gradients).
+* ``two_pass`` -- run ``per_section`` first, then ``global`` (default).
+
+The ``--strength`` parameter (0-1) blends between the original and the
+fully-corrected result:
+``output = strength * corrected + (1 - strength) * input``.
+"""
+
+# Configure thread limits before numpy/scipy imports
+import linumpy.config.threads  # noqa: F401
+
+import argparse
+import logging
+
+import numpy as np
+
+from linumpy.cli.args import add_processes_arg, parse_processes_arg
+from linumpy.intensity.bias_field import (
+    compute_tissue_mask,
+    n4_correct,
+    n4_correct_per_section,
+)
+from linumpy.intensity.normalization import apply_histogram_matching, apply_zprofile_smoothing
+from linumpy.io.zarr import AnalysisOmeZarrWriter, read_omezarr_array
+
+logger = logging.getLogger(__name__)
+
+_MODES = ("per_section", "global", "two_pass")
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
+    p.add_argument("in_image", help="Input OME-Zarr image.")
+    p.add_argument("out_image", help="Output OME-Zarr image.")
+
+    # Mode / strength
+    p.add_argument(
+        "--mode",
+        choices=_MODES,
+        default="two_pass",
+        help="Correction mode. [%(default)s]",
+    )
+    p.add_argument(
+        "--strength",
+        type=float,
+        default=1.0,
+        help="Mixing weight between corrected and original (0 = no correction, 1 = full). [%(default)s]",
+    )
+
+    # Per-section options
+    p.add_argument(
+        "--n_serial_slices",
+        type=int,
+        default=1,
+        help="Number of serial tissue sections stacked along Z (for per_section / two_pass). [%(default)s]",
+    )
+    add_processes_arg(p)
+
+    # N4 tuning
+    p.add_argument(
+        "--shrink_factor",
+        type=int,
+        default=4,
+        help="Spatial downsampling factor for the N4 fit. [%(default)s]",
+    )
+    p.add_argument(
+        "--n_iterations",
+        type=int,
+        nargs="+",
+        default=None,
+        help=(
+            "Max N4 iterations per fitting level.  Length of list = number of fitting levels. "
+            "Defaults to the backend's own choice ([50, 50, 50, 50] for cpu, [25, 25, 25] for gpu)."
+        ),
+    )
+    p.add_argument(
+        "--spline_distance_mm",
+        type=float,
+        default=None,
+        help="Approximate B-spline knot spacing in mm.  Defaults to 2.0 for per_section, 10.0 for global.",
+    )
+    p.add_argument(
+        "--mask_smoothing_sigma",
+        type=float,
+        default=2.0,
+        help="Gaussian smoothing sigma for tissue mask estimation. [%(default)s]",
+    )
+
+    # Histogram-matching pre-pass (corrects inter-section intensity drift)
+    p.add_argument(
+        "--histogram_match",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Apply per-section histogram matching to a global reference distribution\n"
+        "before N4 correction.  Equalises section-to-section intensity drift while\n"
+        "preserving relative contrast within each section. [%(default)s]",
+    )
+    p.add_argument(
+        "--histogram_n_bins",
+        type=int,
+        default=512,
+        help="Number of histogram bins for matching. [%(default)s]",
+    )
+    p.add_argument(
+        "--histogram_match_per_zplane",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Match each Z-plane independently to the global tissue distribution\n"
+        "(strongest reduction of inter-slice intensity steps).  When False, the\n"
+        "volume is split into --n_serial_slices chunks (legacy behaviour). [%(default)s]",
+    )
+    p.add_argument(
+        "--tissue_threshold",
+        type=float,
+        default=0.0,
+        help="Voxels at or below this intensity are background and left unchanged\n"
+        "by histogram matching.  Use a small positive value (e.g. 0.005) to exclude\n"
+        "near-zero noise. [%(default)s]",
+    )
+    p.add_argument(
+        "--zprofile_smooth_sigma",
+        type=float,
+        default=0.0,
+        help="After histogram matching, remove residual per-Z-plane jitter with a\n"
+        "smoothed scalar gain (Gaussian sigma in Z-plane units).  0 = disabled.\n"
+        "Typical: 2.0-4.0.  Eliminates the ~1-2%% inter-slice steps HM cannot\n"
+        "remove while preserving the smooth depth attenuation profile. [%(default)s]",
+    )
+
+    # Background masking (zero out agarose)
+    p.add_argument(
+        "--zero_outside_mask",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Zero out voxels outside the tissue mask in the final output\n(removes agarose halo). [%(default)s]",
+    )
+
+    # Output options
+    p.add_argument(
+        "--save_bias_field",
+        metavar="PATH",
+        default=None,
+        help="Save recovered bias field to this path.",
+    )
+    p.add_argument(
+        "--pyramid_resolutions",
+        type=float,
+        nargs="+",
+        default=[10, 25, 50, 100],
+        help="Target resolutions for pyramid levels in microns. [%(default)s]",
+    )
+    p.add_argument(
+        "--make_isotropic",
+        action="store_true",
+        default=True,
+        help="Resample to isotropic voxels. [%(default)s]",
+    )
+    p.add_argument("--no_isotropic", dest="make_isotropic", action="store_false")
+    p.add_argument(
+        "--n_levels",
+        type=int,
+        default=None,
+        help="Use fixed pyramid levels instead of pyramid_resolutions.",
+    )
+    p.add_argument("--verbose", action="store_true", help="Enable INFO-level logging.")
+    p.add_argument(
+        "--backend",
+        type=str,
+        default="cpu",
+        choices=("cpu", "gpu", "auto"),
+        help=(
+            "N4 backend.  'cpu' uses SimpleITK; 'gpu' uses the CuPy/NumPy port "
+            "in linumpy.gpu.n4; 'auto' picks gpu when CUDA is available. [%(default)s]"
+        ),
+    )
+    return p
+
+
+def _save(arr: np.ndarray, path: str, res: list, args: argparse.Namespace) -> None:
+    """Save a volume to OME-Zarr using resolution-based or fixed pyramid levels."""
+    from pathlib import Path
+
+    writer = AnalysisOmeZarrWriter(Path(path), arr.shape, chunk_shape=(128, 128, 128), dtype=np.float32)
+    writer[:] = arr
+    writer.finalize(
+        res,
+        n_levels=args.n_levels,
+        target_resolutions_um=args.pyramid_resolutions,
+        make_isotropic=args.make_isotropic,
+    )
+
+
+def main() -> None:
+    """Run function."""
+    parser = _build_arg_parser()
+    args = parser.parse_args()
+
+    if args.verbose:
+        logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+    else:
+        logging.basicConfig(level=logging.WARNING)
+
+    n_processes = parse_processes_arg(args.n_processes)
+
+    # Resolve GPU usage from --backend choice for non-N4 stages. We resolve
+    # this BEFORE reading so we can stream the volume directly into device
+    # memory through the GDS / zarr-gpu fast path when the GPU is in play.
+    if args.backend == "gpu":
+        use_gpu_pre = True
+    elif args.backend == "auto":
+        from linumpy.gpu import GPU_AVAILABLE
+
+        use_gpu_pre = GPU_AVAILABLE
+    else:
+        use_gpu_pre = False
+
+    # Load volume — onto GPU directly when use_gpu_pre, else host.
+    vol, res = read_omezarr_array(args.in_image, level=0, use_gpu=use_gpu_pre)
+    vol = vol.astype(np.float32)  # works on both numpy and cupy arrays
+    logger.info("Loaded volume %s from %s (gpu=%s)", vol.shape, args.in_image, use_gpu_pre)
+
+    # Tissue mask (per serial section)
+    mask = compute_tissue_mask(
+        vol,
+        smoothing_sigma=args.mask_smoothing_sigma,
+        n_serial_slices=args.n_serial_slices,
+        use_gpu=use_gpu_pre,
+    )
+    logger.info("Tissue mask: %d/%d voxels", int(mask.sum()), mask.size)
+
+    # Histogram-matching pre-pass: equalise inter-section intensity drift
+    if args.histogram_match:
+        hm_n_serial = None if args.histogram_match_per_zplane else args.n_serial_slices
+        logger.info(
+            "Histogram matching (n_serial_slices=%s, n_bins=%d, threshold=%g)\u2026",
+            "per_zplane" if hm_n_serial is None else hm_n_serial,
+            args.histogram_n_bins,
+            args.tissue_threshold,
+        )
+        vol = apply_histogram_matching(
+            vol,
+            n_serial_slices=hm_n_serial,
+            n_bins=args.histogram_n_bins,
+            tissue_threshold=args.tissue_threshold,
+            use_gpu=use_gpu_pre,
+        ).astype(np.float32)
+
+    # Z-profile smoothing: remove residual per-Z jitter that HM cannot fully fix
+    if args.zprofile_smooth_sigma > 0:
+        logger.info("Z-profile gain smoothing (sigma=%g)\u2026", args.zprofile_smooth_sigma)
+        vol = apply_zprofile_smoothing(vol, mask, sigma=args.zprofile_smooth_sigma).astype(np.float32)
+
+    # Resolve spline distance defaults
+    per_section_spline = args.spline_distance_mm if args.spline_distance_mm is not None else 2.0
+    global_spline = args.spline_distance_mm if args.spline_distance_mm is not None else 10.0
+
+    n4_kwargs = {
+        "shrink_factor": args.shrink_factor,
+        "n_iterations": args.n_iterations,
+        "voxel_size_mm": (float(res[0]), float(res[1]), float(res[2])),
+        "backend": args.backend,
+    }
+
+    # Correction passes
+    bias_field_combined: np.ndarray | None = None
+
+    if args.mode in ("per_section", "two_pass"):
+        logger.info(
+            "Running per-section N4 (n_serial_slices=%d, n_processes=%d)…",
+            args.n_serial_slices,
+            n_processes,
+        )
+        vol_ps, bias_ps = n4_correct_per_section(
+            vol,
+            n_serial_slices=args.n_serial_slices,
+            mask=mask,
+            n_processes=n_processes,
+            spline_distance_mm=per_section_spline,
+            **n4_kwargs,
+        )
+        bias_field_combined = bias_ps
+        working_vol = vol_ps
+        # Drop the per-section aliases so the global pass below does not have
+        # to keep two extra full-size float32 volumes alive (~72 GB on a
+        # 36 GB mosaic). bias_field_combined / working_vol still hold them.
+        del vol_ps, bias_ps
+    else:
+        working_vol = vol
+
+    if args.mode in ("global", "two_pass"):
+        logger.info("Running global N4…")
+        # When the GPU backend is in play and ``working_vol`` already
+        # owns a full-resolution float32 buffer, alias it as the output
+        # destination so n4_correct_gpu does not allocate a fresh
+        # ``corrected_host`` (~one full-volume float32, ~80 GB on a
+        # large mosaic).  The host buffer is not read after the initial
+        # H2D upload.  Pre-allocate a separate ``bias_global`` buffer
+        # so the multiplicative combine into ``bias_field_combined``
+        # below stays well-defined.
+        gpu_inplace = (
+            args.backend in ("gpu", "auto")
+            and isinstance(working_vol, np.ndarray)
+            and working_vol.dtype == np.float32
+            and vol_for_blend is not working_vol
+        )
+        if gpu_inplace:
+            bias_global = np.empty_like(working_vol, dtype=np.float32)
+            n4_correct(
+                working_vol,
+                mask,
+                spline_distance_mm=global_spline,
+                out=working_vol,
+                bias_out=bias_global,
+                **n4_kwargs,
+            )
+        else:
+            working_vol, bias_global = n4_correct(
+                working_vol,
+                mask,
+                spline_distance_mm=global_spline,
+                **n4_kwargs,
+            )
+        if bias_field_combined is not None:
+            # Combine in place to avoid a third 36 GB allocation during the
+            # multiply, then release bias_global immediately.
+            bias_field_combined *= bias_global
+            del bias_global
+        else:
+            bias_field_combined = bias_global
+
+    corrected = working_vol
+
+    # Strength blend
+    if args.strength < 1.0:
+        logger.info("Blending: strength=%.3f", args.strength)
+        corrected = args.strength * corrected + (1.0 - args.strength) * vol
+
+    corrected = corrected.astype(np.float32)
+
+    # Zero out non-tissue voxels (suppress agarose)
+    if args.zero_outside_mask:
+        logger.info("Zeroing voxels outside tissue mask\u2026")
+        corrected = np.where(mask, corrected, 0.0).astype(np.float32)
+
+    # Save output
+    _save(corrected, args.out_image, res, args)
+    logger.info("Saved corrected volume to %s", args.out_image)
+
+    # Optionally save bias field
+    if args.save_bias_field is not None and bias_field_combined is not None:
+        _save(bias_field_combined, args.save_bias_field, res, args)
+        logger.info("Saved bias field to %s", args.save_bias_field)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/linum_generate_pipeline_report.py
+++ b/scripts/linum_generate_pipeline_report.py
@@ -1,0 +1,2028 @@
+#!/usr/bin/env python3
+"""
+Generate a quality report from pipeline metrics.
+
+This script aggregates metrics from various pipeline steps and generates
+a comprehensive report in HTML or text format to help identify potential
+issues in the 3D reconstruction pipeline.
+"""
+
+# Configure thread limits before numpy/scipy imports
+import linumpy.config.threads  # noqa: F401
+
+import argparse
+import base64
+import io as _io
+import json
+import re
+import zipfile
+from collections import defaultdict
+from datetime import datetime
+from pathlib import Path
+
+try:
+    from PIL import Image as _PILImage
+
+    _PIL_AVAILABLE = True
+except ImportError:
+    _PIL_AVAILABLE = False
+
+from typing import Any
+
+import numpy as np
+
+from linumpy.metrics import aggregate_metrics, compute_summary_statistics
+
+# Logical pipeline step ordering
+STEP_ORDER = [
+    "stitch_3d",
+    "xy_transform_estimation",
+    "normalize_intensities",
+    "psf_compensation",
+    "crop_interface",
+    "pairwise_registration",
+    "stack_slices",
+]
+
+# Human-readable display names (step_name → display label)
+STEP_DISPLAY_NAMES = {
+    "stitch_3d": "Stitch 3D",
+    "xy_transform_estimation": "XY Transform Estimation",
+    "normalize_intensities": "Normalize Intensities",
+    "psf_compensation": "PSF Compensation",
+    "crop_interface": "Crop Interface",
+    "pairwise_registration": "Pairwise Registration",
+    "stack_slices": "Stack Slices",
+}
+
+# Human-readable descriptions for pipeline steps
+STEP_DESCRIPTIONS = {
+    "stitch_3d": "Stitches individual mosaic tiles into a single 2D slice.",
+    "xy_transform_estimation": "Estimates the affine transformation for tile overlap correction.",
+    "normalize_intensities": "Normalizes per-slice intensities using agarose background.",
+    "psf_compensation": "Compensates for beam profile / PSF attenuation along the optical axis.",
+    "crop_interface": "Detects and crops the tissue-agarose interface.",
+    "pairwise_registration": "Registers consecutive serial sections to align the 3D volume.",
+    "stack_slices": "Stacks registered slices into the final 3D volume.",
+}
+
+# Maps pipeline step_name → image category shown in that step section
+STEP_PREVIEW_CATEGORY = {
+    "stitch_3d": "stitch_preview",
+    "pairwise_registration": "common_space_preview",
+}
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
+    p.add_argument("input_dir", help="Input directory containing pipeline output with metrics files.")
+    p.add_argument("output_report", help="Output report file path (.html, .zip, or .txt)")
+    p.add_argument(
+        "--format",
+        choices=["html", "text", "zip", "auto"],
+        default="auto",
+        help="Output format. 'auto' infers from extension. [%(default)s]",
+    )
+    p.add_argument("--title", default="Pipeline Quality Report", help="Report title. [%(default)s]")
+    p.add_argument("--verbose", action="store_true", help="Include all metric details in the report.")
+    p.add_argument(
+        "--overview_png", type=Path, default=None, help="Path to the main volume PNG screenshot (embedded in summary)."
+    )
+    p.add_argument(
+        "--annotated_png", type=Path, default=None, help="Path to the annotated volume PNG screenshot (embedded in summary)."
+    )
+    p.add_argument("--max_overview_width", type=int, default=900, help="Max pixel width for overview images. [%(default)s]")
+    p.add_argument("--max_thumb_width", type=int, default=380, help="Max pixel width for gallery thumbnails. [%(default)s]")
+    p.add_argument("--no_images", action="store_true", help="Disable image discovery for zip bundles.")
+    return p
+
+
+def get_status_color(status: str) -> str:
+    """Get HTML color for status."""
+    colors = {
+        "ok": "#28a745",  # green
+        "warning": "#ffc107",  # yellow/amber
+        "error": "#dc3545",  # red
+        "info": "#17a2b8",  # blue
+        "unknown": "#6c757d",  # gray
+    }
+    return colors.get(status, colors["unknown"])
+
+
+def get_status_emoji(status: str) -> str:
+    """Get emoji for status in text format."""
+    emojis = {"ok": "✓", "warning": "⚠", "error": "✗", "info": "ℹ", "unknown": "?"}
+    return emojis.get(status, "?")
+
+
+def format_value(value: float, precision: int = 4) -> str:
+    """Format a value for display."""
+    if isinstance(value, float):
+        if abs(value) < 0.0001 or abs(value) > 10000:
+            return f"{value:.{precision}e}"
+        return f"{value:.{precision}f}"
+    elif isinstance(value, list) and len(value) > 5:
+        return f"[{len(value)} items]"
+    return str(value)
+
+
+def sort_steps(aggregated: dict) -> dict:
+    """Sort pipeline steps in logical execution order."""
+
+    def step_key(step_name: str) -> Any:
+        try:
+            return (0, STEP_ORDER.index(step_name))
+        except ValueError:
+            return (1, step_name)
+
+    return dict(sorted(aggregated.items(), key=lambda x: step_key(x[0])))
+
+
+def extract_slice_id(source_file: str) -> str:
+    """Extract a meaningful slice identifier from a source file path."""
+    path = Path(source_file)
+    # Search path components for a slice pattern like z01, z002, slice_3
+    for part in reversed(path.parts):
+        m = re.search(r"(z\d+|slice_z?\d+)", part, re.IGNORECASE)
+        if m:
+            return m.group(1)
+    return path.stem
+
+
+def parse_issue(issue_str: str) -> dict:
+    """Parse an issue string of the form 'source: metric: value op threshold (level)'."""
+    parts = issue_str.split(": ", 2)
+    if len(parts) < 3:
+        return {"source": parts[0] if parts else "", "metric": "", "raw": issue_str, "value": None, "threshold": None}
+    source, metric, rest = parts[0], parts[1], parts[2]
+    m = re.match(r"([+-]?[\d.e+-]+)\s*([><]=?)\s*([+-]?[\d.e+-]+)", rest)
+    if m:
+        return {
+            "source": source,
+            "metric": metric,
+            "raw": issue_str,
+            "value": float(m.group(1)),
+            "op": m.group(2),
+            "threshold": float(m.group(3)),
+        }
+    return {"source": source, "metric": metric, "raw": issue_str, "value": None, "threshold": None}
+
+
+def group_issues(issues: list[str]) -> list[dict]:
+    """
+    Group issues by metric name.
+
+    Returns a list of dicts with keys: metric, count, values, threshold, details.
+    """
+    groups = defaultdict(list)
+    for issue in issues:
+        parsed = parse_issue(issue)
+        key = parsed["metric"] if parsed["metric"] else "__other__"
+        groups[key].append(parsed)
+
+    result = []
+    for metric, items in groups.items():
+        values = [i["value"] for i in items if i.get("value") is not None]
+        threshold = items[0].get("threshold") if items else None
+        op = items[0].get("op", ">") if items else ">"
+        result.append(
+            {
+                "metric": metric if metric != "__other__" else "",
+                "count": len(items),
+                "values": values,
+                "threshold": threshold,
+                "op": op,
+                "details": [i["raw"] for i in items],
+            }
+        )
+    return result
+
+
+def separate_metrics_by_type(metrics_list: list[dict]) -> tuple[dict, dict]:
+    """
+    Separate metrics into quality metrics and info/parameter fields.
+
+    Returns
+    -------
+    tuple
+        quality_metrics: {name: {'entries': [{value, status}], 'unit': str}}
+        info_fields: {name: {'values': [v], 'description': str, 'is_constant': bool, 'display_value': any}}
+    """
+    quality_metrics: dict = {}
+    info_fields: dict = {}
+
+    for m in metrics_list:
+        for name, data in m.get("metrics", {}).items():
+            if not isinstance(data, dict):
+                continue
+            status = data.get("status", "ok")
+            value = data.get("value")
+            unit = data.get("unit") or ""
+            desc = data.get("description") or ""
+
+            if status == "info":
+                if name not in info_fields:
+                    info_fields[name] = {"values": [], "description": desc, "unit": unit}
+                info_fields[name]["values"].append(value)
+            else:
+                if name not in quality_metrics:
+                    quality_metrics[name] = {"entries": [], "unit": unit, "description": desc}
+                quality_metrics[name]["entries"].append({"value": value, "status": status})
+
+    # Determine if each info field is constant across all files
+    for info in info_fields.values():
+        vals = info["values"]
+        try:
+            numeric = [v for v in vals if isinstance(v, (int, float))]
+            if numeric and len(numeric) == len(vals):
+                is_const = float(np.std(numeric)) < 1e-10
+            else:
+                is_const = len({str(v) for v in vals}) <= 1
+        except Exception:
+            is_const = len({str(v) for v in vals}) <= 1
+        info["is_constant"] = is_const
+        info["display_value"] = vals[0] if vals else None
+
+    return quality_metrics, info_fields
+
+
+def generate_sparkline_svg(values: list, statuses: list[str] | None = None, width: int = 160, height: int = 36) -> str:
+    """Generate an inline SVG bar-chart sparkline for a list of values."""
+    numeric = [(i, v) for i, v in enumerate(values) if isinstance(v, (int, float))]
+    if len(numeric) < 2:
+        return ""
+
+    all_vals = [v for _, v in numeric]
+    min_val, max_val = min(all_vals), max(all_vals)
+    val_range = max_val - min_val or 1.0
+
+    if statuses is None:
+        statuses = ["ok"] * len(values)
+
+    n = len(values)
+    bar_w = width / n
+    rects = []
+    for i, v in numeric:
+        h = max(2.0, (v - min_val) / val_range * (height - 4))
+        y = height - h
+        color = get_status_color(statuses[i]) if i < len(statuses) else get_status_color("ok")
+        rects.append(
+            f'<rect x="{i * bar_w:.1f}" y="{y:.1f}" '
+            f'width="{max(1.0, bar_w - 0.5):.1f}" height="{h:.1f}" '
+            f'fill="{color}" opacity="0.85" rx="1"/>'
+        )
+
+    title = f"Min: {min_val:.3g}  Max: {max_val:.3g}  n={len(numeric)}"
+    return (
+        f'<svg width="{width}" height="{height}" '
+        f'style="display:block;vertical-align:middle;" title="{title}">' + "".join(rects) + "</svg>"
+    )
+
+
+def generate_trend_line_svg(
+    values: list,
+    _labels: list[str] | None = None,
+    width: int = 420,
+    height: int = 90,
+    show_trend: bool = True,
+    color: str = "#4a90d9",
+) -> str:
+    """Generate an inline SVG line chart for cross-slice trend visualisation."""
+    numeric = [(i, float(v)) for i, v in enumerate(values) if isinstance(v, (int, float))]
+    if len(numeric) < 2:
+        return ""
+
+    xs = [p[0] for p in numeric]
+    ys = [p[1] for p in numeric]
+    min_y, max_y = min(ys), max(ys)
+    y_range = max_y - min_y or 1.0
+    pad_x, pad_y = 30, 10
+
+    def to_svg_x(i: Any) -> Any:
+        return pad_x + (i / (len(values) - 1)) * (width - 2 * pad_x)
+
+    def to_svg_y(v: Any) -> Any:
+        return height - pad_y - ((v - min_y) / y_range) * (height - 2 * pad_y)
+
+    # Build polyline points
+    pts = " ".join(f"{to_svg_x(i):.1f},{to_svg_y(v):.1f}" for i, v in numeric)
+
+    elements = [
+        f'<polyline points="{pts}" fill="none" stroke="{color}" stroke-width="1.5" stroke-opacity="0.85"/>',
+    ]
+
+    # Dots at each data point
+    for i, v in numeric:
+        elements.append(f'<circle cx="{to_svg_x(i):.1f}" cy="{to_svg_y(v):.1f}" r="2" fill="{color}" opacity="0.7"/>')
+
+    # Trend line (least squares)
+    if show_trend and len(xs) >= 3:
+        x_arr = np.array(xs, dtype=float)
+        y_arr = np.array(ys, dtype=float)
+        slope = (np.mean(x_arr * y_arr) - np.mean(x_arr) * np.mean(y_arr)) / (np.mean(x_arr**2) - np.mean(x_arr) ** 2 + 1e-12)
+        intercept = np.mean(y_arr) - slope * np.mean(x_arr)
+        x0, x1 = xs[0], xs[-1]
+        y0, y1 = slope * x0 + intercept, slope * x1 + intercept
+        elements.append(
+            f'<line x1="{to_svg_x(x0):.1f}" y1="{to_svg_y(y0):.1f}" '
+            f'x2="{to_svg_x(x1):.1f}" y2="{to_svg_y(y1):.1f}" '
+            f'stroke="#e74c3c" stroke-width="1" stroke-dasharray="4 2" opacity="0.7"/>'
+        )
+
+    # Y-axis labels
+    elements.append(
+        f'<text x="{pad_x - 3}" y="{to_svg_y(max_y):.1f}" text-anchor="end" font-size="8" fill="#888">{max_y:.3g}</text>'
+    )
+    elements.append(
+        f'<text x="{pad_x - 3}" y="{to_svg_y(min_y):.1f}" text-anchor="end" font-size="8" fill="#888">{min_y:.3g}</text>'
+    )
+
+    title_text = f"n={len(numeric)}, range [{min_y:.3g}, {max_y:.3g}]"
+    return (
+        f'<svg width="{width}" height="{height}" style="display:block;" title="{title_text}">' + "".join(elements) + "</svg>"
+    )
+
+
+def compute_cross_slice_trends(aggregated: dict[str, list[dict]]) -> dict:
+    """
+    Compute cross-slice aggregate trends from aggregated metrics.
+
+    Returns a dict with trend groups, each containing:
+      'label', 'description', 'series': [{name, values, unit}]
+    """
+    trends = {}
+
+    def _extract(metrics_list: Any, key: str) -> list:
+        """Extract sorted numerical values for a given metric key."""
+        pairs = []
+        for m in metrics_list:
+            src = m.get("source_file", "")
+            val = m.get("metrics", {}).get(key, {}).get("value")
+            if isinstance(val, (int, float)):
+                pairs.append((src, val))
+        pairs.sort(key=lambda p: p[0])  # sort by source file path
+        return [v for _, v in pairs]
+
+    # XY tile transform: scale and shear across slices
+    if "xy_transform_estimation" in aggregated:
+        ml = aggregated["xy_transform_estimation"]
+        t00 = _extract(ml, "transform_00")
+        t11 = _extract(ml, "transform_11")
+        rms = _extract(ml, "rms_residual")
+        acc_sys = _extract(ml, "accumulated_systematic_error_px")
+        acc_rnd = _extract(ml, "accumulated_random_error_px")
+        series = []
+        if t00:
+            series.append({"name": "Step Y (px)", "values": t00, "unit": "px"})
+        if t11:
+            series.append({"name": "Step X (px)", "values": t11, "unit": "px"})
+        if rms:
+            series.append({"name": "RMS residual (px)", "values": rms, "unit": "px"})
+        if acc_sys:
+            series.append({"name": "Accum. systematic error (px)", "values": acc_sys, "unit": "px"})
+        if acc_rnd:
+            series.append({"name": "Accum. random error (px)", "values": acc_rnd, "unit": "px"})
+        if series:
+            trends["xy_transform"] = {
+                "label": "XY Tile Transform Consistency",
+                "description": (
+                    "Tile step sizes and fitting residuals across slices. Large variation indicates unstable tile positioning."
+                ),
+                "series": series,
+            }
+
+    # Pairwise registration: cumulative drift
+    if "pairwise_registration" in aggregated:
+        ml = aggregated["pairwise_registration"]
+        tx = _extract(ml, "translation_x")
+        ty = _extract(ml, "translation_y")
+        rot = _extract(ml, "rotation")
+        series = []
+        if tx:
+            cum_tx = list(np.cumsum(tx))
+            series.append({"name": "Cumulative tx (px)", "values": cum_tx, "unit": "px"})
+        if ty:
+            cum_ty = list(np.cumsum(ty))
+            series.append({"name": "Cumulative ty (px)", "values": cum_ty, "unit": "px"})
+        if rot:
+            cum_rot = list(np.cumsum(rot))
+            series.append({"name": "Cumulative rotation (deg)", "values": cum_rot, "unit": "deg"})
+        if series:
+            trends["registration_drift"] = {
+                "label": "Cumulative Registration Drift",
+                "description": (
+                    "Accumulated translation and rotation across all slices. "
+                    "A large net drift indicates systematic 3D volume distortion."
+                ),
+                "series": series,
+            }
+
+    # Interface depth trend
+    if "crop_interface" in aggregated:
+        ml = aggregated["crop_interface"]
+        depth = _extract(ml, "detected_interface_depth_um")
+        if depth:
+            trends["interface_depth"] = {
+                "label": "Interface Depth Trend",
+                "description": (
+                    "Detected tissue-agarose interface depth across slices. "
+                    "A systematic slope may indicate progressive tissue deformation."
+                ),
+                "series": [{"name": "Interface depth (µm)", "values": depth, "unit": "µm"}],
+            }
+
+    # Background normalization drift
+    if "normalize_intensities" in aggregated:
+        ml = aggregated["normalize_intensities"]
+        bg = _extract(ml, "mean_background")
+        if bg:
+            trends["background_drift"] = {
+                "label": "Background Level Trend",
+                "description": (
+                    "Mean agarose background level across slices. "
+                    "A strong trend indicates illumination drift during acquisition."
+                ),
+                "series": [{"name": "Mean background", "values": bg, "unit": ""}],
+            }
+
+    return trends
+
+
+# =============================================================================
+# Diagnostic data discovery
+# =============================================================================
+
+
+def discover_interpolation_data(input_dir: Path) -> dict | None:
+    """
+    Discover slice-interpolation outputs.
+
+    Reads per-slice diagnostic JSONs written by ``linum_interpolate_missing_slice.py``
+    (``slice_z*_interpolated_diagnostics.json``) and the preview PNGs.
+    ``slice_config_final.csv`` (produced by ``finalise_interpolation``) is
+    read via :mod:`linumpy.io.slice_config` to enrich the rows with the
+    per-slice trace fields (``interpolated``, ``interpolation_method_used``,
+    ``interpolation_fallback_reason``, ``use``, ``auto_excluded``, ...).
+
+    Returns
+    -------
+    dict or None
+        ``None`` when no interpolation happened. Otherwise a dict with keys
+        ``rows`` (list of per-slice dicts), ``images`` (list of preview
+        PNG paths), ``slice_config_final`` (path or None) and
+        ``summary`` (aggregated stats).
+    """
+    from linumpy.io import slice_config as slice_config_io
+
+    interp_dir = input_dir / "interpolate_missing_slice"
+    if not interp_dir.is_dir():
+        return None
+
+    diag_files = sorted(interp_dir.glob("slice_z*_interpolated_diagnostics.json"))
+    if not diag_files:
+        return None
+
+    rows: list[dict] = []
+    for path in diag_files:
+        try:
+            with path.open() as fh:
+                data = json.load(fh)
+        except Exception:
+            continue
+        rows.append(
+            {
+                "slice_id": str(data.get("slice_id") or "").strip(),
+                "method": str(data.get("method") or "unknown"),
+                "method_used": (
+                    ""
+                    if data.get("interpolation_failed") is True
+                    else str(data.get("method_used") or data.get("method") or "unknown")
+                ),
+                "fallback_reason": str(data.get("fallback_reason") or ""),
+                "interpolation_failed": bool(data.get("interpolation_failed", False)),
+                "pre_reg_ncc": data.get("pre_reg_ncc"),
+                "post_reg_ncc": data.get("post_reg_ncc"),
+                "ncc_improvement": data.get("ncc_improvement"),
+                "affine_determinant": data.get("affine_determinant"),
+                "output_path": str(data.get("output_path") or ""),
+                "diagnostics_path": str(path),
+            }
+        )
+
+    if not rows:
+        return None
+
+    # Enrich from slice_config_final.csv when available (single source of truth).
+    slice_config_final = input_dir / "slice_config_final.csv"
+    if slice_config_final.exists():
+        try:
+            sc_rows = slice_config_io.read(slice_config_final)
+            for r in rows:
+                sid = slice_config_io.normalize_slice_id(r["slice_id"])
+                sc_row = sc_rows.get(sid)
+                if sc_row is not None:
+                    r["slice_config_use"] = sc_row.get("use", "")
+                    r["slice_config_interpolated"] = sc_row.get("interpolated", "")
+                    r["slice_config_interpolation_failed"] = sc_row.get("interpolation_failed", "")
+                    r["slice_config_auto_excluded"] = sc_row.get("auto_excluded", "")
+                    r["slice_config_notes"] = sc_row.get("notes", "")
+        except Exception:
+            slice_config_final = None
+
+    images: list[Path] = sorted(interp_dir.glob("slice_z*_interpolated_preview.png"))
+
+    method_counts: dict[str, int] = {}
+    method_used_counts: dict[str, int] = {}
+    fallback_counts: dict[str, int] = {}
+    pre_nccs: list[float] = []
+    post_nccs: list[float] = []
+    improvements: list[float] = []
+
+    def _to_float(value: object) -> float | None:
+        if not isinstance(value, (int, float, str, bytes, bytearray)):
+            return None
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+    for r in rows:
+        method = (r.get("method") or "unknown").strip() or "unknown"
+        method_used = (r.get("method_used") or method).strip() or method
+        fallback = (r.get("fallback_reason") or "").strip()
+        method_counts[method] = method_counts.get(method, 0) + 1
+        method_used_counts[method_used] = method_used_counts.get(method_used, 0) + 1
+        if fallback:
+            fallback_counts[fallback] = fallback_counts.get(fallback, 0) + 1
+        pre = _to_float(r.get("pre_reg_ncc"))
+        post = _to_float(r.get("post_reg_ncc"))
+        imp = _to_float(r.get("ncc_improvement"))
+        if pre is not None:
+            pre_nccs.append(pre)
+        if post is not None:
+            post_nccs.append(post)
+        if imp is not None:
+            improvements.append(imp)
+
+    n_failed = sum(1 for r in rows if r.get("interpolation_failed"))
+
+    summary = {
+        "count": len(rows),
+        "n_succeeded": len(rows) - n_failed,
+        "n_failed": n_failed,
+        "method_counts": method_counts,
+        "method_used_counts": method_used_counts,
+        "fallback_counts": fallback_counts,
+        "n_with_fallback": sum(fallback_counts.values()),
+        "pre_reg_ncc_mean": float(np.mean(pre_nccs)) if pre_nccs else None,
+        "post_reg_ncc_mean": float(np.mean(post_nccs)) if post_nccs else None,
+        "ncc_improvement_mean": float(np.mean(improvements)) if improvements else None,
+    }
+
+    return {
+        "rows": rows,
+        "images": images,
+        "slice_config_final": slice_config_final if (slice_config_final and slice_config_final.exists()) else None,
+        "summary": summary,
+    }
+
+
+def discover_diagnostic_data(input_dir: Path) -> dict[str, dict]:
+    """
+    Discover diagnostic outputs in the pipeline output directory.
+
+    Looks for known diagnostic subdirectories and reads their JSON data.
+
+    Returns
+    -------
+    dict
+        Maps diagnostic_name → {'label', 'description', 'json_data': [...], 'images': [Path]}
+    """
+    import json as _json
+
+    diagnostics: dict[str, dict] = {}
+
+    diag_dir = input_dir / "diagnostics"
+    if not diag_dir.exists():
+        return diagnostics
+
+    # Define known diagnostics: (subdir, label, description)
+    known = [
+        ("dilation_analysis", "Tile Dilation Analysis", "Per-slice scale factors and mosaic positioning accuracy."),
+        ("aggregated_dilation", "Aggregated Dilation Analysis", "Cross-slice tile dilation summary."),
+        ("rotation_analysis", "Rotation Drift Analysis", "Rotation angle drift across slices."),
+        ("acquisition_rotation", "Acquisition Rotation Analysis", "In-plane rotation estimated from acquisition metadata."),
+        (
+            "motor_only_stitch",
+            "Motor-Only Stitching (comparison)",
+            "Stitched mosaic using motor positions only (no registration correction).",
+        ),
+        (
+            "motor_only_stack",
+            "Motor-Only Stack (comparison)",
+            "Volume stacked without pairwise registration (motor positions only).",
+        ),
+        (
+            "stitch_comparison",
+            "Stitching Comparison",
+            "Side-by-side comparison of registration-based vs motor-based stitching.",
+        ),
+    ]
+
+    for subdir_name, label, description in known:
+        subdir = diag_dir / subdir_name
+        if not subdir.exists():
+            continue
+
+        json_data = []
+        images = []
+
+        # Collect all JSON files (recursively for per-slice diagnostics)
+        for json_file in sorted(subdir.rglob("*.json")):
+            try:
+                with Path(json_file).open() as f:
+                    data = _json.load(f)
+                data["_source"] = str(json_file)
+                json_data.append(data)
+            except Exception:
+                pass
+
+        # Collect PNG images
+        images.extend(sorted(subdir.rglob("*.png")))
+
+        if json_data or images:
+            diagnostics[subdir_name] = {
+                "label": label,
+                "description": description,
+                "json_data": json_data,
+                "images": images,
+            }
+
+    return diagnostics
+
+
+def discover_images(
+    input_dir: Path, overview_png: Path | None = None, annotated_png: Path | None = None
+) -> dict[str, list[Path]]:
+    """
+    Discover preview images in the pipeline output directory.
+
+    Returns a dict mapping category → sorted list of image paths:
+      'overview'              – main volume screenshots (up to 2)
+      'stitch_preview'        – per-slice stitched previews
+      'common_space_preview'  – common-space alignment previews
+      'diag_*'                – images found in diagnostics/ subdirs
+    """
+    images: dict[str, list[Path]] = {
+        "overview": [],
+        "stitch_preview": [],
+        "common_space_preview": [],
+    }
+
+    # Overview images from CLI (staged in Nextflow work dir)
+    for p in [overview_png, annotated_png]:
+        if p and Path(p).exists():
+            images["overview"].append(Path(p))
+
+    # Stitched slice previews
+    stitch_dir = input_dir / "previews" / "stitched_slices"
+    if stitch_dir.exists():
+        images["stitch_preview"] = sorted(stitch_dir.glob("*.png"))
+
+    # Common-space alignment previews
+    cs_dir = input_dir / "common_space_previews"
+    if cs_dir.exists():
+        images["common_space_preview"] = sorted(cs_dir.glob("*.png"))
+
+    # Auto-detect overview from stack output directories if not provided via CLI
+    if not images["overview"]:
+        for stack_dir_name in ("stack_motor", "stack", "normalize_z_intensity"):
+            d = input_dir / stack_dir_name
+            if d.exists():
+                pngs = sorted(d.glob("*.png"))
+                if pngs:
+                    images["overview"] = pngs[:2]  # at most overview + annotated
+                    break
+
+    # Diagnostic images: add one category per diagnostics subdir
+    diag_dir = input_dir / "diagnostics"
+    if diag_dir.exists():
+        for subdir in sorted(diag_dir.iterdir()):
+            if subdir.is_dir():
+                pngs = sorted(subdir.rglob("*.png"))
+                if pngs:
+                    cat_key = f"diag_{subdir.name}"
+                    images[cat_key] = pngs
+
+    return images
+
+
+def image_to_data_uri(path: Path, max_width: int | None = None) -> str:
+    """Encode a PNG image as a base64 data URI, optionally resizing."""
+    if max_width and _PIL_AVAILABLE:
+        with _PILImage.open(path) as img:
+            if img.width > max_width:
+                ratio = max_width / img.width
+                new_size = (max_width, int(img.height * ratio))
+                img = img.resize(new_size, _PILImage.Resampling.LANCZOS)
+            buf = _io.BytesIO()
+            img.save(buf, format="PNG", optimize=True)
+            data_bytes = buf.getvalue()
+    else:
+        data_bytes = path.read_bytes()
+    b64 = base64.b64encode(data_bytes).decode("ascii")
+    return f"data:image/png;base64,{b64}"
+
+
+def render_image_gallery_html(
+    images: list[Path], mode: str = "embed", category: str = "images", _label: str = "Preview Images", max_width: int = 380
+) -> str:
+    """
+    Render a collapsible image gallery section.
+
+    Parameters
+    ----------
+    images : list of Path
+        Image file paths to include in the gallery.
+    mode : str
+        Embedding mode: 'embed' (base64 in HTML) or 'link' (relative path for zip mode).
+    category : str
+        Image category name, used as subfolder in zip mode.
+    max_width : int
+        Maximum image width in pixels for embedded previews.
+    """
+    if not images:
+        return ""
+
+    items = []
+    for p in images:
+        src = image_to_data_uri(p, max_width=max_width) if mode == "embed" else f"previews/{category}/{p.name}"
+        name = p.stem
+        items.append(
+            f'<figure class="gallery-item">'
+            f'<a href="{src}" target="_blank">'
+            f'<img src="{src}" alt="{name}" title="{name}" loading="lazy">'
+            f"</a>"
+            f"<figcaption>{name}</figcaption>"
+            f"</figure>"
+        )
+
+    return f"""
+        <details class="gallery-details">
+            <summary class="gallery-summary">Preview Images ({len(images)})</summary>
+            <div class="image-gallery">
+                {"".join(items)}
+            </div>
+        </details>
+"""
+
+
+def generate_zip_bundle(html: str, images: dict[str, list[Path]], output_path: Path) -> None:
+    """Bundle the HTML report and all image files into a zip archive."""
+    with zipfile.ZipFile(output_path, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("index.html", html)
+        for category, paths in images.items():
+            for p in paths:
+                zf.write(p, f"previews/{category}/{p.name}")
+
+
+def compute_overall_status(aggregated: dict[str, list[dict]]) -> tuple:
+    """
+    Compute overall status counts from aggregated metrics.
+
+    Returns
+    -------
+    tuple
+        (all_statuses, error_count, warning_count, ok_count)
+    """
+    all_statuses = [m.get("overall_status", "unknown") for step_metrics in aggregated.values() for m in step_metrics]
+
+    error_count = all_statuses.count("error")
+    warning_count = all_statuses.count("warning")
+    ok_count = all_statuses.count("ok")
+
+    return all_statuses, error_count, warning_count, ok_count
+
+
+def get_step_status(metrics_list: list[dict]) -> str:
+    """Get the overall status for a step based on its metrics."""
+    step_statuses = [m.get("overall_status", "unknown") for m in metrics_list]
+    if "error" in step_statuses:
+        return "error"
+    elif "warning" in step_statuses:
+        return "warning"
+    return "ok"
+
+
+def collect_issues(metrics_list: list[dict]) -> tuple:
+    """
+    Collect all warnings and errors from a metrics list.
+
+    Returns
+    -------
+    tuple
+        (all_warnings, all_errors)
+    """
+    all_warnings = []
+    all_errors = []
+    for m in metrics_list:
+        source = Path(m.get("source_file", "unknown")).stem
+        all_warnings.extend(f"{source}: {w}" for w in m.get("warnings", []))
+        all_errors.extend(f"{source}: {e}" for e in m.get("errors", []))
+    return all_warnings, all_errors
+
+
+def _render_grouped_issues_html(grouped: list[dict], color_class: str, label: str) -> str:
+    """Render a collapsible grouped-issues section in HTML."""
+    total = sum(g["count"] for g in grouped)
+    html = f"""
+        <details class="issues-details {color_class}-details">
+            <summary class="issues-summary {color_class}-summary">
+                <strong>{label}</strong>
+                <span class="issue-count-badge">{total}</span>
+            </summary>
+            <div class="issues-body">
+"""
+    for g in grouped:
+        if g["count"] == 1:
+            html += f'                <div class="issue-item">{g["details"][0]}</div>\n'
+        else:
+            vals = g["values"]
+            val_str = f"range {min(vals):.3g} – {max(vals):.3g}" if vals else f"{g['count']} occurrences"
+            thresh_str = f", threshold: {g['threshold']:.3g}" if g["threshold"] is not None else ""
+            summary_line = f"<strong>{g['metric']}</strong>: {g['count']} slices affected ({val_str}{thresh_str})"
+            html += '                <details class="sub-issue">\n'
+            html += f'                    <summary class="issue-item">{summary_line}</summary>\n'
+            html += '                    <div class="sub-issue-list">\n'
+            for detail in g["details"]:
+                html += f'                        <div class="sub-issue-item">{detail}</div>\n'
+            html += "                    </div>\n"
+            html += "                </details>\n"
+    html += "            </div>\n        </details>\n"
+    return html
+
+
+def _render_interpolation_section_html(
+    interpolation: dict,
+    image_mode: str = "link",
+    max_thumb_width: int = 380,
+) -> str:
+    """Render the slice-interpolation section of the HTML report."""
+    summary = interpolation.get("summary", {})
+    rows = interpolation.get("rows", [])
+    images = interpolation.get("images", [])
+    slice_config_final = interpolation.get("slice_config_final")
+
+    count = summary.get("count", 0)
+    n_failed = summary.get("n_failed", 0)
+    n_succeeded = summary.get("n_succeeded", count - n_failed)
+    method_counts = summary.get("method_counts", {})
+    method_used_counts = summary.get("method_used_counts", {})
+    fallback_counts = summary.get("fallback_counts", {})
+    pre_mean = summary.get("pre_reg_ncc_mean")
+    post_mean = summary.get("post_reg_ncc_mean")
+    imp_mean = summary.get("ncc_improvement_mean")
+
+    status = "ok"
+    if n_failed > 0 and count > 0:
+        status = "warning" if n_failed < count else "error"
+
+    html = '\n    <div class="diag-section">\n'
+    html += "        <h2>Slice Interpolation</h2>\n"
+    html += (
+        '        <p style="color:#555;font-size:0.9em;">'
+        "Missing slices reconstructed from their neighbours via <code>zmorph</code>. "
+        "Successful interpolations stamp <code>interpolated=true</code> and are flagged "
+        "<code>reliable=0</code> in downstream pairwise registration. When quality gates "
+        "fail the slice is <strong>hard-skipped</strong> (<code>interpolation_failed=true</code>) "
+        "and the slot stays a genuine gap in the stacked volume \u2014 no blended volume is "
+        "written. See <code>docs/SLICE_INTERPOLATION_FEATURE.md</code>.</p>\n"
+    )
+
+    html += '        <div class="stats-grid">\n'
+    html += f'            <div class="stat-box"><div class="stat-value">{count}</div>'
+    html += '<div class="stat-label">Gaps Detected</div></div>\n'
+    ok_color = get_status_color("ok")
+    html += (
+        f'            <div class="stat-box"><div class="stat-value" style="color:{ok_color};">'
+        f'{n_succeeded}</div><div class="stat-label">Successfully Interpolated</div></div>\n'
+    )
+    html += (
+        f'            <div class="stat-box"><div class="stat-value" style="color:{get_status_color(status)};">'
+        f'{n_failed}</div><div class="stat-label">Hard-Skipped (Gap)</div></div>\n'
+    )
+    if pre_mean is not None:
+        html += f'            <div class="stat-box"><div class="stat-value">{pre_mean:.3f}</div>'
+        html += '<div class="stat-label">Mean Pre-Reg NCC</div></div>\n'
+    if post_mean is not None:
+        html += f'            <div class="stat-box"><div class="stat-value">{post_mean:.3f}</div>'
+        html += '<div class="stat-label">Mean Post-Reg NCC</div></div>\n'
+    if imp_mean is not None:
+        html += f'            <div class="stat-box"><div class="stat-value">{imp_mean:+.3f}</div>'
+        html += '<div class="stat-label">Mean NCC Improvement</div></div>\n'
+    html += "        </div>\n"
+
+    # Method breakdown
+    html += '        <div style="margin-top:12px;">\n'
+    html += '            <div class="section-label">Methods</div>\n'
+    html += '            <table class="diag-kv-table">\n'
+    html += "                <tr><td><strong>Method requested</strong></td><td>"
+    html += ", ".join(f"{k}: {v}" for k, v in sorted(method_counts.items())) or "(none)"
+    html += "</td></tr>\n"
+    html += "                <tr><td><strong>Method actually used</strong></td><td>"
+    html += ", ".join(f"{k}: {v}" for k, v in sorted(method_used_counts.items())) or "(none)"
+    html += "</td></tr>\n"
+    if fallback_counts:
+        html += "                <tr><td><strong>Hard-skip reasons</strong></td><td>"
+        html += ", ".join(f"{k}: {v}" for k, v in sorted(fallback_counts.items()))
+        html += "</td></tr>\n"
+    if slice_config_final is not None:
+        html += "                <tr><td><strong>Per-slice trace file</strong></td>"
+        html += f"<td>{slice_config_final.name}</td></tr>\n"
+    html += "            </table>\n"
+    html += "        </div>\n"
+
+    # Per-slice table (cap to 50 rows; more than that is rare)
+    if rows:
+        html += '        <details class="params-details" open>\n'
+        html += '            <summary class="params-summary">'
+        html += f"Per-slice interpolation diagnostics ({len(rows)} slice(s))</summary>\n"
+        html += '            <table class="metrics-table" style="font-size:0.85em;">\n'
+        html += (
+            "                <tr>"
+            "<th>Slice</th><th>Status</th><th>Method Used</th>"
+            "<th>Reason</th><th>Pre NCC</th><th>Post NCC</th>"
+            "<th>ΔNCC</th><th>|det|</th>"
+            "</tr>\n"
+        )
+        for r in rows[:50]:
+            sid = r.get("slice_id", "") or "?"
+            failed = bool(r.get("interpolation_failed"))
+            status_label = "SKIPPED" if failed else "OK"
+            method_used = r.get("method_used", "") or ("—" if failed else "")
+            fb = r.get("fallback_reason", "") or ""
+            pre = r.get("pre_reg_ncc", "")
+            post = r.get("post_reg_ncc", "")
+            imp = r.get("ncc_improvement", "")
+            det = r.get("affine_determinant", "")
+
+            pre_fmt = f"{float(pre):.3f}" if pre not in ("", None) else "-"
+            post_fmt = f"{float(post):.3f}" if post not in ("", None) else "-"
+            imp_fmt = f"{float(imp):+.3f}" if imp not in ("", None) else "-"
+            det_fmt = f"{float(det):.3f}" if det not in ("", None) else "-"
+
+            if failed:
+                row_style = ' style="background:#ffe5e5;"'
+            elif fb:
+                row_style = ' style="background:#fff8e1;"'
+            else:
+                row_style = ""
+            html += (
+                f"                <tr{row_style}>"
+                f"<td>{sid}</td><td>{status_label}</td><td>{method_used}</td>"
+                f"<td>{fb}</td><td>{pre_fmt}</td><td>{post_fmt}</td>"
+                f"<td>{imp_fmt}</td><td>{det_fmt}</td>"
+                "</tr>\n"
+            )
+        if len(rows) > 50:
+            html += (
+                f'                <tr><td colspan="8" style="color:#888;">(showing first 50 of {len(rows)} rows)</td></tr>\n'
+            )
+        html += "            </table>\n"
+        html += "        </details>\n"
+
+    # Preview image gallery (shown in zip/link mode only; embed mode skips images)
+    if images:
+        gallery = render_image_gallery_html(
+            images,
+            mode=image_mode,
+            category="diag_interpolate_missing_slice",
+            _label="Interpolation Previews",
+            max_width=max_thumb_width,
+        )
+        html += gallery
+
+    html += "    </div>\n"
+    return html
+
+
+def _render_interpolation_section_text(interpolation: dict) -> str:
+    """Render the slice-interpolation section of the text report."""
+    summary = interpolation.get("summary", {})
+    rows = interpolation.get("rows", [])
+    count = summary.get("count", 0)
+    n_failed = summary.get("n_failed", 0)
+    n_succeeded = summary.get("n_succeeded", count - n_failed)
+    pre_mean = summary.get("pre_reg_ncc_mean")
+    post_mean = summary.get("post_reg_ncc_mean")
+    imp_mean = summary.get("ncc_improvement_mean")
+
+    lines = []
+    lines.append("")
+    lines.append(f"{get_status_emoji('info')} SLICE INTERPOLATION")
+    lines.append("-" * 70)
+    lines.append(f"  Gaps detected          : {count}")
+    lines.append(f"  Successfully interp'd  : {n_succeeded}")
+    lines.append(f"  Hard-skipped (gap)     : {n_failed}")
+    if pre_mean is not None:
+        lines.append(f"  Mean pre-reg NCC       : {pre_mean:.3f}")
+    if post_mean is not None:
+        lines.append(f"  Mean post-reg NCC      : {post_mean:.3f}")
+    if imp_mean is not None:
+        lines.append(f"  Mean NCC improvement   : {imp_mean:+.3f}")
+
+    method_used_counts = summary.get("method_used_counts", {})
+    if method_used_counts:
+        mu_parts = ", ".join(f"{k}: {v}" for k, v in sorted(method_used_counts.items()))
+        lines.append(f"  Methods used           : {mu_parts}")
+    fallback_counts = summary.get("fallback_counts", {})
+    if fallback_counts:
+        fb_parts = ", ".join(f"{k}: {v}" for k, v in sorted(fallback_counts.items()))
+        lines.append(f"  Hard-skip reasons      : {fb_parts}")
+
+    if rows:
+        lines.append("")
+        lines.append(f"  {'Slice':<6} {'Status':<8} {'Used':<14} {'Reason':<28} {'PreNCC':>7} {'PostNCC':>7}")
+        lines.append("  " + "-" * 80)
+        for r in rows[:50]:
+            sid = (r.get("slice_id", "") or "?")[:6]
+            failed = bool(r.get("interpolation_failed"))
+            status = "SKIP" if failed else "OK"
+            method_used = (r.get("method_used", "") or ("—" if failed else ""))[:14]
+            fb = (r.get("fallback_reason", "") or "")[:28]
+            pre = r.get("pre_reg_ncc", "")
+            post = r.get("post_reg_ncc", "")
+            try:
+                pre_fmt = f"{float(pre):.3f}" if pre not in ("", None) else "-"
+            except (TypeError, ValueError):
+                pre_fmt = "-"
+            try:
+                post_fmt = f"{float(post):.3f}" if post not in ("", None) else "-"
+            except (TypeError, ValueError):
+                post_fmt = "-"
+            lines.append(f"  {sid:<6} {status:<8} {method_used:<14} {fb:<28} {pre_fmt:>7} {post_fmt:>7}")
+        if len(rows) > 50:
+            lines.append(f"  ... ({len(rows) - 50} more row(s) not shown)")
+
+    return "\n".join(lines)
+
+
+def generate_html_report(
+    aggregated: dict[str, list[dict]],
+    title: str,
+    verbose: bool = False,
+    images: dict[str, list[Path]] | None = None,
+    image_mode: str = "embed",
+    max_overview_width: int = 900,
+    max_thumb_width: int = 380,
+    trends: dict | None = None,
+    diagnostics: dict | None = None,
+    interpolation: dict | None = None,
+) -> str:
+    """Generate an HTML report from aggregated metrics."""
+    aggregated = sort_steps(aggregated)
+    images = images or {}
+
+    _, error_count, warning_count, ok_count = compute_overall_status(aggregated)
+
+    if error_count > 0:
+        overall_status = "error"
+        overall_message = f"{error_count} error(s), {warning_count} warning(s)"
+    elif warning_count > 0:
+        overall_status = "warning"
+        overall_message = f"{warning_count} warning(s)"
+    else:
+        overall_status = "ok"
+        overall_message = "All checks passed"
+
+    html = f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{title}</title>
+    <style>
+        body {{
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
+            line-height: 1.6;
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 20px;
+            background-color: #f5f5f5;
+        }}
+        .header {{
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: white;
+            padding: 30px;
+            border-radius: 10px;
+            margin-bottom: 20px;
+        }}
+        .header h1 {{ margin: 0; }}
+        .header .timestamp {{ opacity: 0.8; font-size: 0.9em; }}
+        .summary {{
+            background: white;
+            padding: 20px;
+            border-radius: 10px;
+            margin-bottom: 20px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }}
+        .summary-status {{
+            display: inline-block;
+            padding: 10px 20px;
+            border-radius: 5px;
+            color: white;
+            font-weight: bold;
+            font-size: 1.2em;
+            margin-bottom: 15px;
+        }}
+        .step-section {{
+            background: white;
+            padding: 20px;
+            border-radius: 10px;
+            margin-bottom: 15px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }}
+        .step-header {{
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            border-bottom: 1px solid #eee;
+            padding-bottom: 10px;
+            margin-bottom: 10px;
+        }}
+        .step-title {{ font-size: 1.3em; font-weight: bold; }}
+        .step-description {{ color: #666; font-size: 0.9em; margin-bottom: 15px; }}
+        .status-badge {{
+            padding: 5px 15px;
+            border-radius: 20px;
+            color: white;
+            font-size: 0.85em;
+            font-weight: bold;
+            white-space: nowrap;
+        }}
+        .metrics-table {{
+            width: 100%;
+            border-collapse: collapse;
+        }}
+        .metrics-table th, .metrics-table td {{
+            padding: 8px 10px;
+            text-align: left;
+            border-bottom: 1px solid #eee;
+        }}
+        .metrics-table th {{
+            background: #f8f9fa;
+            font-weight: 600;
+            font-size: 0.85em;
+            text-transform: uppercase;
+            letter-spacing: 0.04em;
+        }}
+        .metrics-table td.sparkline-cell {{
+            padding: 4px 10px;
+        }}
+        .metric-status {{
+            width: 10px;
+            height: 10px;
+            border-radius: 50%;
+            display: inline-block;
+            margin-right: 8px;
+            flex-shrink: 0;
+        }}
+        .stats-grid {{
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+            gap: 10px;
+            margin-top: 10px;
+        }}
+        .stat-box {{
+            background: #f8f9fa;
+            padding: 10px;
+            border-radius: 5px;
+            text-align: center;
+        }}
+        .stat-value {{ font-size: 1.4em; font-weight: bold; color: #333; }}
+        .stat-label {{ font-size: 0.8em; color: #666; }}
+
+        /* Issues sections */
+        .issues-details {{
+            border-radius: 5px;
+            margin-top: 12px;
+            overflow: hidden;
+        }}
+        .issues-summary {{
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            padding: 10px 15px;
+            cursor: pointer;
+            user-select: none;
+            list-style: none;
+            font-weight: 600;
+        }}
+        .issues-summary::-webkit-details-marker {{ display: none; }}
+        .issues-summary::before {{
+            content: "▶";
+            font-size: 0.7em;
+            transition: transform 0.2s;
+        }}
+        details[open] > .issues-summary::before {{ transform: rotate(90deg); }}
+        .error-details   {{ border: 1px solid #dc3545; }}
+        .error-summary   {{ background: #f8d7da; color: #842029; }}
+        .warning-details {{ border: 1px solid #ffc107; }}
+        .warning-summary {{ background: #fff3cd; color: #664d03; }}
+        .issue-count-badge {{
+            background: rgba(0,0,0,0.15);
+            border-radius: 20px;
+            padding: 1px 8px;
+            font-size: 0.85em;
+        }}
+        .issues-body {{
+            padding: 8px 15px 12px;
+        }}
+        .issue-item {{
+            padding: 4px 0;
+            border-bottom: 1px solid rgba(0,0,0,0.06);
+            font-size: 0.9em;
+        }}
+        .issue-item:last-child {{ border-bottom: none; }}
+        .sub-issue > summary {{ cursor: pointer; }}
+        .sub-issue-list {{
+            padding-left: 20px;
+            border-left: 3px solid #dee2e6;
+            margin: 4px 0 4px 8px;
+        }}
+        .sub-issue-item {{
+            padding: 2px 0;
+            font-size: 0.85em;
+            color: #555;
+        }}
+
+        /* Info/params section */
+        .params-details {{
+            border: 1px solid #dee2e6;
+            border-radius: 5px;
+            margin-top: 12px;
+        }}
+        .params-summary {{
+            padding: 8px 15px;
+            cursor: pointer;
+            background: #f8f9fa;
+            color: #495057;
+            font-size: 0.9em;
+            font-weight: 500;
+            user-select: none;
+            list-style: none;
+        }}
+        .params-summary::-webkit-details-marker {{ display: none; }}
+        .params-summary::before {{
+            content: "▶";
+            font-size: 0.65em;
+            margin-right: 6px;
+            transition: transform 0.2s;
+        }}
+        details[open] > .params-summary::before {{ transform: rotate(90deg); }}
+        .params-table {{
+            width: 100%;
+            border-collapse: collapse;
+            font-size: 0.85em;
+        }}
+        .params-table td {{
+            padding: 5px 15px;
+            border-bottom: 1px solid #f0f0f0;
+            vertical-align: top;
+        }}
+        .params-table td:first-child {{ color: #555; font-weight: 500; width: 35%; }}
+        .params-table td:last-child  {{ color: #333; font-family: monospace; }}
+
+        /* Verbose individual results */
+        .collapsible {{ cursor: pointer; user-select: none; }}
+        .collapsible:hover {{ background: #f0f0f0; }}
+        .content {{ display: none; padding: 10px; background: #fafafa; }}
+        .show {{ display: block; }}
+        .section-label {{
+            font-size: 0.8em;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.06em;
+            color: #666;
+            margin: 18px 0 6px;
+        }}
+
+        /* Image galleries */
+        .gallery-details {{
+            border: 1px solid #dee2e6;
+            border-radius: 5px;
+            margin-top: 12px;
+            overflow: hidden;
+        }}
+        .gallery-summary {{
+            padding: 8px 15px;
+            cursor: pointer;
+            background: #f0f4ff;
+            color: #3d4db7;
+            font-size: 0.9em;
+            font-weight: 500;
+            user-select: none;
+            list-style: none;
+        }}
+        .gallery-summary::-webkit-details-marker {{ display: none; }}
+        .gallery-summary::before {{
+            content: "▶";
+            font-size: 0.65em;
+            margin-right: 6px;
+            transition: transform 0.2s;
+        }}
+        details[open] > .gallery-summary::before {{ transform: rotate(90deg); }}
+        .image-gallery {{
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+            padding: 12px;
+            background: #fafbff;
+            max-height: 520px;
+            overflow-y: auto;
+        }}
+        .gallery-item {{
+            flex: 0 0 auto;
+            text-align: center;
+        }}
+        .gallery-item img {{
+            display: block;
+            max-width: 100%;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            transition: box-shadow 0.15s;
+        }}
+        .gallery-item img:hover {{ box-shadow: 0 4px 12px rgba(0,0,0,0.2); }}
+        .gallery-item figcaption {{
+            font-size: 0.7em;
+            color: #666;
+            margin-top: 3px;
+            max-width: 200px;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }}
+        /* Overview image in summary */
+        .overview-container {{
+            margin-top: 16px;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 12px;
+        }}
+        .overview-container figure {{
+            margin: 0;
+            flex: 1 1 45%;
+        }}
+        .overview-container img {{
+            width: 100%;
+            border-radius: 6px;
+            box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+        }}
+        .overview-container figcaption {{
+            font-size: 0.8em;
+            color: #666;
+            margin-top: 4px;
+            text-align: center;
+        }}
+
+        /* Cross-slice trends section */
+        .trends-section {{
+            background: white;
+            padding: 20px;
+            border-radius: 10px;
+            margin-bottom: 15px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }}
+        .trends-grid {{
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(460px, 1fr));
+            gap: 14px;
+            margin-top: 12px;
+        }}
+        .trend-card {{
+            border: 1px solid #dee2e6;
+            border-radius: 6px;
+            overflow: hidden;
+        }}
+        .trend-card-header {{
+            background: #f8f9fa;
+            padding: 8px 12px;
+            font-weight: 600;
+            font-size: 0.9em;
+            color: #333;
+        }}
+        .trend-card-desc {{
+            font-size: 0.8em;
+            color: #666;
+            padding: 4px 12px 8px;
+        }}
+        .trend-series {{
+            padding: 4px 12px 8px;
+        }}
+        .trend-series-label {{
+            font-size: 0.78em;
+            color: #555;
+            margin-bottom: 2px;
+        }}
+
+        /* Diagnostics section */
+        .diag-section {{
+            background: white;
+            padding: 20px;
+            border-radius: 10px;
+            margin-bottom: 15px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }}
+        .diag-item {{
+            border: 1px solid #dee2e6;
+            border-radius: 6px;
+            margin-top: 12px;
+            overflow: hidden;
+        }}
+        .diag-item-header {{
+            background: #f0f4ff;
+            padding: 10px 15px;
+            font-weight: 600;
+            font-size: 0.95em;
+            color: #3d4db7;
+        }}
+        .diag-item-desc {{
+            font-size: 0.85em;
+            color: #555;
+            padding: 6px 15px 8px;
+        }}
+        .diag-kv-table {{
+            width: 100%;
+            border-collapse: collapse;
+            font-size: 0.82em;
+        }}
+        .diag-kv-table td {{
+            padding: 3px 15px;
+            border-bottom: 1px solid #f0f0f0;
+        }}
+        .diag-kv-table td:first-child {{ color: #555; font-weight: 500; width: 40%; }}
+        .diag-kv-table td:last-child  {{ color: #333; font-family: monospace; }}
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>{title}</h1>
+        <div class="timestamp">Generated: {datetime.now().strftime("%Y-%m-%d %H:%M:%S")}</div>
+    </div>
+
+    <div class="summary">
+        <h2>Summary</h2>
+        <div class="summary-status" style="background-color: {get_status_color(overall_status)};">
+            {overall_message}
+        </div>
+        <div class="stats-grid">
+            <div class="stat-box">
+                <div class="stat-value">{len(aggregated)}</div>
+                <div class="stat-label">Pipeline Steps</div>
+            </div>
+            <div class="stat-box">
+                <div class="stat-value">{sum(len(v) for v in aggregated.values())}</div>
+                <div class="stat-label">Total Metrics Files</div>
+            </div>
+            <div class="stat-box">
+                <div class="stat-value" style="color: {get_status_color("ok")};">{ok_count}</div>
+                <div class="stat-label">OK</div>
+            </div>
+            <div class="stat-box">
+                <div class="stat-value" style="color: {get_status_color("warning")};">{warning_count}</div>
+                <div class="stat-label">Warnings</div>
+            </div>
+            <div class="stat-box">
+                <div class="stat-value" style="color: {get_status_color("error")};">{error_count}</div>
+                <div class="stat-label">Errors</div>
+            </div>
+        </div>
+    </div>
+"""
+
+    # Overview images in the summary section
+    overview_imgs = images.get("overview", [])
+    if overview_imgs:
+        html += '    <div class="summary" style="padding-top:10px;">\n'
+        html += '        <div class="section-label">Volume Overview</div>\n'
+        html += '        <div class="overview-container">\n'
+        for p in overview_imgs:
+            if image_mode == "embed":
+                src = image_to_data_uri(p, max_width=max_overview_width)
+            else:
+                src = f"previews/overview/{p.name}"
+            html += (
+                f"            <figure>"
+                f'<a href="{src}" target="_blank">'
+                f'<img src="{src}" alt="{p.stem}"></a>'
+                f"<figcaption>{p.stem}</figcaption></figure>\n"
+            )
+        html += "        </div>\n    </div>\n"
+
+    # Cross-slice trends section
+    if trends:
+        colors = ["#4a90d9", "#e67e22", "#27ae60", "#8e44ad", "#c0392b"]
+        html += '\n    <div class="trends-section">\n'
+        html += "        <h2>Cross-Slice Trends</h2>\n"
+        html += (
+            '        <p style="color:#555;font-size:0.9em;">'
+            "Aggregate quality indicators computed across all slices. "
+            "Red dashed lines show the linear trend.</p>\n"
+        )
+        html += '        <div class="trends-grid">\n'
+        for trend in trends.values():
+            html += '            <div class="trend-card">\n'
+            html += f'                <div class="trend-card-header">{trend["label"]}</div>\n'
+            html += f'                <div class="trend-card-desc">{trend["description"]}</div>\n'
+            for ci, series in enumerate(trend["series"]):
+                col = colors[ci % len(colors)]
+                svg = generate_trend_line_svg(series["values"], color=col)
+                html += '                <div class="trend-series">\n'
+                html += f'                    <div class="trend-series-label">{series["name"]}</div>\n'
+                html += f"                    {svg}\n"
+                html += "                </div>\n"
+            html += "            </div>\n"
+        html += "        </div>\n    </div>\n"
+
+    # Generate section for each step
+    for step_name, metrics_list in aggregated.items():
+        summary = compute_summary_statistics(metrics_list)
+        step_status = get_step_status(metrics_list)
+        description = STEP_DESCRIPTIONS.get(step_name, "")
+
+        # Separate quality metrics from info/parameter fields
+        quality_metrics, info_fields = separate_metrics_by_type(metrics_list)
+
+        html += f"""
+    <div class="step-section">
+        <div class="step-header">
+            <span class="step-title">{STEP_DISPLAY_NAMES.get(step_name, step_name.replace("_", " ").title())}</span>
+            <span class="status-badge" style="background-color: {get_status_color(step_status)};">
+                {summary["count"]} items &mdash; {step_status.upper()}
+            </span>
+        </div>
+"""
+        if description:
+            html += f'        <div class="step-description">{description}</div>\n'
+
+        # --- Quality metrics stats table with sparklines ---
+        if quality_metrics:
+            html += '        <div class="section-label">Quality Metrics</div>\n'
+            html += """        <table class="metrics-table">
+            <tr>
+                <th>Metric</th>
+                <th>Mean</th>
+                <th>Median</th>
+                <th>Std</th>
+                <th>Min</th>
+                <th>Max</th>
+                <th>Distribution</th>
+            </tr>
+"""
+            for metric_name, mdata in quality_metrics.items():
+                entries = mdata["entries"]
+                numeric_vals = [e["value"] for e in entries if isinstance(e.get("value"), (int, float))]
+                if not numeric_vals:
+                    continue
+                arr = np.array(numeric_vals)
+                mean_v = float(np.mean(arr))
+                median_v = float(np.median(arr))
+                std_v = float(np.std(arr))
+                min_v = float(np.min(arr))
+                max_v = float(np.max(arr))
+                statuses = [e.get("status", "ok") for e in entries]
+                unit = mdata.get("unit", "")
+                unit_str = f" {unit}" if unit else ""
+
+                # Worst status in this metric
+                if "error" in statuses:
+                    metric_status = "error"
+                elif "warning" in statuses:
+                    metric_status = "warning"
+                else:
+                    metric_status = "ok"
+
+                sparkline = generate_sparkline_svg([e.get("value") for e in entries], statuses)
+
+                html += f"""            <tr>
+                <td>
+                    <span class="metric-status" style="background-color:{get_status_color(metric_status)};"></span>
+                    {metric_name}{unit_str}
+                </td>
+                <td>{format_value(mean_v)}</td>
+                <td>{format_value(median_v)}</td>
+                <td>{format_value(std_v)}</td>
+                <td>{format_value(min_v)}</td>
+                <td>{format_value(max_v)}</td>
+                <td class="sparkline-cell">{sparkline}</td>
+            </tr>
+"""
+            html += "        </table>\n"
+
+        # --- Errors and warnings (grouped, collapsible) ---
+        all_warnings, all_errors = collect_issues(metrics_list)
+
+        if all_errors:
+            grouped_errors = group_issues(all_errors)
+            html += _render_grouped_issues_html(grouped_errors, "error", "Errors")
+
+        if all_warnings:
+            grouped_warnings = group_issues(all_warnings)
+            html += _render_grouped_issues_html(grouped_warnings, "warning", "Warnings")
+
+        # --- Info / parameter fields (collapsed) ---
+        if info_fields:
+            constant_params = {k: v for k, v in info_fields.items() if v["is_constant"]}
+            variable_infos = {k: v for k, v in info_fields.items() if not v["is_constant"]}
+
+            if constant_params:
+                html += """
+        <details class="params-details">
+            <summary class="params-summary">Pipeline Parameters</summary>
+            <table class="params-table">
+"""
+                for name, info in constant_params.items():
+                    val = info["display_value"]
+                    unit = info.get("unit", "")
+                    unit_str = f" {unit}" if unit else ""
+                    html += f"""                <tr>
+                    <td>{name}</td>
+                    <td>{format_value(val)}{unit_str}</td>
+                </tr>
+"""
+                html += "            </table>\n        </details>\n"
+
+            if variable_infos:
+                html += """
+        <details class="params-details">
+            <summary class="params-summary">Variable Info Fields (per-slice)</summary>
+            <table class="metrics-table" style="font-size:0.85em;">
+                <tr>
+                    <th>Field</th>
+                    <th>Mean</th>
+                    <th>Std</th>
+                    <th>Min</th>
+                    <th>Max</th>
+                </tr>
+"""
+                for name, info in variable_infos.items():
+                    numeric = [v for v in info["values"] if isinstance(v, (int, float))]
+                    if not numeric:
+                        continue
+                    arr = np.array(numeric)
+                    unit = info.get("unit", "")
+                    unit_str = f" {unit}" if unit else ""
+                    html += f"""                <tr>
+                    <td>{name}{unit_str}</td>
+                    <td>{format_value(float(np.mean(arr)))}</td>
+                    <td>{format_value(float(np.std(arr)))}</td>
+                    <td>{format_value(float(np.min(arr)))}</td>
+                    <td>{format_value(float(np.max(arr)))}</td>
+                </tr>
+"""
+                html += "            </table>\n        </details>\n"
+
+        # --- Verbose: individual per-slice results (collapsible as a unit) ---
+        if verbose:
+            n_items = len(metrics_list)
+            html += f"""
+        <details class="params-details">
+            <summary class="params-summary">Individual Results ({n_items} slices)</summary>
+"""
+            for m in metrics_list:
+                source = extract_slice_id(m.get("source_file", "unknown"))
+                m_status = m.get("overall_status", "unknown")
+                html += f"""
+        <details>
+            <summary style="cursor:pointer; padding:5px; background:#f8f9fa; border-radius:3px; margin:5px 0;">
+                <span class="metric-status" style="background-color: {get_status_color(m_status)};"></span>
+                {source}
+            </summary>
+            <table class="metrics-table" style="margin:10px 0;">
+"""
+                for name, data in m.get("metrics", {}).items():
+                    if isinstance(data, dict):
+                        value = data.get("value", "N/A")
+                        unit = data.get("unit", "") or ""
+                        status = data.get("status", "info")
+                        html += f"""
+                <tr>
+                    <td>
+                        <span class="metric-status" style="background-color: {get_status_color(status)};"></span>
+                        {name}
+                    </td>
+                    <td>{format_value(value)}{(" " + unit) if unit else ""}</td>
+                </tr>
+"""
+                html += """            </table>
+        </details>
+"""
+            html += "        </details>\n"
+
+        # --- Per-step preview image gallery ---
+        preview_category = STEP_PREVIEW_CATEGORY.get(step_name)
+        if preview_category:
+            step_imgs = images.get(preview_category, [])
+            if step_imgs:
+                html += render_image_gallery_html(
+                    step_imgs, mode=image_mode, category=preview_category, max_width=max_thumb_width
+                )
+
+        html += "    </div>\n"
+
+    # Slice interpolation section (only if interpolation happened)
+    if interpolation:
+        html += _render_interpolation_section_html(interpolation, image_mode=image_mode, max_thumb_width=max_thumb_width)
+
+    # Diagnostics section (only if diagnostic data was found)
+    if diagnostics:
+        html += '\n    <div class="diag-section">\n'
+        html += "        <h2>Diagnostic Outputs</h2>\n"
+        html += (
+            '        <p style="color:#555;font-size:0.9em;">'
+            "Additional diagnostic analyses enabled in the pipeline configuration.</p>\n"
+        )
+        for diag_key, diag in diagnostics.items():
+            label = diag["label"]
+            description = diag["description"]
+            json_data = diag.get("json_data", [])
+            diag_images = diag.get("images", [])
+
+            html += '        <div class="diag-item">\n'
+            html += f'            <div class="diag-item-header">{label}</div>\n'
+            html += f'            <div class="diag-item-desc">{description}</div>\n'
+
+            # Render key JSON fields
+            if json_data:
+                # Collect interesting numeric/scalar fields from first entry
+                first = json_data[0]
+                numeric_fields = {}
+                for k, v in first.items():
+                    if k.startswith("_") or k == "slice_id":
+                        continue
+                    if isinstance(v, (int, float, str, bool)):
+                        numeric_fields[k] = v
+                    elif isinstance(v, dict):
+                        # like scale_factors / residuals / distortions sub-dicts
+                        for sk, sv in v.items():
+                            if isinstance(sv, (int, float, str, bool)):
+                                numeric_fields[f"{k}.{sk}"] = sv
+
+                if numeric_fields:
+                    html += '            <table class="diag-kv-table">\n'
+                    for k, v in list(numeric_fields.items())[:20]:
+                        html += (
+                            f"                <tr><td>{k}</td>"
+                            f"<td>{format_value(v) if isinstance(v, (int, float)) else v}</td></tr>\n"
+                        )
+                    html += "            </table>\n"
+
+            # Render diagnostic image gallery
+            if diag_images:
+                # In zip mode images are referenced via relative paths; in embed mode as data URIs
+                cat_key = f"diag_{diag_key}"
+                gallery = render_image_gallery_html(
+                    diag_images, mode=image_mode, category=cat_key, _label=f"{label} Images", max_width=max_thumb_width
+                )
+                html += gallery
+
+            html += "        </div>\n"
+        html += "    </div>\n"
+
+    html += """
+</body>
+</html>
+"""
+    return html
+
+
+def generate_text_report(
+    aggregated: dict[str, list[dict]],
+    title: str,
+    verbose: bool = False,
+    interpolation: dict | None = None,
+) -> str:
+    """Generate a plain text report from aggregated metrics."""
+    aggregated = sort_steps(aggregated)
+
+    lines = []
+    lines.append("=" * 70)
+    lines.append(title.center(70))
+    lines.append(f"Generated: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}".center(70))
+    lines.append("=" * 70)
+    lines.append("")
+
+    _, error_count, warning_count, ok_count = compute_overall_status(aggregated)
+
+    lines.append("SUMMARY")
+    lines.append("-" * 70)
+    lines.append(f"  Pipeline Steps: {len(aggregated)}")
+    lines.append(f"  Total Metrics Files: {sum(len(v) for v in aggregated.values())}")
+    lines.append(
+        f"  Status: {get_status_emoji('ok')} OK: {ok_count}  "
+        f"{get_status_emoji('warning')} Warnings: {warning_count}  "
+        f"{get_status_emoji('error')} Errors: {error_count}"
+    )
+    lines.append("")
+
+    for step_name, metrics_list in aggregated.items():
+        summary = compute_summary_statistics(metrics_list)
+        step_status = get_step_status(metrics_list)
+
+        lines.append("")
+        lines.append(f"{get_status_emoji(step_status)} {step_name.replace('_', ' ').upper()}")
+        lines.append("-" * 70)
+        lines.append(f"  Items: {summary['count']} | Status: {step_status.upper()}")
+
+        # Quality metrics stats
+        quality_metrics, _ = separate_metrics_by_type(metrics_list)
+        if quality_metrics:
+            lines.append("")
+            lines.append("  Quality Metrics:")
+            lines.append(f"  {'Metric':<25} {'Mean':>12} {'Median':>12} {'Std':>12} {'Min':>12} {'Max':>12}")
+            lines.append("  " + "-" * 77)
+            for metric_name, mdata in quality_metrics.items():
+                entries = mdata["entries"]
+                numeric_vals = [e["value"] for e in entries if isinstance(e.get("value"), (int, float))]
+                if not numeric_vals:
+                    continue
+                arr = np.array(numeric_vals)
+                name = metric_name[:25]
+                lines.append(
+                    f"  {name:<25} {format_value(float(np.mean(arr))):>12} "
+                    f"{format_value(float(np.median(arr))):>12} "
+                    f"{format_value(float(np.std(arr))):>12} "
+                    f"{format_value(float(np.min(arr))):>12} "
+                    f"{format_value(float(np.max(arr))):>12}"
+                )
+
+        all_warnings, all_errors = collect_issues(metrics_list)
+
+        if all_errors:
+            lines.append("")
+            lines.append(f"  {get_status_emoji('error')} ERRORS:")
+            for g in group_issues(all_errors):
+                if g["count"] == 1:
+                    lines.append(f"    - {g['details'][0]}")
+                else:
+                    vals = g["values"]
+                    val_str = f"range {min(vals):.3g}–{max(vals):.3g}" if vals else f"{g['count']} occurrences"
+                    lines.append(f"    - {g['metric']}: {g['count']} slices ({val_str})")
+
+        if all_warnings:
+            lines.append("")
+            lines.append(f"  {get_status_emoji('warning')} WARNINGS:")
+            for g in group_issues(all_warnings):
+                if g["count"] == 1:
+                    lines.append(f"    - {g['details'][0]}")
+                else:
+                    vals = g["values"]
+                    val_str = f"range {min(vals):.3g}–{max(vals):.3g}" if vals else f"{g['count']} occurrences"
+                    lines.append(f"    - {g['metric']}: {g['count']} slices ({val_str})")
+
+        if verbose:
+            lines.append("")
+            lines.append("  Individual Results:")
+            for m in metrics_list:
+                source = extract_slice_id(m.get("source_file", "unknown"))
+                m_status = m.get("overall_status", "unknown")
+                lines.append(f"    {get_status_emoji(m_status)} {source}")
+                for name, data in m.get("metrics", {}).items():
+                    if isinstance(data, dict):
+                        value = data.get("value", "N/A")
+                        unit = data.get("unit", "") or ""
+                        lines.append(f"       {name}: {format_value(value)}{(' ' + unit) if unit else ''}")
+
+    if interpolation:
+        lines.append(_render_interpolation_section_text(interpolation))
+
+    lines.append("")
+    lines.append("=" * 70)
+    lines.append("End of Report".center(70))
+    lines.append("=" * 70)
+
+    return "\n".join(lines)
+
+
+def main() -> None:
+    """Run function."""
+    parser = _build_arg_parser()
+    args = parser.parse_args()
+
+    input_dir = Path(args.input_dir)
+    output_file = Path(args.output_report)
+
+    if not input_dir.exists():
+        parser.error(f"Input directory does not exist: {input_dir}")
+
+    # Determine format
+    if args.format == "auto":
+        suffix = output_file.suffix.lower()
+        if suffix == ".html":
+            output_format = "html"
+        elif suffix == ".zip":
+            output_format = "zip"
+        else:
+            output_format = "text"
+    else:
+        output_format = args.format
+
+    # Aggregate metrics from all subdirectories
+    print(f"Scanning for metrics files in: {input_dir}")
+    aggregated = aggregate_metrics(input_dir)
+
+    if not aggregated:
+        print("No metrics files found. Checking for process subdirectories...")
+        for subdir in input_dir.iterdir():
+            if subdir.is_dir():
+                sub_aggregated = aggregate_metrics(subdir)
+                for step, metrics in sub_aggregated.items():
+                    if step not in aggregated:
+                        aggregated[step] = []
+                    aggregated[step].extend(metrics)
+
+    if not aggregated:
+        print("Warning: No metrics files found in the input directory.")
+        print("Make sure the pipeline has been run with metrics collection enabled.")
+        aggregated = {}
+
+    print(f"Found {sum(len(v) for v in aggregated.values())} metrics files across {len(aggregated)} pipeline steps")
+
+    # Discover preview images — only for zip bundles; HTML is always image-free
+    images: dict[str, list[Path]] = {}
+    if output_format == "zip" and not args.no_images:
+        images = discover_images(input_dir, overview_png=args.overview_png, annotated_png=args.annotated_png)
+        total_imgs = sum(len(v) for v in images.values())
+        if total_imgs:
+            print(f"Found {total_imgs} preview image(s) to bundle in zip")
+
+    # Zip bundles use relative image links; standalone HTML has no images
+    image_mode = "link"
+
+    # Compute cross-slice aggregate trends
+    trends = compute_cross_slice_trends(aggregated)
+    if trends:
+        n_trend_groups = len(trends)
+        print(f"Computed {n_trend_groups} cross-slice trend group(s)")
+
+    # Discover slice-interpolation outputs
+    interpolation = discover_interpolation_data(input_dir)
+    if interpolation:
+        s = interpolation["summary"]
+        print(f"Found interpolation output(s): {s['count']} slice(s), {s['n_with_fallback']} with fallback")
+        if output_format == "zip" and not args.no_images and interpolation.get("images"):
+            images["diag_interpolate_missing_slice"] = list(interpolation["images"])
+
+    # Discover diagnostic outputs
+    diagnostics = discover_diagnostic_data(input_dir)
+    if diagnostics:
+        print(f"Found {len(diagnostics)} diagnostic output(s): {', '.join(diagnostics.keys())}")
+        # In zip mode, include diagnostic images in the bundle
+        if output_format == "zip" and not args.no_images:
+            for diag_key, diag in diagnostics.items():
+                cat_key = f"diag_{diag_key}"
+                diag_imgs = diag.get("images", [])
+                if diag_imgs:
+                    images[cat_key] = diag_imgs
+
+    # Generate report
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    if output_format in ("html", "zip"):
+        report = generate_html_report(
+            aggregated,
+            args.title,
+            args.verbose,
+            images=images,
+            image_mode=image_mode,
+            max_overview_width=args.max_overview_width,
+            max_thumb_width=args.max_thumb_width,
+            trends=trends if trends else None,
+            diagnostics=diagnostics if diagnostics else None,
+            interpolation=interpolation,
+        )
+        if output_format == "zip":
+            if output_file.suffix.lower() != ".zip":
+                output_file = output_file.with_suffix(".zip")
+            generate_zip_bundle(report, images, output_file)
+        else:
+            with Path(output_file).open("w") as f:
+                f.write(report)
+    else:
+        report = generate_text_report(aggregated, args.title, args.verbose, interpolation=interpolation)
+        with Path(output_file).open("w") as f:
+            f.write(report)
+
+    print(f"Report saved to: {output_file}")
+
+    _, error_count, warning_count, _ = compute_overall_status(aggregated)
+
+    if error_count > 0:
+        print(f"\n{get_status_emoji('error')} {error_count} error(s) found - please review the report")
+    elif warning_count > 0:
+        print(f"\n{get_status_emoji('warning')} {warning_count} warning(s) found - please review the report")
+    else:
+        print(f"\n{get_status_emoji('ok')} All checks passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/linum_interpolate_missing_slice.py
+++ b/scripts/linum_interpolate_missing_slice.py
@@ -1,0 +1,593 @@
+#!/usr/bin/env python3
+r"""
+Interpolate a missing slice using information from adjacent slices.
+
+Uses z-aware morphing (``zmorph``): an affine transform ``T`` between the
+boundary planes of the two neighbours is computed, then for each output
+plane at fractional depth ``alpha`` the before-boundary is warped by
+``T^alpha`` and the after-boundary by ``T^(alpha - 1)`` and the two are
+cross-faded.
+
+Hard skip on gate failure: when zmorph's 2D boundary registration fails
+any quality gate, no interpolated zarr is produced: the slot is left as a
+genuine gap rather than filled with a blended (and therefore fabricated)
+volume. A manifest fragment and diagnostics JSON are still emitted so the
+failure is visible in ``slice_config_final.csv`` and the final report. The
+``average`` / ``weighted`` methods remain available as explicit,
+user-requested baselines.
+
+Only a SINGLE missing slice can be reconstructed -- two or more consecutive
+gaps carry insufficient information.
+
+See ``docs/SLICE_INTERPOLATION_FEATURE.md`` for the physical model and
+parameter-tuning guidance.
+
+Example usage::
+
+    linum_interpolate_missing_slice.py slice_z00.ome.zarr slice_z02.ome.zarr \\
+        slice_z01_interpolated.ome.zarr
+
+    # Finalise mode: merge per-slice manifest fragments into slice_config.csv
+    linum_interpolate_missing_slice.py --finalise \\
+        --slice_config_in  slice_config.csv \\
+        --slice_config_out slice_config_final.csv \\
+        --fragments        interpolate_missing_slice/
+"""
+
+import linumpy.config.threads  # noqa: F401
+from linumpy.config.threads import configure_all_libraries
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+import dask.array as da
+import matplotlib.pyplot as plt
+import numpy as np
+
+from linumpy.cli.args import add_overwrite_arg, assert_output_exists
+from linumpy.io import slice_config as slice_config_io
+from linumpy.io.zarr import read_omezarr, save_omezarr
+from linumpy.mosaic.interpolation import (
+    interpolate_average,
+    interpolate_weighted,
+    interpolate_z_morph,
+)
+
+configure_all_libraries()
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
+    p.add_argument("slice_before", nargs="?", help="Path to the slice BEFORE the missing slice (`*.ome.zarr`)")
+    p.add_argument("slice_after", nargs="?", help="Path to the slice AFTER the missing slice (`*.ome.zarr`)")
+    p.add_argument("output", nargs="?", help="Output path for the interpolated slice (`*.ome.zarr`)")
+    p.add_argument(
+        "--method",
+        choices=["zmorph", "average", "weighted"],
+        default="zmorph",
+        help="Interpolation method:\n"
+        "  zmorph   - z-aware morphing (respects serial-section geometry; recommended)\n"
+        "  average  - Simple average of adjacent slices\n"
+        "  weighted - Weighted average with distance falloff\n"
+        "\n"
+        "[default: %(default)s]",
+    )
+    p.add_argument(
+        "--blend_method",
+        choices=["linear", "gaussian"],
+        default="gaussian",
+        help="Blending method for combining warped slices:\n"
+        "  linear - Equal 50/50 blend (may show edges)\n"
+        "  gaussian - Feathered blend using distance transform (recommended)\n"
+        "\n"
+        "[default: %(default)s]",
+    )
+    p.add_argument(
+        "--registration_metric",
+        choices=["MSE", "CC", "MI"],
+        default="MSE",
+        help="Metric for registration [default: %(default)s]",
+    )
+    p.add_argument(
+        "--max_iterations", type=int, default=1000, help="Maximum iterations for registration [default: %(default)s]"
+    )
+    p.add_argument(
+        "--overlap_search_window",
+        type=int,
+        default=5,
+        help="Number of z-planes to search at each volume boundary\n"
+        "when selecting the registration reference pair automatically.\n"
+        "[default: %(default)s]",
+    )
+    p.add_argument(
+        "--min_overlap_correlation",
+        type=float,
+        default=0.3,
+        help="Minimum normalized cross-correlation required between the\n"
+        "boundary planes to proceed with registration. Below this\n"
+        "threshold zmorph emits no output (hard skip).\n"
+        "[default: %(default)s]",
+    )
+    p.add_argument(
+        "--reference_slab_size",
+        type=int,
+        default=3,
+        help="Number of z-planes averaged around the boundary reference\n"
+        "plane when running the 2D registration. Larger slabs are\n"
+        "more robust to per-plane noise. [default: %(default)s]",
+    )
+    p.add_argument(
+        "--min_foreground_fraction",
+        type=float,
+        default=0.1,
+        help="Minimum fraction of foreground pixels required for a\n"
+        "candidate boundary plane to be considered. [default: %(default)s]",
+    )
+    p.add_argument(
+        "--min_ncc_improvement",
+        type=float,
+        default=0.05,
+        help="Minimum improvement in boundary NCC required after 2D\n"
+        "registration to accept the transform. Below this zmorph emits\n"
+        "no output (hard skip). [default: %(default)s]",
+    )
+    p.add_argument(
+        "--diagnostics",
+        type=str,
+        default=None,
+        help="Path to write a JSON diagnostics file (plane selection,\n"
+        "pre/post NCC, half-transform verification, fallback reason).",
+    )
+    p.add_argument(
+        "--manifest_entry",
+        type=str,
+        default=None,
+        help="Path to write a single-line CSV manifest entry for this\ninterpolated slice (aggregated downstream).",
+    )
+    p.add_argument(
+        "--slice_id",
+        type=str,
+        default=None,
+        help="Slice id string (e.g. '02') to record in the manifest entry.",
+    )
+
+    # Finalise / slice_config merge mode
+    finalise_group = p.add_argument_group(
+        "Finalise Mode",
+        "Merge per-slice interpolation manifest fragments into slice_config.csv. "
+        "When --finalise is set, the positional slice arguments are ignored and "
+        "the script instead consumes --slice_config_in + --fragments and writes "
+        "--slice_config_out.",
+    )
+    finalise_group.add_argument(
+        "--finalise",
+        action="store_true",
+        help="Run in finalise mode: merge fragments into slice_config.csv.",
+    )
+    finalise_group.add_argument(
+        "--slice_config_in",
+        type=str,
+        default=None,
+        help="Input slice_config.csv (finalise mode).",
+    )
+    finalise_group.add_argument(
+        "--slice_config_out",
+        type=str,
+        default=None,
+        help="Output slice_config.csv (finalise mode).",
+    )
+    finalise_group.add_argument(
+        "--fragments",
+        type=str,
+        default=None,
+        help="Directory containing per-slice manifest fragment CSVs (finalise mode). "
+        "Fragments are discovered by glob; empty dir results in slice_config copied "
+        "unchanged.",
+    )
+
+    # Preview/debug options
+    preview_group = p.add_argument_group("Preview Options", "Generate visual previews for quality checking")
+    preview_group.add_argument(
+        "--preview",
+        type=str,
+        default=None,
+        help=(
+            "Path to save a preview image (PNG) showing slice before, slice\n"
+            "after, and the interpolated result. Useful for verifying\n"
+            "interpolation quality."
+        ),
+    )
+    preview_group.add_argument(
+        "--preview_slice", type=int, default=None, help="Z-index to use for preview. Default: middle slice."
+    )
+    preview_group.add_argument("--preview_dpi", type=int, default=150, help="DPI for preview image [default: %(default)s]")
+
+    add_overwrite_arg(p)
+    return p
+
+
+def generate_preview(
+    vol_before: Any,
+    vol_after: Any,
+    interpolated: Any,
+    output_path: Path,
+    preview_slice: Any = None,
+    dpi: int = 150,
+    failure_reason: str | None = None,
+) -> Any:
+    """
+    Generate a preview image showing the interpolation results.
+
+    When *interpolated* is ``None`` the preview degrades gracefully to a
+    before/after pair with a red banner explaining why no output was
+    produced. This keeps visual QA working even for hard-skipped slices.
+
+    Parameters
+    ----------
+    vol_before, vol_after : np.ndarray
+        Neighbouring volumes.
+    interpolated : np.ndarray | None
+        Interpolated result, or ``None`` for a hard-skipped slice.
+    output_path : str or Path
+        Path to save the preview image.
+    preview_slice : int, optional
+        Z-index to use for preview. Default: middle slice.
+    dpi : int
+        DPI for the output image.
+    failure_reason : str, optional
+        Text shown in the banner when *interpolated* is ``None``.
+    """
+    if preview_slice is None:
+        preview_slice = vol_before.shape[0] // 2
+    preview_slice = max(0, min(preview_slice, vol_before.shape[0] - 1))
+
+    def normalize_for_display(img: Any) -> Any:
+        img = img.astype(np.float32)
+        p1, p99 = np.percentile(img[img > 0], [1, 99]) if np.any(img > 0) else (0, 1)
+        if p99 > p1:
+            img = (img - p1) / (p99 - p1)
+        return np.clip(img, 0, 1)
+
+    before_slice = normalize_for_display(vol_before[preview_slice])
+    after_slice = normalize_for_display(vol_after[preview_slice])
+
+    fig, axes = plt.subplots(2, 2, figsize=(12, 10))
+    axes = axes.flatten()
+
+    axes[0].imshow(before_slice, cmap="gray")
+    axes[0].set_title("Slice Before (input)")
+    axes[0].axis("off")
+
+    axes[1].imshow(after_slice, cmap="gray")
+    axes[1].set_title("Slice After (input)")
+    axes[1].axis("off")
+
+    if interpolated is None:
+        axes[2].set_facecolor("#3a0a0a")
+        axes[2].text(
+            0.5,
+            0.55,
+            "INTERPOLATION FAILED",
+            color="white",
+            ha="center",
+            va="center",
+            fontsize=16,
+            fontweight="bold",
+            transform=axes[2].transAxes,
+        )
+        if failure_reason:
+            axes[2].text(
+                0.5,
+                0.35,
+                f"reason: {failure_reason}",
+                color="#ffd0d0",
+                ha="center",
+                va="center",
+                fontsize=10,
+                transform=axes[2].transAxes,
+            )
+        axes[2].set_xticks([])
+        axes[2].set_yticks([])
+
+        # XZ view still useful for context -- skip the missing middle slab.
+        y_mid = vol_before.shape[1] // 2
+        xz_before = normalize_for_display(vol_before[:, y_mid, :])
+        xz_after = normalize_for_display(vol_after[:, y_mid, :])
+        gap = np.full(
+            (max(1, min(vol_before.shape[0], vol_after.shape[0]) // 2), xz_before.shape[1]),
+            0.15,
+            dtype=np.float32,
+        )
+        xz_combined = np.vstack([xz_before, gap, xz_after])
+        axes[3].imshow(xz_combined, cmap="gray", aspect="auto")
+        axes[3].set_title("XZ View: Before | [skipped] | After")
+        axes[3].axis("off")
+    else:
+        interp_slice = normalize_for_display(interpolated[preview_slice])
+        axes[2].imshow(interp_slice, cmap="gray")
+        axes[2].set_title("Interpolated (output)")
+        axes[2].axis("off")
+
+        y_mid = vol_before.shape[1] // 2
+        xz_before = normalize_for_display(vol_before[:, y_mid, :])
+        xz_interp = normalize_for_display(interpolated[:, y_mid, :])
+        xz_after = normalize_for_display(vol_after[:, y_mid, :])
+        xz_combined = np.vstack([xz_before, xz_interp, xz_after])
+        axes[3].imshow(xz_combined, cmap="gray", aspect="auto")
+        axes[3].set_title("XZ View: Before | Interp | After")
+        axes[3].axhline(y=xz_before.shape[0], color="cyan", linestyle="--", linewidth=0.5)
+        axes[3].axhline(y=xz_before.shape[0] + xz_interp.shape[0], color="cyan", linestyle="--", linewidth=0.5)
+        axes[3].axis("off")
+
+    title = (
+        f"Slice Interpolation Preview (z={preview_slice}) -- FAILED"
+        if interpolated is None
+        else f"Slice Interpolation Preview (z={preview_slice})"
+    )
+    fig.suptitle(title, fontsize=14)
+    fig.tight_layout()
+    fig.savefig(output_path, dpi=dpi, bbox_inches="tight")
+    plt.close(fig)
+    print(f"Preview saved to: {output_path}")
+
+
+_FRAGMENT_COLUMN_MAP = {
+    "method_used": "interpolation_method_used",
+    "fallback_reason": "interpolation_fallback_reason",
+}
+
+
+def _finalise(args: argparse.Namespace) -> None:
+    """Merge per-slice manifest fragments into a single slice_config.csv.
+
+    Each fragment represents one attempt, successful or not:
+
+    * ``interpolation_failed != true`` → slice was reconstructed. Stamps
+      ``interpolated=true`` plus method / fallback_reason.
+    * ``interpolation_failed == true`` → slice was hard-skipped. Stamps
+      ``interpolated=false``, ``interpolation_failed=true``, and
+      ``interpolation_fallback_reason=<reason>`` so the final report can
+      surface it.
+    """
+    if args.slice_config_in is None or args.slice_config_out is None or args.fragments is None:
+        raise SystemExit("--finalise requires --slice_config_in, --slice_config_out, and --fragments")
+
+    fragments_dir = Path(args.fragments)
+    fragment_paths: list[Path] = []
+    if fragments_dir.is_dir():
+        fragment_paths = sorted(fragments_dir.glob("*.csv"))
+    elif fragments_dir.exists():
+        fragment_paths = [fragments_dir]
+    else:
+        print(f"  Fragments path does not exist: {fragments_dir} -- copying slice_config unchanged.")
+
+    updates: dict[str, dict[str, object]] = {}
+    interpolated_ids: set[str] = set()
+    failed_ids: set[str] = set()
+    import csv
+
+    for frag_path in fragment_paths:
+        with frag_path.open() as fh:
+            reader = csv.DictReader(fh)
+            for raw in reader:
+                sid = slice_config_io.normalize_slice_id(raw.get("slice_id", ""))
+                if not sid:
+                    continue
+                failed_raw = (raw.get("interpolation_failed") or "").strip().lower()
+                failed = failed_raw in ("true", "1", "yes", "y", "t")
+                entry: dict[str, object] = {
+                    "interpolated": not failed,
+                    "interpolation_failed": failed,
+                }
+                for col, val in raw.items():
+                    if col in ("slice_id", "interpolation_failed", None) or val is None:
+                        continue
+                    target = _FRAGMENT_COLUMN_MAP.get(col)
+                    if target:
+                        entry[target] = val
+                if failed:
+                    failed_ids.add(sid)
+                    entry["interpolation_method_used"] = ""
+                else:
+                    interpolated_ids.add(sid)
+                updates[sid] = entry
+
+    slice_config_io.stamp_many(args.slice_config_in, args.slice_config_out, updates)
+    print(
+        f"Finalise: merged {len(fragment_paths)} fragment(s), "
+        f"{len(interpolated_ids)} interpolated, {len(failed_ids)} failed → {args.slice_config_out}"
+    )
+
+
+def main() -> None:
+    """Run the interpolate missing slice script."""
+    p = _build_arg_parser()
+    args = p.parse_args()
+
+    if args.finalise:
+        _finalise(args)
+        return
+
+    if not (args.slice_before and args.slice_after and args.output):
+        p.error("slice_before, slice_after, and output are required unless --finalise is set")
+
+    slice_before_path = Path(args.slice_before)
+    slice_after_path = Path(args.slice_after)
+    output_path = Path(args.output)
+
+    if not slice_before_path.exists():
+        p.error(f"Slice before not found: {slice_before_path}")
+    if not slice_after_path.exists():
+        p.error(f"Slice after not found: {slice_after_path}")
+
+    assert_output_exists(output_path, p, args)
+
+    print(f"Loading slice before: {slice_before_path}")
+    vol_before, res_before = read_omezarr(slice_before_path)
+    vol_before = np.array(vol_before)
+
+    print(f"Loading slice after: {slice_after_path}")
+    vol_after, res_after = read_omezarr(slice_after_path)
+    vol_after = np.array(vol_after)
+
+    # Handle shape mismatches
+    if vol_before.shape != vol_after.shape:
+        print(f"Shape mismatch detected: {vol_before.shape} vs {vol_after.shape}")
+
+        # Handle z-dimension mismatch by truncating to minimum
+        min_z = min(vol_before.shape[0], vol_after.shape[0])
+        if vol_before.shape[0] != vol_after.shape[0]:
+            print(f"  Truncating z-dimension to minimum: {min_z}")
+            vol_before = vol_before[:min_z]
+            vol_after = vol_after[:min_z]
+
+        # Handle X/Y dimension mismatch by using maximum and zero-padding
+        if vol_before.shape[1:] != vol_after.shape[1:]:
+            max_x = max(vol_before.shape[1], vol_after.shape[1])
+            max_y = max(vol_before.shape[2], vol_after.shape[2])
+            print(f"  Adjusting X/Y dimensions to: ({max_x}, {max_y})")
+
+            # Pad vol_before if needed
+            if vol_before.shape[1] < max_x or vol_before.shape[2] < max_y:
+                padded = np.zeros((min_z, max_x, max_y), dtype=vol_before.dtype)
+                padded[:, : vol_before.shape[1], : vol_before.shape[2]] = vol_before
+                vol_before = padded
+
+            # Pad vol_after if needed
+            if vol_after.shape[1] < max_x or vol_after.shape[2] < max_y:
+                padded = np.zeros((min_z, max_x, max_y), dtype=vol_after.dtype)
+                padded[:, : vol_after.shape[1], : vol_after.shape[2]] = vol_after
+                vol_after = padded
+
+        print(f"  Adjusted shapes: {vol_before.shape}")
+
+    # Validate resolutions match
+    if res_before != res_after:
+        print(f"Warning: Resolution mismatch: {res_before} vs {res_after}")
+
+    print(f"Volume shape: {vol_before.shape}")
+    print(f"Resolution: {res_before}")
+    print(f"Method: {args.method}")
+
+    diagnostics: dict = {}
+
+    if args.method == "zmorph":
+        print("Performing z-morph interpolation...")
+        interpolated, diagnostics = interpolate_z_morph(
+            vol_before,
+            vol_after,
+            metric=args.registration_metric,
+            max_iterations=args.max_iterations,
+            blend_method=args.blend_method,
+            overlap_search_window=args.overlap_search_window,
+            min_overlap_correlation=args.min_overlap_correlation,
+            reference_slab_size=args.reference_slab_size,
+            min_foreground_fraction=args.min_foreground_fraction,
+            min_ncc_improvement=args.min_ncc_improvement,
+        )
+    elif args.method == "average":
+        print("Performing simple average interpolation...")
+        interpolated = interpolate_average(vol_before, vol_after)
+        diagnostics = {"method": "average", "method_used": "average", "fallback_reason": None}
+    elif args.method == "weighted":
+        print("Performing weighted average interpolation...")
+        interpolated = interpolate_weighted(vol_before, vol_after)
+        diagnostics = {"method": "weighted", "method_used": "weighted", "fallback_reason": None}
+    else:
+        p.error(f"Unknown method: {args.method}")
+
+    failed = interpolated is None or diagnostics.get("interpolation_failed") is True
+
+    if failed:
+        print(
+            f"  [interpolation] zmorph could not produce a reliable output "
+            f"(reason={diagnostics.get('fallback_reason')}); emitting no zarr, "
+            f"the slice will be treated as a gap downstream."
+        )
+
+    # Preview is still useful on failure (shows the before/after pair and the
+    # skipped middle slab), so emit it regardless.
+    if args.preview is not None:
+        print("Generating preview...")
+        generate_preview(
+            vol_before,
+            vol_after,
+            interpolated,
+            output_path=args.preview,
+            preview_slice=args.preview_slice,
+            dpi=args.preview_dpi,
+            failure_reason=diagnostics.get("fallback_reason") if failed else None,
+        )
+
+    if not failed:
+        assert interpolated is not None
+        final_result: np.ndarray = interpolated
+        original_dtype = vol_before.dtype
+        if np.issubdtype(original_dtype, np.integer):
+            imax = int(np.iinfo(original_dtype).max)
+            final_result = np.clip(final_result, 0, imax)
+            final_result = final_result.astype(original_dtype)
+
+        print(f"Saving interpolated slice to: {output_path}")
+        save_omezarr(da.from_array(final_result), Path(output_path), res_before)
+    else:
+        print("Skipping zarr output -- no fabricated data will enter the reconstruction.")
+
+    if args.diagnostics is not None:
+        diagnostics["slice_id"] = args.slice_id
+        diagnostics["slice_before_path"] = str(slice_before_path)
+        diagnostics["slice_after_path"] = str(slice_after_path)
+        diagnostics["output_path"] = None if failed else str(output_path)
+        diagnostics["interpolation_failed"] = bool(failed)
+        diagnostics_path = Path(args.diagnostics)
+        diagnostics_path.parent.mkdir(parents=True, exist_ok=True)
+        with diagnostics_path.open("w") as fh:
+            json.dump(diagnostics, fh, indent=2, default=_json_default)
+        print(f"Diagnostics saved to: {diagnostics_path}")
+
+    # Manifest records pipeline-relevant flags only -- raw metrics live in the
+    # per-slice diagnostics JSON. The `interpolation_failed` column is what
+    # finalise_interpolation uses to decide whether to stamp the slice as
+    # successfully interpolated or as a hard-skip.
+    if args.manifest_entry is not None:
+        manifest_path = Path(args.manifest_entry)
+        manifest_path.parent.mkdir(parents=True, exist_ok=True)
+        row = {
+            "slice_id": args.slice_id or "",
+            "method": diagnostics.get("method", args.method),
+            "method_used": "" if failed else (diagnostics.get("method_used") or args.method),
+            "fallback_reason": diagnostics.get("fallback_reason") or "",
+            "interpolation_failed": "true" if failed else "false",
+            "output_path": "" if failed else str(output_path),
+        }
+        header = ",".join(row.keys())
+        values = ",".join(_csv_escape(v) for v in row.values())
+        with manifest_path.open("w") as fh:
+            fh.write(header + "\n")
+            fh.write(values + "\n")
+        print(f"Manifest entry saved to: {manifest_path}")
+
+    print("Done!")
+
+
+def _json_default(obj: Any) -> Any:
+    if isinstance(obj, (np.floating,)):
+        return float(obj)
+    if isinstance(obj, (np.integer,)):
+        return int(obj)
+    if isinstance(obj, np.ndarray):
+        return obj.tolist()
+    return str(obj)
+
+
+def _csv_escape(value: Any) -> str:
+    s = "" if value is None else str(value)
+    if "," in s or '"' in s or "\n" in s:
+        s = '"' + s.replace('"', '""') + '"'
+    return s
+
+
+if __name__ == "__main__":
+    main()

--- a/shell_scripts/server_setup/nvfs_kernel7_patch.sh
+++ b/shell_scripts/server_setup/nvfs_kernel7_patch.sh
@@ -1,0 +1,208 @@
+#!/bin/bash
+# Patch nvidia-fs 2.28.4 to build against Linux kernel 7.0 (Ubuntu 26.04).
+#
+# REMOVAL TRIGGER
+# ---------------
+# Delete this script as soon as nvidia-fs-dkms ships an upstream version
+# that builds cleanly on the running kernel. Quick check:
+#
+#   sudo dkms add /usr/src/nvidia-fs-<NEW_VER>      # try the stock sources
+#   sudo dkms build nvidia-fs/<NEW_VER>             # if this succeeds, drop the patch
+#
+# Two upstream API changes this patch works around:
+#   1) struct vm_area_struct: __vm_flags removed, vm_flags is now a const
+#      field of an anonymous union (writes still go through vm_flags_set).
+#      Fix: read via vma->vm_flags.
+#   2) struct blk_dma_iter::iter is now struct blk_map_iter (was
+#      struct req_iterator). They share .iter (bvec_iter) and .bio in the
+#      same order, so we add a configure probe HAVE_BLK_MAP_ITER and
+#      typedef nvfs_req_iter_t accordingly. Helper signatures use the typedef.
+#   3) create_nv.symvers.sh only decompressed *.ko.xz; Ubuntu 26.04 ships
+#      kernel modules as *.ko.zst, so nm fails and Module.symvers ends up
+#      empty. Without CRCs the runtime symbol-version check on
+#      nvidia_p2p_dma_unmap_pages fails and nvidia-fs falls back to the
+#      no-symver path -> GDS stays in compat mode. Fix: add a *.ko.zst
+#      branch that decompresses with zstd before nm runs.
+#   4) create_nv.symvers.sh detects relative CRCs with `grep -e "\sR\s*__crc"`
+#      but on kernel 7.0 / current open-gpu-kmd builds the __crc_nvidia_p2p_*
+#      symbols are emitted as section-local rodata (lowercase `r`), not
+#      global (`R`). The detection misses them, so the script falls through
+#      and writes the *relocation offsets* (0x4, 0x8, 0xc, ...) as fake
+#      CRCs. nvidia-fs.ko then fails the modversion check on
+#      nvidia_p2p_dma_unmap_pages at load time and GDS silently drops to
+#      compat -> NVMe: Unsupported. Fix: case-insensitive grep, which
+#      triggers the existing try_compile_nvidia_sources fallback that
+#      compiles nvidia from /usr/src/nvidia-<ver> and produces a real
+#      Module.symvers via genksyms.
+#
+# USAGE (server-side, as root)
+# ----------------------------
+#   sudo bash nvfs_kernel7_patch.sh
+#   sudo dkms remove nvidia-fs/2.28.4 --all 2>/dev/null || true
+#   sudo dkms add /usr/src/nvidia-fs-2.28.4
+#   sudo dkms build nvidia-fs/2.28.4
+#   sudo dkms install nvidia-fs/2.28.4
+#   sudo modprobe nvidia-fs
+#   /usr/local/cuda/gds/tools/gdscheck -p
+#
+# The script is idempotent (creates *.orig backups, skips reapplying if the
+# probe is already present). Safe to re-run after kernel header upgrades.
+
+set -e
+SRC=${NVFS_SRC:-/usr/src/nvidia-fs-2.28.4}
+if [ ! -d "$SRC" ]; then
+    echo "ERROR: $SRC not found. Set NVFS_SRC=/usr/src/nvidia-fs-<ver> if version differs." >&2
+    exit 2
+fi
+cd "$SRC"
+
+# Idempotency: keep one .orig backup
+for f in nvfs-mmap.c nvfs-dma.c configure create_nv.symvers.sh; do
+    [ -f "$f.orig" ] || cp -p "$f" "$f.orig"
+done
+
+# --- nvfs-mmap.c: drop ACCESS_PRIVATE(__vm_flags) --------------------------
+# kernel 7.0 dropped the __vm_flags private name; vm_flags is the public
+# (const) field name again.
+python3 - <<'PY'
+from pathlib import Path
+p = Path("nvfs-mmap.c")
+s = p.read_text()
+old = "\tvm_flags = ACCESS_PRIVATE(vma, __vm_flags);"
+new = "\tvm_flags = vma->vm_flags;"
+if old not in s:
+    assert new in s, "neither original nor patched vm_flags line found"
+    print("nvfs-mmap.c: already patched")
+else:
+    p.write_text(s.replace(old, new, 1))
+    print("nvfs-mmap.c: patched vm_flags read")
+PY
+
+# --- configure: add HAVE_BLK_MAP_ITER probe --------------------------------
+python3 - <<'PY'
+from pathlib import Path
+p = Path("configure")
+s = p.read_text()
+marker = 'if compile_prog "Checking if blk_rq_dma_map_iter_start is present..."; then\n        output_sym "HAVE_BLK_RQ_DMA_MAP_ITER_START"\nfi\n'
+addition = '''
+cat > $TEST_C <<EOF
+#include <linux/blkdev.h>
+#include <linux/blk-mq.h>
+#include <linux/blk-mq-dma.h>
+#include "test.h"
+
+int test (void)
+{
+        struct blk_map_iter iter;
+        (void)iter;
+        return 0;
+}
+
+EOF
+if compile_prog "Checking if struct blk_map_iter is present..."; then
+        output_sym "HAVE_BLK_MAP_ITER"
+fi
+'''
+if "HAVE_BLK_MAP_ITER" in s:
+    print("configure: HAVE_BLK_MAP_ITER probe already present")
+else:
+    assert marker in s, "anchor not found in configure"
+    s = s.replace(marker, marker + addition, 1)
+    p.write_text(s)
+    print("configure: added HAVE_BLK_MAP_ITER probe")
+PY
+
+# --- nvfs-dma.c: typedef nvfs_req_iter_t and rewire V2 path ----------------
+python3 - <<'PY'
+from pathlib import Path
+p = Path("nvfs-dma.c")
+s = p.read_text()
+
+# Insert typedef just after the V2 #ifdef
+anchor = "// V2 ops implementations for kernels with iterator API\n#ifdef HAVE_BLK_RQ_DMA_MAP_ITER_START\n"
+typedef_block = '''
+/*
+ * Kernel 6.16+ (e.g. 7.0) replaced struct req_iterator inside struct
+ * blk_dma_iter with struct blk_map_iter. Both layouts share .iter
+ * (bvec_iter) and .bio in the same order, so the helpers below only
+ * use those two fields.
+ */
+#ifdef HAVE_BLK_MAP_ITER
+typedef struct blk_map_iter nvfs_req_iter_t;
+#else
+typedef struct req_iterator nvfs_req_iter_t;
+#endif
+
+'''
+if "nvfs_req_iter_t" not in s:
+    assert anchor in s, "V2 #ifdef anchor not found"
+    s = s.replace(anchor, anchor + typedef_block, 1)
+    print("nvfs-dma.c: inserted typedef")
+
+# Replace `struct req_iterator` with the typedef *only* inside the V2 path
+# (i.e. between the V2 #ifdef and the matching #endif). The V1 path lives
+# above this block and still expects struct req_iterator.
+v2_start = s.index("// V2 ops implementations for kernels with iterator API\n#ifdef HAVE_BLK_RQ_DMA_MAP_ITER_START\n")
+# match closing #endif that terminates the V2 section: it's the last #endif in file
+# but to be safe locate the next "#endif /* HAVE_BLK_RQ_DMA_MAP_ITER_START */"
+# Try canonical first, then fall back to last #endif before EOF.
+end_marker = "#endif /* HAVE_BLK_RQ_DMA_MAP_ITER_START */"
+if end_marker in s:
+    v2_end = s.index(end_marker, v2_start)
+else:
+    v2_end = s.rfind("#endif")
+
+before = s[:v2_start]
+v2 = s[v2_start:v2_end]
+after = s[v2_end:]
+
+new_v2 = v2.replace("struct req_iterator", "nvfs_req_iter_t")
+if new_v2 != v2:
+    s = before + new_v2 + after
+    p.write_text(s)
+    print("nvfs-dma.c: rewired V2 path to nvfs_req_iter_t")
+else:
+    print("nvfs-dma.c: no further substitution needed (already patched)")
+PY
+
+# --- create_nv.symvers.sh: handle *.ko.zst (Ubuntu 26.04) ------------------
+python3 - <<'PY'
+from pathlib import Path
+p = Path("create_nv.symvers.sh")
+s = p.read_text()
+anchor = '''\tcase "$nvidia_mod" in\n\t\t*ko.xz)\n\t\t\t/bin/cp -fv $nvidia_mod .\n\t\t\tnvidia_mod=$(basename $nvidia_mod | sed -e "s/.xz//g")\n\t\t\txz -d ${nvidia_mod}.xz\n\t\t\t;;\n\tesac'''
+addition = '''\tcase "$nvidia_mod" in\n\t\t*ko.xz)\n\t\t\t/bin/cp -fv $nvidia_mod .\n\t\t\tnvidia_mod=$(basename $nvidia_mod | sed -e "s/.xz//g")\n\t\t\txz -df ${nvidia_mod}.xz\n\t\t\t;;\n\t\t*ko.zst)\n\t\t\t/bin/cp -fv $nvidia_mod .\n\t\t\tnvidia_mod=$(basename $nvidia_mod | sed -e "s/.zst//g")\n\t\t\tzstd -df --rm ${nvidia_mod}.zst\n\t\t\t;;\n\tesac'''
+if "*ko.zst" in s:
+    # Ensure -df (force overwrite) is present even if branch already added by an older patch run
+    s2 = s.replace("zstd -d --rm", "zstd -df --rm")
+    if s2 != s:
+        p.write_text(s2)
+        print("create_nv.symvers.sh: upgraded zstd to -df (force)")
+    else:
+        print("create_nv.symvers.sh: zst branch already present")
+else:
+    assert anchor in s, "xz case anchor not found in create_nv.symvers.sh"
+    p.write_text(s.replace(anchor, addition, 1))
+    print("create_nv.symvers.sh: added zst decompression branch")
+PY
+
+# --- create_nv.symvers.sh: case-insensitive relative-CRC detection ---------
+# kernel 7.0 / current open-gpu-kmd emit __crc_nvidia_p2p_* as section-local
+# rodata (lowercase `r`); upstream regex only matches uppercase `R` and
+# silently writes relocation offsets as fake CRCs. Make grep -i so the
+# fallback try_compile_nvidia_sources path runs and yields real CRCs.
+python3 - <<'PY'
+from pathlib import Path
+p = Path("create_nv.symvers.sh")
+s = p.read_text()
+old = 'if (nm -o $nvidia_mod | grep "$crc_mod_str" | grep -qe "\\sR\\s*__crc"); then'
+new = 'if (nm -o $nvidia_mod | grep "$crc_mod_str" | grep -qie "\\sR\\s*__crc"); then'
+if new in s:
+    print("create_nv.symvers.sh: case-insensitive CRC grep already present")
+else:
+    assert old in s, "relative-CRC grep anchor not found"
+    p.write_text(s.replace(old, new, 1))
+    print("create_nv.symvers.sh: made relative-CRC grep case-insensitive")
+PY
+
+echo "patch done"

--- a/workflows/reconst_3d/nextflow.config
+++ b/workflows/reconst_3d/nextflow.config
@@ -3,59 +3,500 @@ manifest {
 }
 
 params {
-    input = "."
-    shifts_xy = "$params.input/shifts_xy.csv"
-    output = "."
-    processes = 1 // Maximum number of python processes per nextflow process
+    // =========================================================================
+    // INPUT/OUTPUT
+    // =========================================================================
+    input = "."                // Directory containing mosaic_grid*.ome.zarr files
+    output = "."               // Output directory for all pipeline results
+    shifts_xy = ""             // Path to shifts CSV (default: {input}/shifts_xy.csv)
+    slice_config = ""          // Path to slice config CSV (default: {input}/slice_config.csv)
+    subject_name = ""          // Subject identifier (default: auto-extracted from path)
 
-    // Resolution of the reconstruction in micron/pixel
-    resolution = 10  // can be set to -1 to skip
+    // =========================================================================
+    // COMPUTE RESOURCES
+    // =========================================================================
+    use_gpu = true           // Enable GPU acceleration (auto-fallback to CPU if unavailable)
+    processes = 8            // Number of parallel Python processes per Nextflow task
 
-    // Clipping of outliers values
-    clip_percentile_upper = 99.9
+    // CPU resource management
+    enable_cpu_limits = true // Enable CPU limiting
+    max_cpus = 16            // Maximum CPUs to use (0 = no limit)
+    reserved_cpus = 4        // CPUs reserved for system overhead
 
-    // Detect and compensate focal curvature
-    fix_curvature_enabled = true
+    // =========================================================================
+    // RESOLUTION & BASIC SETTINGS
+    // =========================================================================
+    resolution = 10               // Target resolution in µm/pixel (set to -1 to skip resampling)
+    clip_percentile_upper = 99.9  // Upper percentile for intensity clipping (0–100)
+                                  // Used in illumination fix, beam profile correction,
+                                  // interface crop, and per-slice normalization
 
-    // Fix illumination inhomogeneities using BaSiC
-    fix_illum_enabled = true
+    // =========================================================================
+    // PREPROCESSING
+    // =========================================================================
+    fix_curvature_enabled = false    // Detect and compensate focal curvature artifacts
+    fix_illum_enabled = true         // Fix illumination inhomogeneity (BaSiCPy algorithm)
+    crop_interface_out_depth = 600   // Maximum tissue depth to retain after interface crop (µm)
 
-    // Maximum depth of the cropped image in microns
-    crop_interface_out_depth = 600
+    // =========================================================================
+    // TILE STITCHING
+    // =========================================================================
+    // Controls how tiles within each slice are assembled in XY.
+    use_motor_positions_for_stitching = true  // Use motor encoder positions for tile stitching
+                                              // (recommended). Only used by diagnostic processes.
+    stitch_overlap_fraction = 0.2             // Expected tile overlap fraction (0.0–1.0).
+                                              // Should match the acquisition overlap setting.
+                                              // Also used as motor_only_overlap in diagnostics.
+    stitch_blending_method = 'diffusion'      // Tile blending: 'none', 'average', 'diffusion'
+    max_blend_refinement_px = 10             // Maximum sub-pixel refinement shift for blending (pixels)
 
-    // Slices registration parameters
-    moving_slice_first_index = 4 // Skip this many voxels from the top of the moving 3d mosaic when registering slices
-    pairwise_transform = 'affine' // One of 'affine', 'euler', 'translation'
-    pairwise_registration_metric = 'MSE' // One of 'MSE', 'CC', 'AntsCC' or 'MI'
+    // Global tile-placement transform.
+    // When true, one 2x2 affine is fitted across a pool of mid-brain mosaic grids
+    // (instrument geometry is slice-invariant) and re-used for every slice.  This
+    // removes the per-slice scale/rotation jitter that the default refined stitcher
+    // introduces when the LS fit is underdetermined on small or sparse grids.
+    // The fitted transform is passed to `linum_stitch_3d_refined.py --input_transform`,
+    // so blend-shift sub-pixel seam refinement still runs per slice.
+    stitch_global_transform = false            // Enable pooled global affine estimation
+    stitch_global_transform_slices = ''        // Optional comma-separated slice IDs to pool
+                                               // from (e.g. "10,11,12,...,40"). Empty =
+                                               // all slices passing slice_config.
+    stitch_global_transform_histogram_match = true  // Match overlap histograms before phase correlation
+    stitch_global_transform_max_empty_fraction = 0.9  // Otsu-based empty-overlap filter fraction
+                                                      // (matches old estimate_mosaic_transform behaviour).
+                                                      // Set to null to use the simpler mean(>0) < 0.1 check.
+    stitch_global_transform_n_samples = 2048   // Max pooled pairs for the LS fit (0 = use all).
+                                               // Random-sampled for reproducibility when the pool
+                                               // exceeds this budget.
+    stitch_global_transform_seed = 0           // Random seed for pair sub-sampling
 
-    // stack algorithm parameters
-    stack_blend_enabled = false
-    stack_max_overlap = -1  // maximum number of overlapping voxels (-1 to use all overlapping voxels)
+    // =========================================================================
+    // AUTOMATIC SLICE QUALITY ASSESSMENT
+    // Runs linum_assess_slice_quality on normalized slices and writes a
+    // slice_config.csv that marks degraded slices for exclusion from the
+    // common-space step.  Enabled by setting auto_assess_quality = true.
+    // =========================================================================
+    auto_assess_quality = false            // Run quality assessment on normalized slices
+    auto_assess_min_quality = 0.3          // Exclude slices with quality score below this
+    auto_assess_exclude_first = 1          // Exclude first N calibration slices automatically
+    auto_assess_roi_size = 1024            // Center-crop size in XY (pixels) for quality metrics.
+                                           // Mosaic grids are single-resolution, so this is the
+                                           // primary speed control: 1024×1024 loads ~2 MB per
+                                           // plane vs ~5 GB at full res. 0 = full plane.
+
+    // =========================================================================
+    // COMMON SPACE ALIGNMENT
+    // =========================================================================
+    // Aligns each slice into a shared XY canvas using shifts_xy.csv motor positions.
+    // When detect_rehoming is true, encoder glitch spikes (large step that
+    // self-cancels with the adjacent step) are zeroed before alignment.
+    // Genuine re-homing events (large step that stays) are always preserved.
+
+    detect_rehoming = true                   // Correct encoder glitch spikes before alignment
+    rehoming_return_fraction = 0.4           // Sensitivity: lower = more conservative (fewer corrections)
+    rehoming_max_shift_mm = 0.5              // Steps below this magnitude are not checked for spikes.
+                                             // Lower to catch smaller self-cancelling glitches.
+    tile_fov_mm = null                       // Post-hoc artifact step correction for shifts_xy.csv files
+                                             // generated with older versions of linum_estimate_xy_shift_from_metadata.py.
+                                             // The updated script now uses both mosaic boundaries to estimate
+                                             // shifts, so this correction is not needed for freshly-generated
+                                             // shifts files.  Set only when re-running from an existing
+                                             // shifts_xy.csv that still contains mosaic-expansion artifacts
+                                             // (look for repeating near-equal large steps in x_shift_mm).
+    tile_fov_tolerance = 0.05                // Fractional tolerance for tile-FOV multiple detection.
+                                             // 0.05 → 5% margin around each integer multiple.
+
+    common_space_excluded_slice_mode = 'local_median' // Interpolation for excluded slices
+    common_space_excluded_slice_window = 2
+    common_space_refine_unreliable = false       // Use image registration to refine shifts flagged as
+                                                 // unreliable (reliable=0) by linum_estimate_xy_shift_from_metadata.py.
+                                                 // Requires scikit-image.  Set to true when mosaic grid expansions
+                                                 // are expected (tissue growing significantly between slices).
+    common_space_refine_max_discrepancy_px = 0   // When common_space_refine_unreliable=true, reject the
+                                                 // image-based shift estimate if it differs from the motor
+                                                 // estimate by more than this many pixels (0 = accept all).
+                                                 // Recommended: 50. Guards against phase-correlation failures
+                                                 // on large-offset or low-overlap transitions.
+    common_space_refine_min_correlation = 0.0    // Minimum phase cross-correlation quality (0-1) to accept
+                                                 // an image-based refinement. 0 = accept all (default).
+                                                 // Recommended: 0.15-0.3. Rejects refinements where the
+                                                 // correlation quality is too low.
+
+    // =========================================================================
+    // MISSING SLICE INTERPOLATION
+    // =========================================================================
+    interpolate_missing_slices = true          // Interpolate single-slice gaps automatically
+    interpolation_method = 'zmorph'            // Method: 'zmorph', 'average', 'weighted'
+                                               //   zmorph   - z-aware morphing; output top matches vol_before, bottom
+                                               //              matches vol_after, interior morphs smoothly via fractional
+                                               //              affine transforms. Falls back to 'weighted' when quality
+                                               //              gates fail. See docs/SLICE_INTERPOLATION_FEATURE.md.
+                                               //   weighted - z-smoothed linear blend of vol_before and vol_after.
+                                               //   average  - plain 50/50 mean of the two neighbours.
+    interpolation_blend_method = 'gaussian'    // Blending: 'gaussian' (feathered edges), 'linear'
+    interpolation_registration_metric = 'MSE'  // Similarity metric for the boundary-plane registration used by zmorph
+    interpolation_max_iterations = 1000        // Maximum registration iterations
+    interpolation_overlap_search_window = 5    // Z-planes to search at each boundary for best overlap pair
+    interpolation_min_overlap_correlation = 0.3 // Pre-registration NCC threshold on boundary planes. Below this
+                                               // the method falls back to a weighted average.
+    interpolation_reference_slab_size = 3      // Number of planes averaged around the boundary reference plane
+                                               // before running the 2D registration.
+    interpolation_min_foreground_fraction = 0.1 // Minimum foreground fraction for a boundary plane to be considered
+    interpolation_min_ncc_improvement = 0.05   // Minimum post-reg NCC improvement to accept the transform;
+                                               // below this the method falls back to weighted average.
+
+    // =========================================================================
+    // PAIRWISE REGISTRATION
+    // =========================================================================
+    // Computes small corrections (rotation, sub-pixel translation) between consecutive
+    // slices. The main XY alignment comes from motor positions (shifts_xy.csv);
+    // these transforms are refinements applied on top.
+
+    registration_transform = 'euler'         // 'translation' (XY only) or 'euler' (XY + rotation)
+    registration_max_translation = 200.0     // Optimizer bound on translation (pixels).
+                                             // Keep large so the optimizer is not clamped — actual
+                                             // applied translations are controlled by max_rotation_deg
+                                             // and apply_rotation_only in stacking.
+    registration_max_rotation = 5.0          // Optimizer bound on rotation (degrees)
+    registration_initial_alignment = 'both'  // Initial alignment before refinement: 'none', 'com', 'gradient', or 'both'
+    moving_slice_first_index = 4             // Starting Z-index in the moving volume
+    registration_slicing_interval_mm = 0.200 // Physical slice thickness (mm)
+    registration_allowed_drifting_mm = 0.100 // Z-search range (mm)
+
+    // =========================================================================
+    // STACKING & OUTPUT
+    // =========================================================================
+
+    // --- Common settings ---
+    stack_blend_enabled = true        // Blend overlapping regions between slices
+    blend_refinement_px = 0           // Z-blend refinement: phase-correlation XY correction in
+                                      // the overlap zone before blending (like stitch_3d_with_refinement
+                                      // but for slice boundaries). Set to max allowed shift in pixels
+                                      // (e.g. 10). 0 = disabled.
+    stack_blend_z_refine_vox = 5      // Z-blend position refinement: search up to N voxels below the
+                                      // expected overlap boundary (use_expected_z_overlap) for the
+                                      // best-correlated tissue plane to blend at. Z-spacing stays fixed
+                                      // at slicing_interval. 0 = disabled.
+
+    // --- Motor stacking ---
+    use_expected_z_overlap = true         // Use expected Z-overlap instead of correlation.
+                                          // Recommended when correlation-based matching is unreliable.
+    apply_pairwise_transforms = true      // Apply pairwise registration transforms during stacking.
+                                          // Set to false to stack using only motor positions + expected
+                                          // Z-overlap (ignores all registration corrections).
+    apply_rotation_only = false           // Apply only the rotation component from registration,
+                                          // not translation — keeps XY from motor positions.
+                                          // When accumulate_translations is enabled, translations
+                                          // are accumulated as canvas offsets regardless.
+    max_rotation_deg = 5.0               // Rotation values larger than this are clamped before
+                                          // application, preventing registration errors from drifting
+
+    // Per-slice adaptive transform degradation
+    // Confidence score (0–1) is computed from Z-correlation, translation magnitude and rotation.
+    // Slices with confidence >= transform_confidence_high: full transform applied (per apply_rotation_only).
+    // Slices with confidence < transform_confidence_high but >= transform_confidence_low: rotation-only.
+    // Slices with confidence < transform_confidence_low: transform skipped (identity).
+    transform_confidence_high = 0.6      // Threshold above which transforms are trusted fully
+    transform_confidence_low = 0.3       // Threshold below which transforms are skipped entirely
+    z_overlap_min_corr = 0.5             // Fall back to expected Z-overlap below this NCC score
+    blend_z_refine_min_confidence = 0.5   // Minimum confidence for blend_z_refine to run.
+                                          // Slices below this skip Z-blend position search
+                                          // and use expected overlap directly.
+
+    // Auto-exclude extended clusters of consecutive low-quality registrations.
+    // The auto_exclude_slices process reads pairwise metrics after registration and
+    // produces a CSV listing slice IDs to force-skip (motor-only) during stacking.
+    auto_exclude_enabled = true           // Enable automatic cluster detection
+    auto_exclude_consecutive = 3          // Min consecutive low-quality pairs to trigger exclusion
+    auto_exclude_z_corr = 0.6             // Z-correlation threshold below which a pair is low-quality
+
+    load_transform_min_zcorr = 0.0        // Metric-based transform gating: minimum z_correlation
+                                          // to load a transform. When > 0 (with max_rotation),
+                                          // replaces status-based gating. 0 = disabled.
+    load_transform_max_rotation = 0.0     // Maximum rotation (degrees) for metric-based gating.
+                                          // Paired with load_transform_min_zcorr. 0 = disabled.
+    skip_error_transforms = true          // Skip transforms flagged as overall_status="error"
+                                          // (e.g. registered against interpolated slices produce
+                                          // spurious large rotations causing visible jumps)
+    skip_warning_transforms = true        // Also skip transforms with overall_status="warning".
+                                          // Warning transforms hit the optimizer boundary; their
+                                          // Z-offsets are unreliable and can create Z gaps.
+                                          // Recommended: keep true to prevent Z-positioning errors.
+    stack_accumulate_translations = true  // Accumulate pairwise translations as cumulative canvas
+                                          // offsets (viewing-plane steering).
+    stack_confidence_weight_translations = true  // Weight each pairwise translation by its confidence
+                                          // score before accumulating. Attenuates low-confidence
+                                          // translations proportionally.
+    stack_max_cumulative_drift_px = 50    // Maximum cumulative translation drift from motor
+                                          // baseline (pixels). Clamps total drift when exceeded.
+                                          // 0 = disabled (unlimited drift).
+    stack_max_pairwise_translation = 0    // Max pairwise translation (pixels) included in
+                                          // accumulation. Values near this limit are assumed to be
+                                          // optimizer-boundary hits and are zeroed out.
+                                          // 0 = disabled (accumulate all translations).
+    stack_smooth_window = 5              // Moving-average window (slices) for smoothing per-slice
+                                         // rotations. Reduces visible jumps from isolated outliers.
+                                         // 0 = disabled.
+    stack_translation_smooth_sigma = 3.0 // Gaussian sigma (slices) for smoothing accumulated
+                                         // translations. Applied BEFORE drift cap to remove
+                                         // slice-to-slice jitter while preserving trends.
+                                         // 0 = disabled.
+    stack_translation_min_zcorr = 0.2    // Minimum z_correlation to use a slice's translation
+                                         // for accumulation. Lower than load_min_zcorr to recover
+                                         // translations from slices with bad rotation but valid
+                                         // translation. 0 = use all translations.
+
+    // --- Output pyramid ---
+    pyramid_resolutions = [10, 25, 50, 100]  // Multi-resolution levels (µm); must be >= base resolution
+    pyramid_n_levels = null                   // Fixed level count (overrides pyramid_resolutions)
+    pyramid_make_isotropic = true             // Resample to isotropic voxel spacing
+
+    // =========================================================================
+    // MANUAL ALIGNMENT
+    // =========================================================================
+    // Export a lightweight data package for interactive manual alignment of
+    // pairwise slice transforms. When enabled, the pipeline produces a
+    // directory with AIP images and transforms that can be downloaded and
+    // opened by the manual alignment tool (tools/manual-align/).
+    export_manual_align = false           // Export manual alignment data after register_pairwise
+    manual_align_level = 1                // Pyramid level for AIP export (0=full, 1=2x, ...)
+    manual_transforms_dir = ''            // Path to manually corrected transforms directory.
+                                          // When set and refine_manual_transforms = false,
+                                          // manual transforms override automated ones for
+                                          // matching slice IDs during stacking.
+    refine_manual_transforms = false      // Re-run pairwise registration for manually corrected
+                                          // pairs, initialised from the manual transform.
+                                          // Produces refined transforms that combine the manual
+                                          // correction with a tight image-based residual fix.
+                                          // Requires manual_transforms_dir to be set.
+    refine_max_translation_px = 10        // Max residual translation searched during refinement (px)
+    refine_max_rotation_deg = 2.0         // Max residual rotation searched during refinement (°)
+
+    // =========================================================================
+    // BIAS FIELD CORRECTION
+    // =========================================================================
+    // N4 bias field correction applied after stacking.
+    // Removes depth-dependent attenuation and slow intensity drift across sections.
+    correct_bias_field = false          // Enable post-stacking N4 bias field correction
+    bias_mode = 'two_pass'              // Correction mode:
+                                        //   'per_section' — correct each serial section independently
+                                        //   'global'      — correct the full stack as one volume
+                                        //   'two_pass'    — per_section then global (recommended)
+    bias_strength = 1.0                 // Correction mixing strength (0.0 = passthrough, 1.0 = full)
+    bias_histogram_match_per_zplane = true   // Match each Z-plane independently to the global tissue
+                                             // distribution before N4. Strongly reduces inter-slice
+                                             // intensity steps (~80% on sub-22 vs ~2% with chunked).
+    bias_tissue_threshold = 0.005       // Voxels at or below this intensity are background (excluded
+                                        // from histogram matching). 0.005 found best on sub-22.
+    bias_zprofile_smooth_sigma = 2.0    // After histogram matching, remove residual per-Z-plane jitter
+                                        // with a smoothed scalar gain (Gaussian sigma in Z-plane units).
+                                        // 0 = disabled. 2.0-4.0 typical. Eliminates the ~1-2% inter-slice
+                                        // steps HM cannot remove (~99% step reduction on sub-22).
+
+    // =========================================================================
+    // ATLAS REGISTRATION
+    // =========================================================================
+    // Registers the final reconstructed volume to the Allen Mouse Brain Atlas
+    // (Common Coordinate Framework, RAS orientation).
+    // The atlas is downloaded automatically at the specified resolution.
+    align_to_ras_enabled = false         // Enable Allen atlas registration
+    allen_resolution = 25                // Atlas resolution for registration (µm): 10, 25, 50, 100
+    allen_metric = 'MI'                  // Registration metric: 'MI', 'MSE', 'CC', 'AntsCC'
+    allen_max_iterations = 1000          // Maximum registration iterations
+    allen_registration_level = 2         // Pyramid level of input zarr to register at
+                                         // (0 = full resolution; level 2 ≈ 50 µm → fast).
+                                         // Output is always written at all pyramid resolutions.
+    ras_input_orientation = ''           // Orientation of the input volume (3-letter code: R/L, A/P, S/I).
+                                         // e.g. 'PIR' for dim0→Posterior, dim1→Inferior, dim2→Right.
+                                         // Leave empty if already roughly RAS.
+    ras_initial_rotation = ''            // Initial rotation hint (degrees): "Rx Ry Rz".
+                                         // e.g. "0.0 0.0 90.0" for a 90° Z-axis pre-rotation.
+                                         // Leave empty for automatic MOMENTS-based initialization.
+    allen_preview = true                 // Save a 3×3 comparison preview (input / aligned / atlas template)
+    ras_orientation_preview = false      // Save a 3-panel preview after --input-orientation and
+                                         // --initial-rotation are applied (before registration).
+                                         // Useful for verifying orientation parameters.
+
+    // =========================================================================
+    // PREVIEWS & REPORTS
+    // =========================================================================
+    stitch_preview = true                // Generate stitched slice preview images
+    common_space_preview = false         // Generate common space alignment previews
+    rehoming_diagnostics = false         // Save rehoming_report.json + rehoming_plot.png
+    interpolation_preview = false        // Generate interpolated slice previews
+    generate_report = true               // Generate HTML quality report after stacking
+    report_verbose = false               // Include detailed per-slice metrics in report
+    report_format = 'zip'                // Report format: 'html' (no images, lightweight) or 'zip' (HTML + bundled previews)
+
+    // Annotated preview settings
+    annotated_label_every = 1            // Label every Nth slice (1 = all slices)
+    annotated_show_lines = false         // Draw slice boundary lines on annotated preview
+
+    // =========================================================================
+    // DEBUGGING
+    // =========================================================================
+    debug_slices = ""            // Comma-separated slice IDs or ranges to process (e.g. "25,26" or "25-29").
+                                 // Leave empty to process all slices.
+    analyze_shifts = true        // Generate a shifts analysis report
+    outlier_iqr_multiplier = 1.5 // IQR multiplier for outlier detection in shifts analysis
+
+    // =========================================================================
+    // DIAGNOSTIC MODE
+    // =========================================================================
+    // Enable for troubleshooting reconstruction artifacts (edge mismatches,
+    // overhangs, alignment issues) in obliquely-mounted samples.
+    diagnostic_mode = false              // Master switch: enables all diagnostic analyses below
+
+    // Individual diagnostic analyses (active when diagnostic_mode=false and set to true)
+    analyze_rotation_drift = false       // Analyze cumulative rotation between slices
+    analyze_acquisition_rotation = false // Analyze acquisition-time rotation from shifts + registration
+    motor_only_stitch = false            // Stitch slices using motor positions only (no image reg.)
+    motor_only_stack = false             // Stack slices using motor positions only (no pairwise reg.)
+    compare_stitching = false            // Compare motor-only vs refined stitching side-by-side
+
+    // Diagnostic parameters
+    motor_only_overlap = 0.2             // Expected tile overlap for motor-only diagnostics (0.0–1.0).
+                                         // Should match stitch_overlap_fraction.
+    motor_only_stitch_blending = 'diffusion'  // Blending for motor_only_stitch: 'none', 'average', 'diffusion'
+    motor_only_stack_blending = 'none'        // Blending for motor_only_stack: 'none', 'average', 'max', 'feather'
+    diagnostic_rotation_threshold = 2.0      // Rotation warning threshold (degrees)
+    save_refinement_data = false             // Save refined stitching transform data as JSON
+    comparison_tile_step = 60               // Tile step for seam detection in stitching comparison
 }
 
+// =========================================================================
+// PROCESS CONFIGURATION
+// =========================================================================
+// Per-task BLAS/OpenMP thread caps (sets process.beforeScript).
+includeConfig '../shared/cpu_limits.config'
+
 process {
-    publishDir = {"$params.output/$slice_id/$task.process"}
+    // Default publish location for processes that don't override it.
+    // Per-slice intermediates (resample/focal/illum) override below to keep
+    // their slice-id grouping; pattern-restricted publishers (e.g. only
+    // *_metrics.json) override inline in the process body.
+    publishDir = [path: { "${params.output}/${task.process}" }, mode: 'copy']
     scratch = true
     errorStrategy = { task.attempt <= 2 ? 'retry' : 'ignore' }
     maxRetries = 2
-    stageInMode='symlink'
-    stageOutMode='rsync'
-    afterScript='sleep 1'
+    stageInMode = 'symlink'
+    stageOutMode = 'rsync'
+    afterScript = 'sleep 1'
+
+    // Per-slice preproc intermediates: keep `<slice_id>/` grouping and use
+    // symlinks (zarr arrays are large; copying them per-stage doubles disk).
+    withName: "resample_mosaic_grid|fix_focal_curvature|fix_illumination" {
+        publishDir = [path: { "${params.output}/${slice_id}/${task.process}" }, mode: 'symlink']
+    }
+
     withName: "resample_mosaic_grid" {
         scratch = false
+        // Parallel resampling on GPU. Peak ~9 GB/fork (Gaussian intermediate at
+        // 2x tile size). With 2x A6000 (48 GB each), 6 forks = 3/GPU = ~27 GB,
+        // leaving headroom for fix_illumination running concurrently.
+        maxForks = params.use_gpu ? 6 : null
+    }
+
+    withName: "fix_focal_curvature" {
+        // GPU path is light (uniform/gaussian filter on the volume + per-tile
+        // take_along_axis). Memory dominated by the volume; a few forks share
+        // the GPU comfortably.
+        maxForks = params.use_gpu ? 4 : null
+    }
+
+    withName: "fix_illumination" {
+        // Limit to 1 parallel instance - BaSiCPy/PyTorch is memory-intensive
+        maxForks = params.use_gpu ? 1 : null
+        // Don't set CUDA_VISIBLE_DEVICES - let linumpy.gpu auto-select GPU with most free memory
+    }
+
+    withName: "normalize" {
+        // Allow parallel normalization on GPU
+        maxForks = params.use_gpu ? 4 : null
+    }
+
+    withName: "correct_bias_field" {
+        // Single-process to avoid GPU OOM — the global stage works on the
+        // full stacked volume.
+        maxForks = params.use_gpu ? 1 : null
     }
 }
 
+// =========================================================================
+// CONTAINER CONFIGURATION
+// =========================================================================
 apptainer {
     autoMounts = true
     enabled = true
 }
 
+// =========================================================================
+// CLUSTER PROFILES
+// =========================================================================
 profiles {
+    // -----------------------------------------------------------------------
+    // RECONSTRUCTION ROBUSTNESS PRESETS
+    // Use -profile conservative (default behaviour), aggressive, or minimal
+    // to set groups of related parameters without touching the params block.
+    // -----------------------------------------------------------------------
+
+    // conservative: safest defaults — trusts motor positions for XY, applies
+    // only rotation from registration, skips unreliable transforms, and
+    // interpolates single-slice gaps.  Recommended starting point.
+    conservative {
+        params {
+            apply_rotation_only            = true
+            skip_error_transforms          = true
+            skip_warning_transforms        = true
+            apply_pairwise_transforms      = true
+            interpolate_missing_slices     = true
+            use_expected_z_overlap         = true
+            stack_blend_z_refine_vox       = 5
+            stack_smooth_window            = 5
+            stack_accumulate_translations  = false
+            transform_confidence_high      = 0.6
+            transform_confidence_low       = 0.3
+        }
+    }
+
+    // aggressive: uses full pairwise registration transforms including XY
+    // translations, and accumulates them cumulatively.  Can produce better
+    // alignment when registration is reliable, but fails badly when it is not.
+    aggressive {
+        params {
+            apply_rotation_only            = false
+            skip_error_transforms          = false
+            skip_warning_transforms        = false
+            apply_pairwise_transforms      = true
+            interpolate_missing_slices     = true
+            use_expected_z_overlap         = false
+            stack_accumulate_translations  = true
+            stack_max_pairwise_translation = 50
+            stack_smooth_window            = 3
+            transform_confidence_high      = 0.4
+            transform_confidence_low       = 0.2
+        }
+    }
+
+    // minimal: motor-only stacking — ignores all pairwise registration
+    // refinements.  Most stable, fastest, and requires no image-based
+    // registration quality. Use when motor positions are reliable and
+    // registration consistently fails.
+    minimal {
+        params {
+            apply_pairwise_transforms      = false
+            use_expected_z_overlap         = true
+            stack_blend_z_refine_vox       = 5
+            stack_smooth_window            = 0
+            interpolate_missing_slices     = true
+            correct_bias_field             = false
+        }
+    }
+
     calliste {
         apptainer {
-            cacheDir='/scratchCalliste/apptainer/cache'
-            libraryDir='/scratchCalliste/apptainer/library'
+            cacheDir = '/scratchCalliste/apptainer/cache'
+            libraryDir = '/scratchCalliste/apptainer/library'
             autoMounts = true
             enabled = true
             runOptions = '-B /mnt/apptainer_tmp:/tmp'
@@ -64,7 +505,7 @@ profiles {
             temp = '/mnt/apptainer_tmp'
         }
         process {
-            withName: "resample_mosaic_grid" { 
+            withName: "resample_mosaic_grid" {
                 scratch = false
                 maxForks = 4
             }

--- a/workflows/reconst_3d/soct_3d_reconst.nf
+++ b/workflows/reconst_3d/soct_3d_reconst.nf
@@ -1,270 +1,1167 @@
 #!/usr/bin/env nextflow
 nextflow.enable.dsl = 2
 
-// Workflow Description
-// Creates a 3D volume from raw S-OCT tiles
-// Input: Directory containing input mosaic grids
-// Output: 3D reconstruction
+/*
+ * 3D RECONSTRUCTION PIPELINE FOR SERIAL OCT DATA
+ *
+ * Input:  Directory containing mosaic_grid*.ome.zarr files + shifts_xy.csv
+ * Output: 3D OME-Zarr volume with multi-resolution pyramid
+ *
+ * Channel patterns and authoring conventions: docs/NEXTFLOW_WORKFLOWS.md
+ *
+ * Helper functions (slice ID parsing, path utilities, CLI flag builders, stack
+ * option builders) live in ./lib/Helpers.groovy and are auto-loaded by
+ * Nextflow. Call sites use the `Helpers.` prefix.
+ */
+
+// =============================================================================
+// SUB-WORKFLOW INCLUDES
+// =============================================================================
+
+// Diagnostic processes (analyze_rotation_drift, stitch_motor_only, stitch_refined,
+// compare_stitching, stack_motor_only, analyze_acquisition_rotation) live in
+// ./diagnostics.nf and are gated below by `params.diagnostic_mode` and
+// per-stage flags.
+include {
+    analyze_rotation_drift;
+    stitch_motor_only;
+    stitch_refined;
+    compare_stitching;
+    stack_motor_only;
+    analyze_acquisition_rotation;
+} from './diagnostics.nf'
+
+// =============================================================================
+// PROCESSES
+// =============================================================================
+
+// -----------------------------------------------------------------------------
+// Utility Processes
+// -----------------------------------------------------------------------------
 
 process README {
-    publishDir "$params.output/$task.process", mode: 'copy'
+    publishDir { "${params.output}/${task.process}" }, mode: 'move'
+
     output:
-        path "readme.txt"
+    path "readme.txt"
+
     script:
     """
-    echo "3D reconstruction pipeline\n" >> readme.txt
-    echo "[Params]" >> readme.txt
-    for p in $params; do
-        echo " \$p" >> readme.txt
-    done
+    echo "3D reconstruction pipeline" >> readme.txt
     echo "" >> readme.txt
-    echo "[Command-line]\n $workflow.commandLine\n" >> readme.txt
-    echo "[Configuration files]">> readme.txt
-    for c in $workflow.configFiles; do
-        echo " \$c" >> readme.txt
-    done
+    echo "[Params]" >> readme.txt
+    for p in ${params}; do echo " \$p" >> readme.txt; done
+    echo "" >> readme.txt
+    echo "[Command-line]" >> readme.txt
+    echo "${workflow.commandLine}" >> readme.txt
+    echo "" >> readme.txt
+    echo "[Configuration files]" >> readme.txt
+    for c in ${workflow.configFiles}; do echo " \$c" >> readme.txt; done
+    """
+
+    stub:
+    """
+    touch readme.txt
     """
 }
 
-process resample_mosaic_grid {
+process analyze_shifts {
     input:
-        tuple val(slice_id), path(mosaic_grid)
+    path(shifts_file)
+
     output:
-        tuple val(slice_id), path("mosaic_grid_z${slice_id}_resampled.ome.zarr")
+    path "shifts_analysis/*"
+
     script:
     """
-    linum_resample_mosaic_grid.py ${mosaic_grid} "mosaic_grid_z${slice_id}_resampled.ome.zarr" -r ${params.resolution}
+    linum_analyze_shifts.py ${shifts_file} shifts_analysis \
+        --resolution ${params.resolution} \
+        --iqr_multiplier ${params.outlier_iqr_multiplier}
+    """
+
+    stub:
+    """
+    mkdir -p shifts_analysis
+    touch shifts_analysis/placeholder.txt
+    """
+}
+
+process generate_report {
+    publishDir "${params.output}", mode: 'copy'
+
+    input:
+    tuple path(zarr), path(zip), path(png), path(annotated_png)
+    val subject_name
+
+    output:
+    path "${subject_name}_quality_report.${params.report_format ?: 'html'}"
+
+    script:
+    def fmt          = params.report_format ?: 'html'
+    def verbose_flag = params.report_verbose ? "--verbose" : ""
+    def overview_arg = png          ? "--overview_png ${png}"          : ""
+    def annotated_arg = annotated_png ? "--annotated_png ${annotated_png}" : ""
+    """
+    linum_generate_pipeline_report.py ${params.output} ${subject_name}_quality_report.${fmt} \
+        --title "Quality Report: ${subject_name}" \
+        --format ${fmt} ${verbose_flag} ${overview_arg} ${annotated_arg}
+    """
+
+    stub:
+    """
+    touch ${subject_name}_quality_report.${params.report_format ?: 'html'}
+    """
+}
+
+// -----------------------------------------------------------------------------
+// Preprocessing Processes
+// -----------------------------------------------------------------------------
+
+process resample_mosaic_grid {
+    input:
+    tuple val(slice_id), path(mosaic_grid)
+
+    output:
+    tuple val(slice_id), path("mosaic_grid_z${slice_id}_resampled.ome.zarr")
+
+    script:
+    def gpu_flag = params.use_gpu ? "--use_gpu" : "--no-use_gpu"
+    """
+    linum_resample_mosaic_grid.py ${mosaic_grid} "mosaic_grid_z${slice_id}_resampled.ome.zarr" \
+        -r ${params.resolution} ${gpu_flag} -v
+    """
+
+    stub:
+    """
+    mkdir -p mosaic_grid_z${slice_id}_resampled.ome.zarr
     """
 }
 
 process fix_focal_curvature {
     input:
-        tuple val(slice_id), path(mosaic_grid)
+    tuple val(slice_id), path(mosaic_grid)
+
     output:
-        tuple val(slice_id), path("mosaic_grid_z${slice_id}_focal_fix.ome.zarr")
+    tuple val(slice_id), path("mosaic_grid_z${slice_id}_focal_fix.ome.zarr")
+
     script:
+    def gpu_flag = params.use_gpu ? "--use_gpu" : "--no-use_gpu"
     """
-    linum_detect_focal_curvature.py ${mosaic_grid} "mosaic_grid_z${slice_id}_focal_fix.ome.zarr"
+    linum_detect_focal_curvature.py ${mosaic_grid} "mosaic_grid_z${slice_id}_focal_fix.ome.zarr" ${gpu_flag}
+    """
+
+    stub:
+    """
+    mkdir -p mosaic_grid_z${slice_id}_focal_fix.ome.zarr
     """
 }
 
 process fix_illumination {
     cpus params.processes
+
     input:
-        tuple val(slice_id), path(mosaic_grid)
+    tuple val(slice_id), path(mosaic_grid)
+
     output:
-        tuple val(slice_id), path("mosaic_grid_z${slice_id}_illum_fix.ome.zarr")
+    tuple val(slice_id), path("mosaic_grid_z${slice_id}_illum_fix.ome.zarr")
+
     script:
+    def gpu_flag = params.use_gpu ? "--use_gpu" : "--no-use_gpu"
     """
-    linum_fix_illumination_3d.py ${mosaic_grid} "mosaic_grid_z${slice_id}_illum_fix.ome.zarr" --n_processes ${params.processes} --percentile_max ${params.clip_percentile_upper}
+    linum_fix_illumination_3d.py ${mosaic_grid} "mosaic_grid_z${slice_id}_illum_fix.ome.zarr" \
+        --n_processes ${params.processes} \
+        --percentile_max ${params.clip_percentile_upper} ${gpu_flag}
+    """
+
+    stub:
+    """
+    mkdir -p mosaic_grid_z${slice_id}_illum_fix.ome.zarr
     """
 }
 
-process generate_aip {
+// -----------------------------------------------------------------------------
+// Stitching Processes
+// -----------------------------------------------------------------------------
+
+process estimate_global_transform {
     input:
-        tuple val(slice_id), path(mosaic_grid)
+    path("pool_input/*")
+    path(slice_config)
+
     output:
-        tuple val(slice_id), path("mosaic_grid_z${slice_id}_aip.ome.zarr")
+    path("global_affine.npy"), emit: transform
+    path("global_affine.json"), optional: true, emit: diagnostics
+
     script:
+    def slice_config_arg = slice_config.name != 'NO_SLICE_CONFIG' ? "--slice_config ${slice_config}" : ""
+    def histogram_arg = params.stitch_global_transform_histogram_match ? "--histogram_match" : ""
+    def empty_arg = params.stitch_global_transform_max_empty_fraction != null
+        ? "--max_empty_fraction ${params.stitch_global_transform_max_empty_fraction}"
+        : ""
+    def n_samples_arg = (params.stitch_global_transform_n_samples as int) > 0
+        ? "--n_samples ${params.stitch_global_transform_n_samples as int}"
+        : ""
+    def include_arg = params.stitch_global_transform_slices?.trim()
+        ? "--include_slice " + params.stitch_global_transform_slices.toString().split('[,\\s]+').join(' ')
+        : ""
+    def gpu_flag = params.use_gpu ? "--use_gpu" : "--no-use_gpu"
     """
-    linum_aip.py ${mosaic_grid} "mosaic_grid_z${slice_id}_aip.ome.zarr"
+    linum_estimate_global_transform.py pool_input global_affine.npy \
+        --overlap_fraction ${params.stitch_overlap_fraction} \
+        ${slice_config_arg} \
+        ${include_arg} \
+        ${histogram_arg} \
+        ${empty_arg} \
+        ${n_samples_arg} \
+        --seed ${params.stitch_global_transform_seed} \
+        --diagnostics_json global_affine.json \
+        -f ${gpu_flag}
+    """
+
+    stub:
+    """
+    touch global_affine.npy
+    touch global_affine.json
     """
 }
 
-process estimate_xy_transformation {
+process stitch_3d_with_refinement {
+    publishDir { "${params.output}/${task.process}" }, mode: 'copy', pattern: "*_metrics.json"
+
     input:
-        tuple val(slice_id), path(aip)
+    tuple val(slice_id), path(mosaic_grid), path(input_transform)
+
     output:
-        tuple val(slice_id), path("z${slice_id}_transform_xy.npy")
+    tuple val(slice_id), path("slice_z${slice_id}_stitch_3d.ome.zarr"), emit: stitched
+    path("*_metrics.json"), optional: true, emit: metrics
+
     script:
+    def transform_arg = input_transform.name != 'NO_TRANSFORM' ? "--input_transform ${input_transform}" : ""
     """
-    linum_estimate_transform.py ${aip} "z${slice_id}_transform_xy.npy"
+    linum_stitch_3d_refined.py ${mosaic_grid} "slice_z${slice_id}_stitch_3d.ome.zarr" \
+        --overlap_fraction ${params.stitch_overlap_fraction} \
+        --blending_method ${params.stitch_blending_method} \
+        --refinement_mode blend_shift \
+        --max_refinement_px ${params.max_blend_refinement_px} \
+        ${transform_arg} \
+        -f
+    """
+
+    stub:
+    """
+    mkdir -p slice_z${slice_id}_stitch_3d.ome.zarr
     """
 }
 
-process stitch_3d {
+process generate_stitch_preview {
+    publishDir "${params.output}/previews/stitched_slices", mode: 'copy'
+
     input:
-        tuple val(slice_id), path(mosaic_grid), path(transform_xy)
+    tuple val(slice_id), path(stitched_slice)
+
     output:
-        tuple val(slice_id), path("slice_z${slice_id}_stitch_3d.ome.zarr")
+    path "slice_z${slice_id}_stitched.png"
+
     script:
     """
-    linum_stitch_3d.py ${mosaic_grid} ${transform_xy} "slice_z${slice_id}_stitch_3d.ome.zarr"
+    linum_screenshot_omezarr.py ${stitched_slice} "slice_z${slice_id}_stitched.png" \
+        --z_slice 0
+    """
+
+    stub:
+    """
+    touch slice_z${slice_id}_stitched.png
     """
 }
+
+// -----------------------------------------------------------------------------
+// Correction Processes
+// -----------------------------------------------------------------------------
 
 process beam_profile_correction {
+    publishDir { "${params.output}/${task.process}" }, mode: 'copy', pattern: "*_metrics.json"
+
     input:
-        tuple val(slice_id), path(slice_3d)
+    tuple val(slice_id), path(slice_3d)
+
     output:
-        tuple val(slice_id), path("slice_z${slice_id}_axial_corr.ome.zarr")
+    tuple val(slice_id), path("slice_z${slice_id}_axial_corr.ome.zarr"), emit: corrected
+    path("*_metrics.json"), optional: true, emit: metrics
+
     script:
     """
-    linum_compensate_psf_model_free.py ${slice_3d} "slice_z${slice_id}_axial_corr.ome.zarr" --percentile_max $params.clip_percentile_upper
+    linum_compensate_psf_model_free.py ${slice_3d} "slice_z${slice_id}_axial_corr.ome.zarr" \
+        --percentile_max ${params.clip_percentile_upper}
+    """
+
+    stub:
+    """
+    mkdir -p slice_z${slice_id}_axial_corr.ome.zarr
     """
 }
 
 process crop_interface {
+    publishDir { "${params.output}/${task.process}" }, mode: 'copy', pattern: "*_metrics.json"
+
     input:
-        tuple val(slice_id), path(image)
+    tuple val(slice_id), path(image)
+
     output:
-        tuple val(slice_id), path("slice_z${slice_id}_crop_interface.ome.zarr")
+    tuple val(slice_id), path("slice_z${slice_id}_crop_interface.ome.zarr"), emit: cropped
+    path("*_metrics.json"), optional: true, emit: metrics
+
     script:
     """
-    linum_crop_3d_mosaic_below_interface.py $image "slice_z${slice_id}_crop_interface.ome.zarr" --depth $params.crop_interface_out_depth --crop_before_interface --percentile_max $params.clip_percentile_upper
+    linum_crop_3d_mosaic_below_interface.py ${image} "slice_z${slice_id}_crop_interface.ome.zarr" \
+        --depth ${params.crop_interface_out_depth} \
+        --crop_before_interface \
+        --percentile_max ${params.clip_percentile_upper}
+    """
+
+    stub:
+    """
+    mkdir -p slice_z${slice_id}_crop_interface.ome.zarr
     """
 }
 
 process normalize {
+    publishDir { "${params.output}/${task.process}" }, mode: 'copy', pattern: "*_metrics.json"
+
     input:
-        tuple val(slice_id), path(image)
+    tuple val(slice_id), path(image)
+
     output:
-        tuple val(slice_id), path("slice_z${slice_id}_normalize.ome.zarr")
+    tuple val(slice_id), path("slice_z${slice_id}_normalize.ome.zarr"), emit: normalized
+    path("*_metrics.json"), optional: true, emit: metrics
+
     script:
+    def gpu_flag = params.use_gpu ? "--use_gpu" : "--no-use_gpu"
     """
-    linum_normalize_intensities_per_slice.py ${image} "slice_z${slice_id}_normalize.ome.zarr" --percentile_max ${params.clip_percentile_upper}
+    linum_normalize_intensities_per_slice.py ${image} "slice_z${slice_id}_normalize.ome.zarr" \
+        --percentile_max ${params.clip_percentile_upper} ${gpu_flag}
+    """
+
+    stub:
+    """
+    mkdir -p slice_z${slice_id}_normalize.ome.zarr
+    """
+}
+
+// -----------------------------------------------------------------------------
+// Alignment Processes
+// -----------------------------------------------------------------------------
+
+process detect_rehoming_events {
+    input:
+    tuple path(shifts_csv), path(slice_config_in)
+
+    output:
+    path "shifts_xy_clean.csv",           emit: corrected_shifts
+    path "slice_config.csv",              optional: true, emit: slice_config
+    path "diagnostics/*",                 optional: true, emit: diagnostics
+
+    script:
+    def diag_arg = params.rehoming_diagnostics ? "--diagnostics diagnostics" : ""
+    def frac_arg = params.rehoming_return_fraction ? "--return_fraction ${params.rehoming_return_fraction}" : ""
+    def tile_fov_arg = params.tile_fov_mm ? "--tile_fov_mm ${params.tile_fov_mm}" : ""
+    def tile_tol_arg = (params.tile_fov_mm && params.tile_fov_tolerance != null) ? "--tile_fov_tolerance ${params.tile_fov_tolerance}" : ""
+    def max_shift_arg = params.rehoming_max_shift_mm ? "--max_shift_mm ${params.rehoming_max_shift_mm}" : ""
+    def sc_args = slice_config_in.name != 'NO_SLICE_CONFIG'
+        ? "--slice_config_in ${slice_config_in} --slice_config_out slice_config.csv"
+        : ""
+    """
+    linum_detect_rehoming.py ${shifts_csv} shifts_xy_clean.csv \
+        ${frac_arg} ${max_shift_arg} ${tile_fov_arg} ${tile_tol_arg} ${diag_arg} \
+        ${sc_args}
+    """
+
+    stub:
+    """
+    printf 'fixed_id,moving_id,x_shift,y_shift,x_shift_mm,y_shift_mm,reliable\n' > shifts_xy_clean.csv
+    """
+}
+
+// Auto-assess slice quality after normalization. An existing slice_config.csv
+// (when supplied) is merged so manually-excluded slices stay excluded.
+// See docs/NEXTFLOW_WORKFLOWS.md "Authoring Notes" for the two-input pattern.
+process auto_assess_quality {
+    input:
+    path "inputs/*"
+    path existing_slice_config
+
+    output:
+    path "slice_config.csv", emit: slice_config
+
+    script:
+    def update_args = existing_slice_config.name != 'NO_SLICE_CONFIG'
+        ? "--update_existing --existing_config ${existing_slice_config}"
+        : ""
+    """
+    linum_assess_slice_quality.py inputs slice_config.csv \\
+        --min_quality ${params.auto_assess_min_quality} \\
+        --exclude_first ${params.auto_assess_exclude_first} \\
+        --roi_size ${params.auto_assess_roi_size} \\
+        --processes ${params.processes} \\
+        ${update_args} \\
+        -f
+    """
+
+    stub:
+    """
+    printf 'slice_id,use\n' > slice_config.csv
     """
 }
 
 process bring_to_common_space {
-    publishDir "$params.output/$task.process", mode: 'copy'
     input:
-        tuple path("inputs/*"), path("shifts_xy.csv")
+    tuple path("inputs/*"), path("shifts_xy.csv"), path(slice_config)
+
     output:
-        path("*.ome.zarr")
+    path "*.ome.zarr"
+
     script:
+    def slice_config_arg = slice_config.name != 'NO_SLICE_CONFIG' ? "--slice_config ${slice_config}" : ""
+
+    def excluded_args = params.common_space_excluded_slice_mode ?
+        "--excluded_slice_mode ${params.common_space_excluded_slice_mode} --excluded_slice_window ${params.common_space_excluded_slice_window}" : ""
+
+    def refine_arg = params.common_space_refine_unreliable ? "--refine_unreliable" : ""
+    def discrepancy_arg = (params.common_space_refine_unreliable && params.common_space_refine_max_discrepancy_px > 0) ?
+        "--refine_max_discrepancy_px ${params.common_space_refine_max_discrepancy_px}" : ""
+    def min_corr_arg = (params.common_space_refine_unreliable && params.common_space_refine_min_correlation > 0) ?
+        "--refine_min_correlation ${params.common_space_refine_min_correlation}" : ""
+
     """
-    linum_align_mosaics_3d_from_shifts.py inputs shifts_xy.csv common_space
+    linum_align_mosaics_3d_from_shifts.py inputs shifts_xy.csv common_space \
+        ${slice_config_arg} ${excluded_args} ${refine_arg} ${discrepancy_arg} ${min_corr_arg}
     mv common_space/* .
     """
+
+    stub:
+    """
+    for f in inputs/*.ome.zarr; do
+        [ -e "\$f" ] || continue
+        mkdir -p "\$(basename \$f)"
+    done
+    """
 }
+
+process generate_common_space_preview {
+    publishDir "${params.output}/common_space_previews", mode: 'copy'
+
+    input:
+    tuple val(slice_id), path(slice_zarr)
+
+    output:
+    path "slice_z${slice_id}_preview.png"
+
+    script:
+    """
+    linum_screenshot_omezarr.py ${slice_zarr} "slice_z${slice_id}_preview.png"
+    """
+
+    stub:
+    """
+    touch slice_z${slice_id}_preview.png
+    """
+}
+
+// Interpolate a single missing slice via z-aware morphing (zmorph).
+// On gate failure the zarr is omitted (hard skip); see
+// docs/SLICE_INTERPOLATION_FEATURE.md for the full failure policy.
+process interpolate_missing_slice {
+    input:
+    tuple val(missing_slice_id), path(slice_before), path(slice_after)
+
+    output:
+    path "slice_z${missing_slice_id}_interpolated.ome.zarr", optional: true, emit: zarr
+    path "slice_z${missing_slice_id}_interpolated_preview.png", optional: true, emit: preview
+    path "slice_z${missing_slice_id}_interpolated_diagnostics.json", emit: diagnostics
+    path "slice_z${missing_slice_id}_manifest.csv", emit: manifest
+
+    script:
+    def preview_opt = params.interpolation_preview ? "--preview slice_z${missing_slice_id}_interpolated_preview.png" : ""
+    def slab_opt = params.interpolation_reference_slab_size ? "--reference_slab_size ${params.interpolation_reference_slab_size}" : ""
+    def fg_opt = params.interpolation_min_foreground_fraction != null ? "--min_foreground_fraction ${params.interpolation_min_foreground_fraction}" : ""
+    def ncc_opt = params.interpolation_min_ncc_improvement != null ? "--min_ncc_improvement ${params.interpolation_min_ncc_improvement}" : ""
+    """
+    linum_interpolate_missing_slice.py ${slice_before} ${slice_after} \
+        "slice_z${missing_slice_id}_interpolated.ome.zarr" \
+        --method ${params.interpolation_method} \
+        --blend_method ${params.interpolation_blend_method} \
+        --registration_metric ${params.interpolation_registration_metric} \
+        --max_iterations ${params.interpolation_max_iterations} \
+        --overlap_search_window ${params.interpolation_overlap_search_window} \
+        --min_overlap_correlation ${params.interpolation_min_overlap_correlation} \
+        ${slab_opt} \
+        ${fg_opt} \
+        ${ncc_opt} \
+        --slice_id ${missing_slice_id} \
+        --diagnostics slice_z${missing_slice_id}_interpolated_diagnostics.json \
+        --manifest_entry slice_z${missing_slice_id}_manifest.csv \
+        ${preview_opt}
+    """
+
+    stub:
+    """
+    mkdir -p slice_z${missing_slice_id}_interpolated.ome.zarr
+    echo '{}' > slice_z${missing_slice_id}_interpolated_diagnostics.json
+    printf 'slice_id,interpolated\n${missing_slice_id},true\n' > slice_z${missing_slice_id}_manifest.csv
+    """
+}
+
+// Merge per-slice interpolation manifest fragments into slice_config.csv.
+// See docs/NEXTFLOW_WORKFLOWS.md "Authoring Notes" for the two-input pattern.
+process finalise_interpolation {
+    publishDir "${params.output}", mode: 'copy'
+
+    input:
+    path slice_config
+    path "fragments/*"
+
+    output:
+    path "slice_config_final.csv"
+
+    script:
+    """
+    linum_interpolate_missing_slice.py --finalise \\
+        --slice_config_in ${slice_config} \\
+        --slice_config_out slice_config_final.csv \\
+        --fragments fragments
+    """
+
+    stub:
+    """
+    printf 'slice_id,use\n' > slice_config_final.csv
+    """
+}
+
+// -----------------------------------------------------------------------------
+// Registration Processes
+// -----------------------------------------------------------------------------
 
 process register_pairwise {
-    publishDir "$params.output/$task.process", mode: 'copy'
     input:
-        tuple path(fixed_vol), path(moving_vol)
+    tuple path(fixed_vol), path(moving_vol)
+
     output:
-        path("*")
+    path "*"
+
     script:
+    def rotation_flag = params.registration_transform == 'translation' ? "--no_rotation" : "--enable_rotation"
     """
-    dirname=`basename $moving_vol .ome.zarr`
-    linum_estimate_transform_pairwise.py ${fixed_vol} ${moving_vol} \$dirname --moving_slice_index $params.moving_slice_first_index --transform $params.pairwise_transform --metric $params.pairwise_registration_metric
+    dirname=\$(basename ${moving_vol} .ome.zarr)
+    linum_register_pairwise.py ${fixed_vol} ${moving_vol} \$dirname \
+        --slicing_interval_mm ${params.registration_slicing_interval_mm} \
+        --search_range_mm ${params.registration_allowed_drifting_mm} \
+        --moving_z_index ${params.moving_slice_first_index} \
+        --max_rotation_deg ${params.registration_max_rotation} \
+        --max_translation_px ${params.registration_max_translation} \
+        --initial_alignment ${params.registration_initial_alignment} \
+        ${rotation_flag}
+    """
+
+    stub:
+    """
+    dirname=\$(basename ${moving_vol} .ome.zarr)
+    mkdir -p \$dirname
+    touch \$dirname/transform.tfm
     """
 }
 
-process stack {
-    publishDir "$params.output/$task.process", mode: 'copy'
+// Optional: re-register slice pairs that have a manual transform, using the
+// manual alignment as initialisation.  Produces a refined transform that
+// combines the manual correction with a tight image-based residual correction.
+// Only runs when params.refine_manual_transforms = true.
+process refine_manual_transforms {
     input:
-        tuple path("mosaics/*"), path("transforms/*")
+    tuple path(fixed_vol), path(moving_vol), path("auto_transforms")
+
     output:
-        tuple path("3d_volume.ome.zarr"), path("3d_volume.ome.zarr.zip"), path("3d_volume.png")
+    path "*"
+
     script:
-    String options = ""
-    if(params.stack_blend_enabled)
-    {
-        options += "--blend"
-        if(params.stack_max_overlap > 0)
-        {
-            options += " --overlap ${params.stack_max_overlap}"
-        }
-    }
+    def manual_dir_opt = params.manual_transforms_dir ? "--manual_transforms_dir ${params.manual_transforms_dir}" : ""
     """
-    linum_stack_slices_3d.py mosaics transforms 3d_volume.ome.zarr ${options}
-    zip -r 3d_volume.ome.zarr.zip 3d_volume.ome.zarr
-    linum_screenshot_omezarr.py 3d_volume.ome.zarr 3d_volume.png
+    dirname=\$(basename ${moving_vol} .ome.zarr)
+    linum_refine_manual_transforms.py ${fixed_vol} ${moving_vol} auto_transforms \$dirname \
+        --max_translation_px ${params.refine_max_translation_px} \
+        --max_rotation_deg ${params.refine_max_rotation_deg} \
+        ${manual_dir_opt} -f
+    """
+
+    stub:
+    """
+    dirname=\$(basename ${moving_vol} .ome.zarr)
+    mkdir -p \$dirname
+    touch \$dirname/transform.tfm
     """
 }
+
+// Auto-exclude clusters of consecutive low-quality registrations by stamping
+// auto_excluded/auto_exclude_reason into slice_config.csv; stack reads them
+// via --slice_config and treats those slices as motor-only.
+// See docs/NEXTFLOW_WORKFLOWS.md "Authoring Notes" for the two-input pattern.
+process auto_exclude_slices {
+    input:
+    path "transforms/*"
+    path slice_config_in
+
+    output:
+    path "slice_config.csv", emit: slice_config
+
+    script:
+    """
+    linum_auto_exclude_slices.py transforms ${slice_config_in} slice_config.csv \
+        --consecutive_threshold ${params.auto_exclude_consecutive} \
+        --z_corr_threshold ${params.auto_exclude_z_corr}
+    """
+
+    stub:
+    """
+    printf 'slice_id,use\n' > slice_config.csv
+    """
+}
+
+// -----------------------------------------------------------------------------
+// Stacking Processes
+// -----------------------------------------------------------------------------
+
+// Export lightweight data package for the manual alignment tool.
+// Produces AIP images and copies pairwise transforms into a self-contained
+// directory that can be downloaded and opened by the manual alignment widget.
+process make_manual_align_package {
+    input:
+    tuple path("slices/*"), path("transforms/*")
+
+    output:
+    path("manual_align_package"), emit: pkg
+
+    script:
+    // When interpolation is enabled, interpolated slices live in a separate
+    // publish dir (interpolate_missing_slice/) rather than bring_to_common_space/.
+    // Pass that directory so the plugin's SSH reader can locate them.
+    def interp_dir_opt = params.interpolate_missing_slices ?
+        "--interpolated_slices_remote_dir ${params.output}/interpolate_missing_slice" : ""
+    """
+    linum_export_manual_align.py slices transforms manual_align_package \
+        --level ${params.manual_align_level} \
+        --slices_remote_dir ${params.output}/bring_to_common_space \
+        ${interp_dir_opt}
+    """
+
+    stub:
+    """
+    mkdir -p manual_align_package
+    """
+}
+
+// Stacking: assembles common-space slices into a 3D volume using motor positions
+// for XY placement, pairwise registration for rotation/translation refinement,
+// and correlation or physics-based Z-matching.
+// publishDir mode is conditional: 'symlink' when a downstream step will produce
+// the final output (preserves work-dir files for -resume); 'move' when this is last.
+process stack {
+    publishDir { "${params.output}/${task.process}" },
+        mode: (params.correct_bias_field || params.align_to_ras_enabled) ? 'symlink' : 'move',
+        saveAs: { fn -> fn.endsWith('.ome.zarr') ? null : fn }
+
+    input:
+    tuple path("slices/*"), path(shifts_file), path("transforms/*"), path(slice_config), val(subject_name), val(slice_ids_str)
+
+    output:
+    tuple path("${subject_name}.ome.zarr"), path("${subject_name}.ome.zarr.zip"), path("${subject_name}.png"), path("${subject_name}_annotated.png"), emit: volume
+    path("*_metrics.json"), optional: true, emit: metrics
+    path("z_matches.csv"), optional: true, emit: z_matches
+    path("stacking_decisions.csv"), optional: true, emit: stacking_decisions
+
+    script:
+    def gpu_flag = params.use_gpu ? " --use_gpu" : " --no-use_gpu"
+    def options = Helpers.stackBlendingArgs(params) +
+                  Helpers.stackZMatchingArgs(params) +
+                  Helpers.stackPairwiseTransformArgs(params) +
+                  Helpers.stackSliceConfigArg(slice_config) +
+                  Helpers.stackManualOverrideArg(params) +
+                  Helpers.stackCumulativeArgs(params) +
+                  Helpers.stackSmoothingArgs(params) +
+                  " --no_xy_shift" +  // slices are already in common space
+                  gpu_flag +
+                  Helpers.pyramidArgs(params)
+
+    def annotated_args = Helpers.annotatedScreenshotArgs(params, slice_ids_str)
+    """
+    linum_stack_slices_motor.py slices ${shifts_file} ${subject_name}.ome.zarr ${options}
+    zip -r ${subject_name}.ome.zarr.zip ${subject_name}.ome.zarr
+    linum_screenshot_omezarr.py ${subject_name}.ome.zarr ${subject_name}.png
+    linum_screenshot_omezarr_annotated.py ${subject_name}.ome.zarr ${subject_name}_annotated.png ${annotated_args}
+    """
+
+    stub:
+    """
+    mkdir -p ${subject_name}.ome.zarr
+    touch ${subject_name}.ome.zarr.zip
+    touch ${subject_name}.png
+    touch ${subject_name}_annotated.png
+    """
+}
+
+// Post-stacking N4 bias field correction.
+// 'symlink' when align_to_ras follows; 'move' when this is the final output step.
+process correct_bias_field {
+    cpus params.processes
+
+    publishDir { "${params.output}/${task.process}" },
+        mode: params.align_to_ras_enabled ? 'symlink' : 'move',
+        saveAs: { fn -> fn.endsWith('.ome.zarr') ? null : fn }
+
+    input:
+    tuple path(stacked_zarr), val(subject_name), val(n_slices), val(slice_ids_str)
+
+    output:
+    tuple path("${subject_name}.ome.zarr"), path("${subject_name}.ome.zarr.zip"), path("${subject_name}.png"), path("${subject_name}_annotated.png")
+
+    script:
+    def n_slices_opt = n_slices > 0 ? "--n_serial_slices ${n_slices}" : ""
+    def annotated_args = Helpers.annotatedScreenshotArgs(params, slice_ids_str)
+    def backend_flag = params.use_gpu ? "auto" : "cpu"
+    def hm_perz_flag = params.bias_histogram_match_per_zplane ? "--histogram_match_per_zplane" : ""
+    def tissue_thresh_flag = params.bias_tissue_threshold != null ? "--tissue_threshold ${params.bias_tissue_threshold}" : ""
+    def zprofile_flag = params.bias_zprofile_smooth_sigma != null ? "--zprofile_smooth_sigma ${params.bias_zprofile_smooth_sigma}" : ""
+    def gpu_pin_block = Helpers.gpuPinBlock(params, "correct_bias_field ${subject_name}")
+    """
+    ${gpu_pin_block}
+    linum_correct_bias_field.py ${stacked_zarr} ${subject_name}.ome.zarr \
+        ${n_slices_opt} \
+        --mode ${params.bias_mode} \
+        --strength ${params.bias_strength} \
+        --backend ${backend_flag} \
+        --n_processes ${task.cpus} \
+        --verbose \
+        ${hm_perz_flag} \
+        ${tissue_thresh_flag} \
+        ${zprofile_flag} \
+        ${Helpers.pyramidArgs(params)}
+
+    zip -r ${subject_name}.ome.zarr.zip ${subject_name}.ome.zarr
+
+    linum_screenshot_omezarr.py ${subject_name}.ome.zarr ${subject_name}.png
+
+    linum_screenshot_omezarr_annotated.py ${subject_name}.ome.zarr ${subject_name}_annotated.png ${annotated_args}
+    """
+
+    stub:
+    """
+    mkdir -p ${subject_name}.ome.zarr
+    touch ${subject_name}.ome.zarr.zip
+    touch ${subject_name}.png
+    touch ${subject_name}_annotated.png
+    """
+}
+
+// Atlas registration to Allen Mouse Brain Atlas. Always the final step when enabled.
+process align_to_ras {
+    publishDir { "${params.output}/${task.process}" }, mode: 'move', saveAs: { fn ->
+        fn.endsWith('.ome.zarr') ? null : fn
+    }
+
+    input:
+    tuple path(stacked_zarr), path(zarr_zip), path(png), path(annotated_png)
+    val subject_name
+
+    output:
+    path "${subject_name}_ras.ome.zarr"
+    path "${subject_name}_ras.ome.zarr.zip"
+    path "${subject_name}_ras_transform.tfm", optional: true
+    path "${subject_name}_ras_preview.png", optional: true
+    path "${subject_name}_ras_orientation_preview.png", optional: true
+
+    script:
+    def orientation_arg = params.ras_input_orientation ? "--input-orientation ${params.ras_input_orientation}" : ""
+    def rotation_arg = params.ras_initial_rotation ? "--initial-rotation ${params.ras_initial_rotation}" : ""
+    def preview_arg = params.allen_preview ? "--preview ${subject_name}_ras_preview.png" : ""
+    def orientation_preview_arg = params.ras_orientation_preview ? "--orientation-preview ${subject_name}_ras_orientation_preview.png" : ""
+    def ras_pyramid_opts = Helpers.pyramidArgs(params, '--n-levels')
+    """
+    linum_align_to_ras.py ${stacked_zarr} ${subject_name}_ras.ome.zarr \
+        --allen-resolution ${params.allen_resolution} \
+        --metric ${params.allen_metric} \
+        --max-iterations ${params.allen_max_iterations} \
+        --level ${params.allen_registration_level} \
+        ${orientation_arg} ${rotation_arg} ${preview_arg} ${orientation_preview_arg} \
+        ${ras_pyramid_opts}
+    zip -r ${subject_name}_ras.ome.zarr.zip ${subject_name}_ras.ome.zarr
+    """
+
+    stub:
+    """
+    mkdir -p ${subject_name}_ras.ome.zarr
+    touch ${subject_name}_ras.ome.zarr.zip
+    """
+}
+
+// =============================================================================
+// MAIN WORKFLOW
+// =============================================================================
 
 workflow {
-    // Write readme containing the parameters for the current execution
     README()
 
-    // Parse inputs
-    inputSlices = channel.fromFilePairs("$params.input/mosaic_grid*_z*.ome.zarr", size: -1, type:'dir')
-        .ifEmpty {
-            error("No valid files found under '${params.input}'. Please supply a valid input directory.")
+    def inputDir = Helpers.normalizePath(params.input)
+    def subject_name = Helpers.resolveSubjectName(inputDir, params.subject_name)
+    log.info "Subject: ${subject_name}"
+    log.info "GPU: ${params.use_gpu ? 'ENABLED' : 'DISABLED'}"
+
+    def debugSlices = Helpers.parseDebugSlices(params.debug_slices)
+    if (debugSlices) {
+        log.info "DEBUG MODE: Processing only slices ${debugSlices.sort().join(', ')}"
+    }
+
+    // Shifts file
+    def shifts_xy_path = params.shifts_xy ?: "${inputDir}/shifts_xy.csv"
+    log.info "Shifts file: ${shifts_xy_path}"
+
+    if (!file(shifts_xy_path).exists()) {
+        error """
+        Shifts file not found: ${shifts_xy_path}
+
+        Please ensure shifts_xy.csv exists in your input directory,
+        or specify the path with --shifts_xy /path/to/shifts_xy.csv
+        """
+    }
+    // Value channel — fans out to many consumers; see "Authoring Notes" in
+    // docs/NEXTFLOW_WORKFLOWS.md.
+    shifts_xy = channel.value(file(shifts_xy_path))
+
+    // Slice config (optional)
+    def slice_config_path = params.slice_config ?: Helpers.joinPath(inputDir, "slice_config.csv")
+    def slicesToUse = null
+    if (file(slice_config_path).exists()) {
+        log.info "Slice config: ${slice_config_path}"
+        def parsed = Helpers.parseSliceConfig(slice_config_path)
+        slicesToUse = parsed.use
+        def total = slicesToUse.size() + parsed.excluded.size()
+        log.info "Slice config: ${total} entries (${slicesToUse.size()} included, ${parsed.excluded.size()} excluded)"
+    } else if (params.slice_config) {
+        error("Slice config file not found: ${slice_config_path}")
+    }
+
+    // Discover input mosaic grids
+    log.info "Looking for mosaic grids in: ${inputDir}"
+
+    def inputDirFile = file(inputDir)
+    def mosaicFiles = inputDirFile.listFiles()
+        .findAll { f -> f.isDirectory() && f.name.startsWith('mosaic_grid') && f.name.endsWith('.ome.zarr') && f.name =~ /z\d+/ }
+        .sort { f -> f.name }
+
+    if (mosaicFiles.isEmpty()) {
+        error("No mosaic grids found in ${inputDir}. Expected: mosaic_grid*_z00.ome.zarr")
+    }
+
+    def selectedIds = mosaicFiles.collect { f -> Helpers.extractSliceId(f) }.findAll { sid ->
+        if (debugSlices != null) return debugSlices.contains(sid)
+        if (slicesToUse != null) return slicesToUse.contains(sid)
+        return true
+    }
+    def skippedCount = mosaicFiles.size() - selectedIds.size()
+    if (skippedCount > 0) {
+        def reason = debugSlices != null ? "debug_slices filter" : "slice_config"
+        log.info "Found ${mosaicFiles.size()} mosaic grids; ${selectedIds.size()} selected, ${skippedCount} skipped (${reason})"
+    } else {
+        log.info "Found ${mosaicFiles.size()} mosaic grids; all selected"
+    }
+
+    inputSlices = channel
+        .fromList(mosaicFiles)
+        .map { f -> Helpers.toSliceTuple(f) }
+        .filter { slice_id, _files ->
+            if (debugSlices != null) {
+                def included = debugSlices.contains(slice_id)
+                if (!included) log.debug "Skipping slice ${slice_id} (not in debug_slices)"
+                return included
+            }
+            if (slicesToUse != null) return slicesToUse.contains(slice_id)
+            return true
         }
-        .map { id, files ->
-            // Extract the two digits after 'z' using regex
-            def matcher = id =~ /z(\d{2})/
-            def key = matcher ? matcher[0][1] : "unknown"
-            [key, files]
+
+    def has_slice_config = file(slice_config_path).exists() || params.auto_assess_quality
+    // Value channel — consumed by auto_assess, common_space, finalise, stack.
+    slice_config_channel = channel.value(
+        file(slice_config_path).exists() ? file(slice_config_path) : file('NO_SLICE_CONFIG')
+    )
+
+    if (params.analyze_shifts) {
+        analyze_shifts(shifts_xy)
+    }
+
+    // Stage 1: Preprocessing
+    resampled = params.resolution > 0 ? resample_mosaic_grid(inputSlices) : inputSlices
+    focal_fixed = params.fix_curvature_enabled ? fix_focal_curvature(resampled) : resampled
+    illum_fixed = params.fix_illum_enabled ? fix_illumination(focal_fixed) : focal_fixed
+
+    // Stage 2: XY Stitching (image-registration-based blend refinement)
+    if (params.stitch_global_transform) {
+        pooled_mosaics = illum_fixed.map { _id, p -> p }.collect()
+        estimate_global_transform(pooled_mosaics, slice_config_channel)
+        stitch_inputs = illum_fixed.combine(estimate_global_transform.out.transform)
+    } else {
+        // Value channel so the placeholder can fan out to every per-slice tuple.
+        no_transform = channel.value(file('NO_TRANSFORM'))
+        stitch_inputs = illum_fixed.combine(no_transform)
+    }
+    stitch_3d_with_refinement(stitch_inputs)
+    stitched_slices = stitch_3d_with_refinement.out.stitched
+
+    if (params.stitch_preview) {
+        generate_stitch_preview(stitched_slices)
+    }
+
+    // Stage 3: Corrections
+    beam_profile_correction(stitched_slices)
+    crop_interface(beam_profile_correction.out.corrected)
+    normalize(crop_interface.out.cropped)
+
+    // Stage 3.5: Auto slice quality assessment (optional). Generates a
+    // slice_config.csv that marks degraded slices; an existing static
+    // slice_config.csv is merged so manually-excluded slices stay excluded.
+    // current_slice_config = the latest slice_config as it flows through the
+    // pipeline; rebound by auto_assess / detect_rehoming when each runs.
+    current_slice_config = slice_config_channel
+    if (params.auto_assess_quality) {
+        auto_assess_inputs = normalize.out.normalized
+            .map { _id, norm_path -> norm_path }
+            .collect()
+        auto_assess_quality(auto_assess_inputs, slice_config_channel)
+        current_slice_config = auto_assess_quality.out.slice_config
+    }
+
+    // Stage 4: Common Space Alignment.
+    // detect_rehoming optionally corrects encoder-glitch spikes in the
+    // shifts file and (when a real slice_config exists) stamps
+    // rehomed/rehoming_reliable flags back into it.
+    if (params.detect_rehoming) {
+        detect_rehoming_input = shifts_xy.combine(current_slice_config)
+        detect_rehoming_events(detect_rehoming_input)
+        aligned_shifts = detect_rehoming_events.out.corrected_shifts
+        if (has_slice_config) {
+            current_slice_config = detect_rehoming_events.out.slice_config
         }
-    shifts_xy = channel.fromPath("$params.shifts_xy", checkIfExists: true)
-        .ifEmpty {
-            error("XY shifts file not found at path '$params.shifts_xy'.")
-        }
+    } else {
+        aligned_shifts = shifts_xy
+    }
 
-    // [Optional] Resample the input mosaic grid
-    resampled_channel = params.resolution > 0 ? resample_mosaic_grid(inputSlices) : inputSlices
-
-    // [Optional] Focal plane curvature correction
-    fixed_focal_channel = params.fix_curvature_enabled ? fix_focal_curvature(resampled_channel) : resampled_channel
-
-    // [Optional] Compensate for XY illumination inhomogeneity
-    fixed_illum_channel = params.fix_illum_enabled ? fix_illumination(fixed_focal_channel) : fixed_focal_channel
-
-    // Generate AIP mosaic grid
-    generate_aip(fixed_illum_channel)
-
-    // Extract tile position (XY) from AIP mosaic grid
-    estimate_xy_transformation(generate_aip.out)
-
-    // Stitch the tiles in 3D mosaics
-    stitch_3d(fixed_illum_channel.combine(estimate_xy_transformation.out, by:0))
-
-    // "PSF" correction
-    beam_profile_correction(stitch_3d.out)
-
-    // Crop at interface
-    crop_interface(beam_profile_correction.out)
-
-    // Normalize slice (compensate signal attenuation with depth)
-    normalize(crop_interface.out)
-
-    // Slices stitching
-    common_space_channel = normalize.out
-        .toSortedList{a, b -> a[0] <=> b[0]}
+    common_space_input = normalize.out.normalized
+        .toSortedList { a, b -> a[0] <=> b[0] }
         .flatten()
         .collate(2)
-        .map{_meta, filename -> filename}
+        .map { _meta, filename -> filename }
         .collect()
-        .merge(shifts_xy){a, b -> tuple(a, b)}
+        .merge(aligned_shifts) { a, b -> tuple(a, b) }
+        .merge(current_slice_config) { a, b -> tuple(a[0], a[1], b) }
 
-    // Bring all stitched slices to common space
-    bring_to_common_space(common_space_channel)
+    bring_to_common_space(common_space_input)
 
-    all_slices_common_space = bring_to_common_space.out
+    slices_common_space = bring_to_common_space.out
         .flatten()
-        .toSortedList{a, b -> a[0] <=> b[0]}
+        .toSortedList { a, b -> a.getName() <=> b.getName() }
 
-    // Prepare for pairwise stack registration
-    fixed_channel = all_slices_common_space
-        .map {list ->
-            if(list.size() > 1){
-                return list.subList(0, list.size() - 1)
+    if (params.common_space_preview) {
+        preview_input = bring_to_common_space.out
+            .flatten()
+            .map { f -> Helpers.toSliceTuple(f) }
+        generate_common_space_preview(preview_input)
+    }
+
+    // Stage 5: Missing Slice Interpolation (optional).
+    // Single-slice gaps (use=false slices already filtered upstream) are
+    // interpolated with zmorph; per-slice diagnostics are merged into
+    // slice_config_final.csv. See docs/SLICE_INTERPOLATION_FEATURE.md.
+    if (params.interpolate_missing_slices) {
+        gaps_channel = slices_common_space
+            .map { sliceList -> [Helpers.detectSingleGaps(sliceList), sliceList] }
+            .flatMap { gapsAndSlices ->
+                def gaps = gapsAndSlices[0]
+                def sliceList = gapsAndSlices[1]
+                if (gaps.isEmpty()) return []
+
+                gaps.collect { gap ->
+                    def (missingId, beforeId, afterId) = gap
+                    def sliceBefore = sliceList.find { f -> f.getName().contains("slice_z${beforeId}") }
+                    def sliceAfter = sliceList.find { f -> f.getName().contains("slice_z${afterId}") }
+                    (sliceBefore && sliceAfter) ? tuple(missingId, sliceBefore, sliceAfter) : null
+                }.findAll { item -> item != null }
             }
-            else {
-                return channel.empty()
-            }
+
+        interpolate_missing_slice(gaps_channel)
+
+        // Publish slice_config_final.csv as an artifact for the report.
+        // Intentionally NOT piped back into current_slice_config: when no
+        // gaps exist, interpolate_missing_slice does not run and finalise's
+        // output channel is empty, which would in turn empty out
+        // current_slice_config and silently skip stack. Stack only reads
+        // use/auto_excluded — neither column is modified here — so reading
+        // the upstream config is equivalent.
+        if (has_slice_config) {
+            finalise_interpolation(
+                current_slice_config,
+                interpolate_missing_slice.out.manifest.collect(),
+            )
         }
+
+        all_slices = slices_common_space
+            .mix(interpolate_missing_slice.out.zarr.collect())
+            .flatten()
+            .toSortedList { a, b -> a.getName() <=> b.getName() }
+    } else {
+        all_slices = slices_common_space
+    }
+
+    // Stage 6: Pairwise Registration
+    log.info "Registering slices pairwise"
+
+    fixed_slices = all_slices
+        .map { list -> list.size() > 1 ? list.subList(0, list.size() - 1) : [] }
         .flatten()
-    moving_channel = all_slices_common_space
-        .map {list ->
-            if(list.size() > 1){
-                return list.subList(1, list.size())
-            }
-            else {
-                return channel.empty()
-            }
+    moving_slices = all_slices
+        .map { list -> list.size() > 1 ? list.subList(1, list.size()) : [] }
+        .flatten()
+    pairs = fixed_slices.merge(moving_slices)
+
+    register_pairwise(pairs)
+
+    slices_collected = all_slices.flatten().collect()
+    transforms_collected = register_pairwise.out.collect()
+
+    // Stage 6.5: Export manual-alignment package (optional).
+    if (params.export_manual_align) {
+        export_input = slices_collected
+            .combine(transforms_collected)
+            .map { items -> Helpers.partitionSlicesAndTransforms(items) }
+        make_manual_align_package(export_input)
+    }
+
+    // Stage 6.75: Refine manual transforms (optional). Re-runs pairwise
+    // registration initialised from each manual transform; non-manual pairs
+    // are copied unchanged. Refined outputs replace automated transforms.
+    if (params.refine_manual_transforms && params.manual_transforms_dir) {
+        log.info "Refining manual transforms from: ${params.manual_transforms_dir}"
+        // Re-derive pairs from all_slices (value channel, safe to reuse)
+        refine_fixed = all_slices
+            .map { list -> list.size() > 1 ? list.subList(0, list.size() - 1) : [] }
+            .flatten()
+        refine_moving = all_slices
+            .map { list -> list.size() > 1 ? list.subList(1, list.size()) : [] }
+            .flatten()
+        // Key pairs by moving zarr basename (= transform dir name)
+        refine_pairs_keyed = refine_fixed
+            .merge(refine_moving)
+            .map { fixed, moving -> tuple(moving.getName().replace('.ome.zarr', ''), fixed, moving) }
+        // Key auto transform dirs by dir name
+        auto_transforms_keyed = register_pairwise.out
+            .flatten()
+            .filter { f -> !f.getName().endsWith('.ome.zarr') }
+            .map { dir -> tuple(dir.getName(), dir) }
+        // Join pairs with their corresponding auto transform dir
+        refine_input = refine_pairs_keyed
+            .join(auto_transforms_keyed)
+            .map { _id, fixed, moving, auto_tfm -> tuple(fixed, moving, auto_tfm) }
+        refine_manual_transforms(refine_input)
+        transforms_for_stack = refine_manual_transforms.out.collect()
+    } else {
+        transforms_for_stack = transforms_collected
+    }
+
+    // Stage 7: Stacking
+    log.info "Stacking slices with registration refinements"
+
+    // Auto-exclude: detect clusters of consecutive low-quality registrations.
+    // Stamps auto_excluded/auto_exclude_reason into slice_config so stack
+    // sees them via --slice_config. Requires a real slice_config.
+    stack_slice_config = current_slice_config
+    if (params.auto_exclude_enabled && has_slice_config) {
+        auto_exclude_slices(transforms_for_stack, current_slice_config)
+        stack_slice_config = auto_exclude_slices.out.slice_config
+    }
+
+    // Build stack_input with `merge` (preserves list-vs-file structure of each
+    // input). Earlier versions used `combine`, which flattens lists into a
+    // single tuple and forced fragile filename-based dispatch in `.map`.
+    stack_input = slices_collected
+        .merge(shifts_xy) { s, x -> tuple(s, x) }
+        .merge(transforms_for_stack) { acc, t -> tuple(acc[0], acc[1], t) }
+        .merge(stack_slice_config) { acc, sc -> tuple(acc[0], acc[1], acc[2], sc) }
+        .map { slices, shifts, transforms, sc ->
+            tuple(slices, shifts, transforms, sc, subject_name, Helpers.extractSliceIdsString(slices))
         }
-        .flatten()
 
-    // Register slices pairwise
-    pairs_channel = fixed_channel.merge(moving_channel)
-    register_pairwise(pairs_channel)
+    stack(stack_input)
+    stack_output = stack.out.volume
+    stack_metadata = stack_input.map { _slices, _shifts, _transforms, _sc, name, ids_str ->
+        tuple(name, ids_str.split(',').size(), ids_str)
+    }
 
-    // Stack all the slices in a single volume
-    stack_channel = all_slices_common_space.merge(register_pairwise.out.collect()){a, b -> tuple(a, b)}
-    stack(stack_channel)
+    // Stage 8: Bias Field Correction (optional)
+    if (params.correct_bias_field) {
+        log.info "Running N4 bias field correction (mode=${params.bias_mode})"
+        znorm_input = stack_output
+            .combine(stack_metadata)
+            .map { zarr, _zip, _png, _annotated, name, n, ids_str -> tuple(zarr, name, n, ids_str) }
+        correct_bias_field(znorm_input)
+        final_stack_output = correct_bias_field.out
+    } else {
+        final_stack_output = stack_output
+    }
+
+    // Stage 9: Report Generation (optional)
+    if (params.generate_report) {
+        generate_report(final_stack_output, subject_name)
+    }
+
+    // Stage 10: Atlas Registration (optional)
+    if (params.align_to_ras_enabled) {
+        log.info "Registering to Allen Mouse Brain Atlas (RAS alignment)"
+        align_to_ras(final_stack_output, subject_name)
+    }
+
+    // Stage 11: Diagnostics (optional). Toggle individually or via diagnostic_mode.
+    if (params.diagnostic_mode) {
+        log.info "DIAGNOSTIC MODE enabled (acq rotation, rotation drift, motor-only stitch/stack)"
+    }
+
+    if (Helpers.diagEnabled(params, 'analyze_acquisition_rotation')) {
+        analyze_acquisition_rotation(shifts_xy, register_pairwise.out.collect())
+    }
+
+    if (Helpers.diagEnabled(params, 'analyze_rotation_drift')) {
+        analyze_rotation_drift(register_pairwise.out.collect())
+    }
+
+    if (Helpers.diagEnabled(params, 'motor_only_stack')) {
+        motor_only_stack_input = normalize.out.normalized
+            .map { _id, slice_file -> slice_file }
+            .collect()
+        stack_motor_only(motor_only_stack_input, shifts_xy)
+    }
+
+    // motor_only_stitch is also a prerequisite for compare_stitching, so run it
+    // whenever either is requested. A second `stitch_motor_only(illum_fixed)`
+    // call would emit the same channel twice, which Nextflow forbids.
+    def runMotorStitch = Helpers.diagEnabled(params, 'motor_only_stitch')
+    def runComparison = params.compare_stitching || params.diagnostic_mode
+    if (runMotorStitch || runComparison) {
+        stitch_motor_only(illum_fixed)
+    }
+
+    if (runComparison) {
+        log.info "Running stitching comparison (motor-only vs refined)..."
+
+        stitch_refined(illum_fixed)
+
+        motor_stitch_with_id = stitch_motor_only.out.map { f -> Helpers.toSliceTuple(f) }
+        refined_stitch_with_id = stitch_refined.out[0].map { f -> Helpers.toSliceTuple(f) }
+
+        comparison_input = motor_stitch_with_id
+            .combine(refined_stitch_with_id, by: 0)
+
+        compare_stitching(comparison_input)
+    }
 }


### PR DESCRIPTION
> **Stacked PR 2/25 — review order:** #115 → #97 → #98 → **#99** → #100 → #101 → #108 → #106 → #107 → #87 → #116 → #110 → #111 → #40 → #112 → #130 → #131 → #118 → #132 → #121 → #122 → #123 → #124 → #128 → #133 → #134 → #135
>
> Base: `pr-e-motor-stacking`. Stacked on #98; retargets to `main` as upstream PRs merge.

---

## PR #99 — feat: GPU acceleration module and scripts

Adds the `linumpy/gpu/` module (CuPy + JAX primitives) and wires the existing CPU scripts in the repo to pick up an optional GPU path via `--use_gpu`. Stand-alone `*_gpu.py` script variants are intentionally **removed** in this PR (replaced by the unified CPU scripts in #97).

### New library module `linumpy/gpu/`
- `array_ops.py` — cupy/jax array primitives and CPU fallbacks
- `corrections.py` — GPU illumination / flat-field corrections
- `cuda_env.py` — CUDA environment detection (CUDA version, CuPy availability, JAX plugin status) + device selection; used by every GPU-capable script to negotiate the backend
- `fft_ops.py` — GPU FFT (phase-correlation building blocks)
- `image_quality.py` — GPU variance / sharpness metrics
- `interpolation.py` — GPU affine/linear resampling
- `morphology.py` — GPU morphological ops (erode/dilate/tophat)
- `normalization.py` — GPU intensity normalization (percentile / rolling-ball) paired with `linumpy/preproc/normalization.py` from #97
- `registration.py` — GPU phase-correlation + refinement; callable from `linumpy/stitching/registration.py`

### Scripts
- `scripts/linum_benchmark_gpu.py` — benchmark harness comparing CPU vs GPU on the key hot paths (normalization, registration, resampling)
- `scripts/linum_gpu_info.py` — report available CUDA / CuPy / JAX devices and plugin status

### Removed (unified into CPU scripts via `--use_gpu`)
- `linum_aip_gpu.py`, `linum_assess_slice_quality_gpu.py`, `linum_create_mosaic_grid_3d_gpu.py`, `linum_estimate_transform_gpu.py`, `linum_fix_illumination_3d_gpu.py`, `linum_generate_mosaic_aips_gpu.py`, `linum_normalize_intensities_per_slice_gpu.py`, `linum_resample_mosaic_grid_gpu.py`

### Shell helpers
- `shell_scripts/fix_jax_cuda_plugin.sh` — resets a broken JAX CUDA plugin install; autodetects CUDA 12 vs 13 and picks the matching `jax-cuda*-plugin` wheel

### Notes
- #95 declares the `gpu` / `gpu-cuda12` / `gpu-cuda13` optional extras used here
- Unified CPU scripts live in #97 (and #100 for diagnostics); those accept `--use_gpu` and dispatch into `linumpy/gpu/`







