### PR TITLE
feat: Allen atlas improvements and RAS alignment

### DIFF
--- a/linumpy/imaging/orientation.py
+++ b/linumpy/imaging/orientation.py
@@ -1,0 +1,160 @@
+"""
+Utilities for handling 3D volume orientation codes and transformations.
+
+The target convention matches the Allen Atlas RAS+ template as returned by
+:func:`linumpy.reference.allen.download_template_ras_aligned`. After
+:func:`apply_orientation_transform`, the numpy array obeys:
+
+  - numpy dim 0 → SITK Z → Allen S (Superior)
+  - numpy dim 1 → SITK Y → Allen A (Anterior)
+  - numpy dim 2 → SITK X → Allen R (Right)
+
+When this volume is handed to
+:func:`linumpy.reference.allen.numpy_to_sitk_image` it becomes a SITK image
+with axis order ``(X=R, Y=A, Z=S)``, which directly matches the
+RAS-aligned Allen template.  Any other target ordering would force the
+rigid registration to recover an extra 90° axis swap from gradient steps,
+which routinely fails to converge.
+
+The RAS target orientation maps:
+  - output dim 0  ←→  Superior (S)
+  - output dim 1  ←→  Anterior (A)
+  - output dim 2  ←→  Right (R)
+"""
+
+import numpy as np
+
+
+def parse_orientation_code(orientation: str) -> tuple[tuple[int, ...], tuple[int, ...]]:
+    """
+    Parse an orientation code and return axis permutation and flips for RAS alignment.
+
+    Parameters
+    ----------
+    orientation : str
+        3-letter code (R/L, A/P, S/I) describing what each *source* axis points to.
+        Example: 'AIR' means dim0→Anterior, dim1→Inferior, dim2→Right.
+
+    Returns
+    -------
+    axis_permutation : tuple of int
+        Source indices for each target dimension, such that
+        ``np.transpose(volume, axis_permutation)`` produces a volume whose axes are
+        ordered (S, A, R) -- matching the Allen RAS+ template convention where:
+
+          - numpy dim 0 → SITK Z → Allen S (Superior)
+          - numpy dim 1 → SITK Y → Allen A (Anterior)
+          - numpy dim 2 → SITK X → Allen R (Right)
+    axis_flips : tuple of int
+        Sign for each axis **after** permutation: -1 means flip that axis, +1 means keep.
+
+    Raises
+    ------
+    ValueError
+        If the orientation code is not exactly 3 letters, contains invalid letters,
+        or has duplicate axis directions.
+
+    Examples
+    --------
+    >>> parse_orientation_code('SAR')  # source already in (S, A, R) order -- identity
+    ((0, 1, 2), (1, 1, 1))
+    >>> parse_orientation_code('PIR')  # common OCT orientation
+    ((1, 0, 2), (-1, -1, 1))
+    """
+    if len(orientation) != 3:
+        raise ValueError(f"Orientation code must be 3 letters, got '{orientation}'")
+
+    orientation = orientation.upper()
+
+    # Map each letter to the TARGET numpy dimension and the sign for that direction.
+    # Target dimensions (after permutation) match the Allen RAS+ template's numpy
+    # ordering ((S, A, R) → SITK (R, A, S)):
+    #   dim 0 → S (Superior)    letter 'S' → same direction, 'I' → flipped
+    #   dim 1 → A (Anterior)    letter 'A' → same direction, 'P' → flipped
+    #   dim 2 → R (Right)       letter 'R' → same direction, 'L' → flipped
+    letter_map = {
+        "S": (0, 1),
+        "I": (0, -1),  # target dim 0 (Superior)
+        "A": (1, 1),
+        "P": (1, -1),  # target dim 1 (Anterior)
+        "R": (2, 1),
+        "L": (2, -1),  # target dim 2 (Right)
+    }
+
+    source_to_target = {}
+    axes_used = set()
+
+    for source_dim, letter in enumerate(orientation):
+        if letter not in letter_map:
+            raise ValueError(f"Invalid orientation letter '{letter}'. Use R/L, A/P, or S/I.")
+        target_dim, sign = letter_map[letter]
+        if target_dim in axes_used:
+            raise ValueError(
+                f"Duplicate axis direction in orientation code '{orientation}': "
+                f"letter '{letter}' maps to an already-used target axis."
+            )
+        axes_used.add(target_dim)
+        source_to_target[source_dim] = (target_dim, sign)
+
+    if axes_used != {0, 1, 2}:
+        raise ValueError(f"Orientation code '{orientation}' must specify all three axes (S/I, R/L, A/P).")
+
+    # Build target_dim -> (source_dim, sign)
+    target_to_source = {v[0]: (k, v[1]) for k, v in source_to_target.items()}
+
+    axis_permutation = tuple(target_to_source[i][0] for i in range(3))
+    axis_flips = tuple(target_to_source[i][1] for i in range(3))
+
+    return axis_permutation, axis_flips
+
+
+def apply_orientation_transform(
+    volume: np.ndarray, permutation: tuple[int, ...], flips: tuple[int, ...] | None = None
+) -> np.ndarray:
+    """
+    Reorient a 3D volume by applying an axis permutation followed by axis flips.
+
+    Parameters
+    ----------
+    volume : np.ndarray
+        Input 3-D volume (any shape).
+    permutation : tuple of int
+        Axis permutation as returned by :func:`parse_orientation_code`.
+        ``np.transpose(volume, permutation)`` is applied first.
+    flips : tuple of int
+        Sign for each axis after permutation.  A value of -1 means that axis is
+        flipped (``np.flip``); +1 means the axis is kept as-is.
+
+    Returns
+    -------
+    np.ndarray
+        Reoriented volume.  The returned array may share memory with *volume*
+        for the non-contiguous transpose, but ``np.flip`` produces a view, so
+        callers should copy if in-place modification is needed.
+    """
+    result = np.transpose(volume, permutation)
+    if flips is not None:
+        for axis, flip in enumerate(flips):
+            if flip < 0:
+                result = np.flip(result, axis=axis)
+    return result
+
+
+def reorder_resolution(resolution: tuple[float, ...], permutation: tuple[int, ...]) -> tuple[float, ...]:
+    """
+    Reorder a per-axis resolution tuple to match the axis permutation.
+
+    Parameters
+    ----------
+    resolution : tuple of float
+        Per-axis resolution values, one per spatial dimension.
+    permutation : tuple of int
+        Axis permutation as returned by :func:`parse_orientation_code`.
+
+    Returns
+    -------
+    tuple of float
+        Resolution values reordered so that ``reordered[i] == resolution[permutation[i]]``,
+        i.e. the resolution now corresponds to the target axis ordering.
+    """
+    return tuple(resolution[permutation[i]] for i in range(len(permutation)))

--- a/linumpy/registration/sitk.py
+++ b/linumpy/registration/sitk.py
@@ -1,5 +1,8 @@
 """SimpleITK-based image registration and transform application."""
 
+from collections.abc import Callable, Sequence
+from typing import Any
+
 import numpy as np
 import SimpleITK as sitk
 
@@ -312,22 +315,50 @@ def command_iteration(method: sitk.ImageRegistrationMethod) -> None:
     print(f"{method.GetOptimizerIteration():3} " + f"= {method.GetMetricValue():7.5f} " + f": {method.GetOptimizerPosition()}")
 
 
-def apply_transform(moving_image: np.ndarray, transform: sitk.Transform) -> np.ndarray:
+def apply_transform(
+    moving_image: np.ndarray,
+    transform: sitk.Transform,
+    reference_image: np.ndarray | None = None,
+    reference_spacing: Sequence[float] | None = None,
+    moving_spacing: Sequence[float] | None = None,
+) -> np.ndarray:
     """Apply `transform` to `moving_image`.
 
-    The image is transformed inside its own domain.
+    By default the image is transformed inside its own domain (preserving
+    backward compatibility).  When ``reference_image`` is provided, the moving
+    image is resampled onto the reference grid instead — required when the
+    transform maps between two volumes that do not share a domain (e.g.
+    inter-subject registration with different shapes / spacing).
 
     Parameters
     ----------
-    moving_image: numpy.ndarray
-        Moving image to transform.
-    transform: sitk.sitkTransform
-        Transform to apply to `moving_image`.
+    moving_image
+        Moving image to transform (numpy ZYX).
+    transform
+        SimpleITK transform mapping the reference (or moving) domain to
+        moving voxel coordinates.
+    reference_image
+        Optional reference volume defining the output grid.  Only its shape
+        and spacing are used; intensities are ignored.
+    reference_spacing
+        Voxel spacing ``(sz, sy, sx)`` in mm for ``reference_image``.
+        Required when ``reference_image`` is given.
+    moving_spacing
+        Voxel spacing ``(sz, sy, sx)`` in mm for ``moving_image``.  Required
+        when ``reference_image`` is given so the moving image carries the
+        correct physical extent.
     """
-    moving_image_sitk = sitk.GetImageFromArray(moving_image)
+    if reference_image is not None:
+        if reference_spacing is None or moving_spacing is None:
+            raise ValueError("reference_spacing and moving_spacing are required when reference_image is given.")
+        moving_image_sitk = _numpy_to_sitk_image(moving_image, moving_spacing)
+        reference_sitk = _numpy_to_sitk_image(reference_image, reference_spacing)
+    else:
+        moving_image_sitk = sitk.GetImageFromArray(moving_image)
+        reference_sitk = moving_image_sitk
 
     resampler = sitk.ResampleImageFilter()
-    resampler.SetReferenceImage(moving_image_sitk)  # transforms the image inside its domain
+    resampler.SetReferenceImage(reference_sitk)
     resampler.SetInterpolator(sitk.sitkLinear)
 
     # Use edge value instead of zero to avoid black dots at boundaries
@@ -341,3 +372,239 @@ def apply_transform(moving_image: np.ndarray, transform: sitk.Transform) -> np.n
     out = sitk.GetArrayFromImage(out)
 
     return out
+
+
+def _numpy_to_sitk_image(volume: np.ndarray, spacing: Sequence[float]) -> sitk.Image:
+    """Convert a numpy ZYX volume to a SimpleITK image with identity frame.
+
+    Spacing is in numpy order ``(sz, sy, sx)``; SITK uses ``(sx, sy, sz)``.
+    Origin is ``(0, 0, 0)`` and direction is identity — matching the
+    project-wide RAS-aligned OME-Zarr convention.
+    """
+    vol_sitk = sitk.GetImageFromArray(volume)
+    vol_sitk.SetSpacing([float(spacing[2]), float(spacing[1]), float(spacing[0])])
+    vol_sitk.SetOrigin([0.0, 0.0, 0.0])
+    vol_sitk.SetDirection([1, 0, 0, 0, 1, 0, 0, 0, 1])
+    return vol_sitk
+
+
+def register_3d_rigid_to_volume(
+    fixed_volume: np.ndarray,
+    fixed_spacing: Sequence[float],
+    moving_volume: np.ndarray,
+    moving_spacing: Sequence[float],
+    metric: str = "MI",
+    max_iterations: int = 1000,
+    initial_rotation_deg: Sequence[float] = (0.0, 0.0, 0.0),
+    crop_to_bbox: bool = True,
+    verbose: bool = False,
+    progress_callback: Callable[[Any], None] | None = None,
+) -> tuple[sitk.Euler3DTransform, str, float]:
+    """Rigid 3-D registration between two arbitrary volumes (no atlas).
+
+    Both volumes are interpreted as ZYX numpy arrays sitting in an identity
+    physical frame (origin = 0, direction = identity, spacing in mm).  The
+    returned ``Euler3DTransform`` maps ``fixed`` coordinates to ``moving``
+    coordinates and can be passed to :func:`apply_transform` together with
+    ``reference_image=fixed_volume`` to resample the moving subject onto the
+    fixed grid.
+
+    The recipe mirrors :func:`linumpy.reference.allen.register_3d_rigid_to_allen`
+    minus the Allen-specific resampling and centroid-fallback logic: the two
+    volumes are expected to already share an approximate RAS frame at a
+    compatible resolution.
+
+    Parameters
+    ----------
+    fixed_volume, moving_volume
+        Numpy ZYX volumes.
+    fixed_spacing, moving_spacing
+        ``(sz, sy, sx)`` in mm.
+    metric
+        ``'MI'`` (default, Mattes), ``'MSE'``, ``'CC'``, or ``'AntsCC'``.
+    max_iterations
+        Maximum optimizer iterations per pyramid level.
+    initial_rotation_deg
+        ``(rx, ry, rz)`` degrees applied before optimisation.
+    crop_to_bbox
+        Crop both volumes to their non-zero tissue bounding box before
+        registration.  Translation offsets are restored on output so the
+        transform is valid for the full original volumes.
+    verbose
+        Print progress.
+    progress_callback
+        Called once per iteration with the SITK registration method.
+
+    Returns
+    -------
+    transform, stop_condition, metric_value
+    """
+    fixed_vol = np.asarray(fixed_volume)
+    moving_vol = np.asarray(moving_volume)
+
+    # Optional crop to non-zero bounding box.  Translation offsets are added
+    # back on the final transform's translation so it remains valid for the
+    # uncropped volumes.
+    margin_voxels = 10
+    fixed_crop_origin_mm = (0.0, 0.0, 0.0)
+    moving_crop_origin_mm = (0.0, 0.0, 0.0)
+    if crop_to_bbox:
+        fixed_vol, fixed_crop_origin_mm = _crop_to_bbox(fixed_vol, fixed_spacing, margin_voxels)
+        moving_vol, moving_crop_origin_mm = _crop_to_bbox(moving_vol, moving_spacing, margin_voxels)
+        if verbose:
+            print(f"Cropped fixed → {fixed_vol.shape}, moving → {moving_vol.shape}")
+
+    fixed_sitk = _numpy_to_sitk_image(fixed_vol, fixed_spacing)
+    moving_sitk = _numpy_to_sitk_image(moving_vol, moving_spacing)
+
+    fixed_image = sitk.Normalize(sitk.Cast(fixed_sitk, sitk.sitkFloat32))
+    moving_image = sitk.Normalize(sitk.Cast(moving_sitk, sitk.sitkFloat32))
+
+    registration = sitk.ImageRegistrationMethod()
+
+    metric_u = metric.upper()
+    if metric_u == "MI":
+        registration.SetMetricAsMattesMutualInformation(numberOfHistogramBins=50)
+    elif metric_u == "MSE":
+        registration.SetMetricAsMeanSquares()
+    elif metric_u == "CC":
+        registration.SetMetricAsCorrelation()
+    elif metric_u == "ANTSCC":
+        registration.SetMetricAsANTSNeighborhoodCorrelation(radius=20)
+    else:
+        raise ValueError(f"Unknown metric: {metric}. Choose from: MI, MSE, CC, AntsCC")
+
+    registration.SetMetricSamplingStrategy(registration.REGULAR)
+    registration.SetMetricSamplingPercentage(0.25)
+
+    registration.SetOptimizerAsRegularStepGradientDescent(
+        learningRate=0.5,
+        minStep=1e-4,
+        numberOfIterations=max_iterations,
+        relaxationFactor=0.5,
+        gradientMagnitudeTolerance=1e-8,
+    )
+    registration.SetOptimizerScalesFromPhysicalShift()
+
+    registration.SetShrinkFactorsPerLevel([8, 4, 2, 1])
+    registration.SetSmoothingSigmasPerLevel([4, 2, 1, 0])
+    registration.SmoothingSigmasAreSpecifiedInPhysicalUnitsOn()
+    registration.SetInterpolator(sitk.sitkLinear)
+
+    # Centroid-based initial alignment: align the centre-of-tissue of each
+    # volume in physical space.  Falls back to geometric centre when a volume
+    # is entirely zero (shouldn't happen for real data but keeps the function
+    # safe).
+    fixed_center = _tissue_centroid_mm(fixed_vol, fixed_spacing)
+    moving_center = _tissue_centroid_mm(moving_vol, moving_spacing)
+
+    initial_transform = sitk.Euler3DTransform()
+    # SITK XYZ order; numpy axes are ZYX.
+    initial_transform.SetCenter([fixed_center[2], fixed_center[1], fixed_center[0]])
+    initial_transform.SetTranslation(
+        [
+            moving_center[2] - fixed_center[2],
+            moving_center[1] - fixed_center[1],
+            moving_center[0] - fixed_center[0],
+        ]
+    )
+    initial_transform.SetRotation(
+        float(np.deg2rad(initial_rotation_deg[0])),
+        float(np.deg2rad(initial_rotation_deg[1])),
+        float(np.deg2rad(initial_rotation_deg[2])),
+    )
+    if verbose:
+        print(f"Centroid init: fixed={fixed_center} mm, moving={moving_center} mm")
+        print(f"Initial translation: {initial_transform.GetTranslation()} mm (SITK XYZ)")
+
+    registration.SetInitialTransform(initial_transform)
+
+    if verbose or progress_callback is not None:
+
+        def _on_iter(method: Any) -> None:
+            if verbose:
+                if method.GetOptimizerIteration() == 0:
+                    print(f"Estimated scales: {method.GetOptimizerScales()}")
+                print(
+                    f"Iter {method.GetOptimizerIteration():3d} "
+                    f"= {method.GetMetricValue():7.5f} : {method.GetOptimizerPosition()}"
+                )
+            if progress_callback is not None:
+                progress_callback(method)
+
+        registration.AddCommand(sitk.sitkIterationEvent, lambda: _on_iter(registration))
+
+    final_transform = registration.Execute(fixed_image, moving_image)
+    stop = registration.GetOptimizerStopConditionDescription()
+    error = registration.GetMetricValue()
+
+    # Restore crop offsets so the transform is valid for the uncropped
+    # volumes (both still anchored at SITK origin = 0, identity direction).
+    # Derivation.  Let R, c, t_crop be the rigid params learned on the
+    # cropped images.  Cropped fixed coord p_fc maps to uncropped fixed coord
+    # p_ff = p_fc + fixed_off, and similarly for moving.  We want
+    #     T_full(p_ff) = T_crop(p_ff - fixed_off) + moving_off
+    #                  = R(p_ff - fixed_off - c) + c + t_crop + moving_off.
+    # Substituting c' = c + fixed_off gives
+    #     T_full(p_ff) = R(p_ff - c') + c' + (t_crop + moving_off - fixed_off).
+    # So c_new = c + fixed_off and t_new = t_crop + moving_off - fixed_off.
+    if crop_to_bbox and (any(fixed_crop_origin_mm) or any(moving_crop_origin_mm)):
+        # SITK XYZ; our offsets are stored in numpy ZYX, so reverse them.
+        fixed_off_xyz = np.array([fixed_crop_origin_mm[2], fixed_crop_origin_mm[1], fixed_crop_origin_mm[0]])
+        moving_off_xyz = np.array([moving_crop_origin_mm[2], moving_crop_origin_mm[1], moving_crop_origin_mm[0]])
+        c_old = np.array(final_transform.GetCenter())
+        params = list(final_transform.GetParameters())
+        t_old = np.array(params[3:6])
+        c_new = c_old + fixed_off_xyz
+        t_new = t_old + moving_off_xyz - fixed_off_xyz
+        final_transform.SetCenter(c_new.tolist())
+        params[3], params[4], params[5] = float(t_new[0]), float(t_new[1]), float(t_new[2])
+        final_transform.SetParameters(params)
+        if verbose:
+            print(f"Crop-restored translation (SITK XYZ): {tuple(params[3:6])} mm")
+
+    if verbose:
+        print(f"Done: {stop}; metric={error:.6f}")
+
+    return final_transform, stop, error
+
+
+def _crop_to_bbox(
+    volume: np.ndarray, spacing: Sequence[float], margin_voxels: int
+) -> tuple[np.ndarray, tuple[float, float, float]]:
+    """Crop ``volume`` to its non-zero bounding box.
+
+    Returns the cropped array and the physical offset ``(z, y, x)`` of the
+    crop origin in mm.  If the volume is entirely zero the original array
+    and a zero offset are returned.
+    """
+    nonzero = np.nonzero(volume)
+    if len(nonzero[0]) == 0:
+        return volume, (0.0, 0.0, 0.0)
+    slices = tuple(
+        slice(
+            max(0, int(idx.min()) - margin_voxels),
+            min(volume.shape[ax], int(idx.max()) + margin_voxels + 1),
+        )
+        for ax, idx in enumerate(nonzero)
+    )
+    cropped = volume[slices]
+    offset_mm = (
+        slices[0].start * float(spacing[0]),
+        slices[1].start * float(spacing[1]),
+        slices[2].start * float(spacing[2]),
+    )
+    return cropped, offset_mm
+
+
+def _tissue_centroid_mm(volume: np.ndarray, spacing: Sequence[float]) -> tuple[float, float, float]:
+    """Return the centroid of non-zero voxels in mm (numpy ZYX order).
+
+    Falls back to the geometric centre when the volume is entirely zero.
+    """
+    nonzero = np.argwhere(volume > 0)
+    if len(nonzero) == 0:
+        z, y, x = volume.shape
+        return (z / 2.0 * spacing[0], y / 2.0 * spacing[1], x / 2.0 * spacing[2])
+    cz, cy, cx = nonzero.mean(axis=0)
+    return (float(cz) * spacing[0], float(cy) * spacing[1], float(cx) * spacing[2])

--- a/linumpy/tests/test_imaging_orientation.py
+++ b/linumpy/tests/test_imaging_orientation.py
@@ -1,0 +1,369 @@
+"""Tests for linumpy/utils/orientation.py"""
+
+import numpy as np
+import pytest
+
+from linumpy.imaging.orientation import (
+    apply_orientation_transform,
+    parse_orientation_code,
+    reorder_resolution,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_gradient_vol(shape=(4, 6, 8)):
+    """Create a volume where each voxel value encodes its (z, x, y) index."""
+    z, x, y = np.indices(shape)
+    # Unique encoding that allows axis identification
+    return (z * 1000 + x * 100 + y).astype(np.float32)
+
+
+# ---------------------------------------------------------------------------
+# parse_orientation_code -- valid codes
+# ---------------------------------------------------------------------------
+
+
+class TestParseOrientationCodeValid:
+    def test_identity_SAR(self):
+        """SAR is the native target order → identity permutation."""
+        perm, flips = parse_orientation_code("SAR")
+        assert perm == (0, 1, 2)
+        assert flips == (1, 1, 1)
+
+    def test_identity_lowercase(self):
+        """Input is case-insensitive."""
+        perm, flips = parse_orientation_code("sar")
+        assert perm == (0, 1, 2)
+        assert flips == (1, 1, 1)
+
+    def test_PIR(self):
+        """PIR is a common OCT orientation."""
+        perm, flips = parse_orientation_code("PIR")
+        # P→target dim1 (flip), I→target dim0 (flip), R→target dim2.
+        # target_to_source: 0→(1,-1), 1→(0,-1), 2→(2,1)
+        assert perm == (1, 0, 2)
+        assert flips == (-1, -1, 1)
+
+    def test_RAS(self):
+        """RAS source orientation."""
+        perm, flips = parse_orientation_code("RAS")
+        # R→target dim2, A→target dim1, S→target dim0.
+        # target_to_source: 0→(2,1), 1→(1,1), 2→(0,1)
+        assert perm == (2, 1, 0)
+        assert flips == (1, 1, 1)
+
+    def test_LPS(self):
+        """LPS (opposite of RAS)."""
+        perm, flips = parse_orientation_code("LPS")
+        # L→target dim2(flip), P→target dim1(flip), S→target dim0.
+        # target_to_source: 0→(2,1), 1→(1,-1), 2→(0,-1)
+        assert perm == (2, 1, 0)
+        assert flips == (1, -1, -1)
+
+    def test_all_flipped_ILP(self):
+        """ILP: all three axes need to be flipped (I→S, L→R, P→A)."""
+        perm, flips = parse_orientation_code("ILP")
+        # I→target 0(flip), L→target 2(flip), P→target 1(flip)
+        assert all(f == -1 for f in flips)
+        assert sorted(perm) == [0, 1, 2]
+
+    def test_AIR(self):
+        """AIR: A in dim0, I in dim1, R in dim2."""
+        perm, flips = parse_orientation_code("AIR")
+        # A→target 1, I→target 0(flip), R→target 2.
+        # target_to_source: 0→(1,-1), 1→(0,1), 2→(2,1)
+        assert perm == (1, 0, 2)
+        assert flips == (-1, 1, 1)
+
+    def test_output_type_is_tuple(self):
+        perm, flips = parse_orientation_code("SAR")
+        assert isinstance(perm, tuple)
+        assert isinstance(flips, tuple)
+
+    def test_output_perm_length_3(self):
+        perm, flips = parse_orientation_code("PIR")
+        assert len(perm) == 3
+        assert len(flips) == 3
+
+    def test_perm_is_valid_permutation(self):
+        """axis_permutation must be a valid permutation of (0,1,2)."""
+        for code in ("SAR", "PIR", "RAS", "LPS", "AIR", "ILP", "SRA"):
+            perm, _ = parse_orientation_code(code)
+            assert sorted(perm) == [0, 1, 2], f"Bad permutation for {code}: {perm}"
+
+    def test_flips_only_1_or_minus1(self):
+        for code in ("SAR", "PIR", "RAS", "LPS", "AIR", "ILP", "SRA"):
+            _, flips = parse_orientation_code(code)
+            for f in flips:
+                assert f in (1, -1), f"Unexpected flip value {f} for {code}"
+
+
+# ---------------------------------------------------------------------------
+# parse_orientation_code -- error cases
+# ---------------------------------------------------------------------------
+
+
+class TestParseOrientationCodeErrors:
+    def test_too_short(self):
+        with pytest.raises(ValueError, match="3 letters"):
+            parse_orientation_code("SR")
+
+    def test_too_long(self):
+        with pytest.raises(ValueError, match="3 letters"):
+            parse_orientation_code("SRAX")
+
+    def test_invalid_letter(self):
+        with pytest.raises(ValueError, match="Invalid orientation letter"):
+            parse_orientation_code("XRA")
+
+    def test_duplicate_axis_same_direction(self):
+        """RRS has R mapping to target-dim1 twice."""
+        with pytest.raises(ValueError):
+            parse_orientation_code("RRS")
+
+    def test_duplicate_axis_opposite_direction(self):
+        """RLS has R=dim1 and L=dim1 -- same target axis."""
+        with pytest.raises(ValueError):
+            parse_orientation_code("RLS")
+
+    def test_missing_axis(self):
+        """SAI uses neither R nor L so target-dim1 is missing."""
+        # S→dim0, A→dim2, I→dim0 -- actually duplicate! Let's use a truly missing case.
+        # SAP: S→0, A→2, P→2 -- duplicate (A and P both target dim2).
+        with pytest.raises(ValueError):
+            parse_orientation_code("SAP")
+
+
+# ---------------------------------------------------------------------------
+# apply_orientation_transform
+# ---------------------------------------------------------------------------
+
+
+class TestApplyOrientationTransform:
+    def test_identity_permutation_no_flip(self):
+        vol = _make_gradient_vol((4, 6, 8))
+        result = apply_orientation_transform(vol, (0, 1, 2), (1, 1, 1))
+        np.testing.assert_array_equal(result, vol)
+
+    def test_permutation_changes_shape(self):
+        vol = np.zeros((4, 6, 8))
+        result = apply_orientation_transform(vol, (1, 2, 0), (1, 1, 1))
+        assert result.shape == (6, 8, 4)
+
+    def test_flip_axis0(self):
+        vol = np.arange(24).reshape(4, 3, 2).astype(np.float32)
+        result = apply_orientation_transform(vol, (0, 1, 2), (-1, 1, 1))
+        np.testing.assert_array_equal(result, vol[::-1, :, :])
+
+    def test_flip_axis1(self):
+        vol = np.arange(24).reshape(4, 3, 2).astype(np.float32)
+        result = apply_orientation_transform(vol, (0, 1, 2), (1, -1, 1))
+        np.testing.assert_array_equal(result, vol[:, ::-1, :])
+
+    def test_flip_axis2(self):
+        vol = np.arange(24).reshape(4, 3, 2).astype(np.float32)
+        result = apply_orientation_transform(vol, (0, 1, 2), (1, 1, -1))
+        np.testing.assert_array_equal(result, vol[:, :, ::-1])
+
+    def test_permutation_and_flip(self):
+        """Permute (1,0,2) then flip axis0."""
+        vol = np.arange(24).reshape(4, 3, 2).astype(np.float32)
+        result = apply_orientation_transform(vol, (1, 0, 2), (-1, 1, 1))
+        expected = np.transpose(vol, (1, 0, 2))[::-1, :, :]
+        np.testing.assert_array_equal(result, expected)
+
+    def test_does_not_modify_input(self):
+        vol = np.arange(24).reshape(4, 3, 2).astype(np.float32)
+        original = vol.copy()
+        apply_orientation_transform(vol, (1, 2, 0), (-1, 1, -1))
+        np.testing.assert_array_equal(vol, original)
+
+
+# ---------------------------------------------------------------------------
+# Roundtrip: applying orientation + inverse gives back the original
+# ---------------------------------------------------------------------------
+
+
+class TestOrientationRoundtrip:
+    def _inverse_permutation(self, perm):
+        """Compute the inverse of a permutation tuple."""
+        inv = [0] * len(perm)
+        for i, p in enumerate(perm):
+            inv[p] = i
+        return tuple(inv)
+
+    def test_roundtrip_PIR(self):
+        vol = _make_gradient_vol((5, 7, 9))
+        perm, flips = parse_orientation_code("PIR")
+
+        # Forward: source → target (SRA)
+        forward = apply_orientation_transform(vol, perm, flips)
+
+        # Inverse permutation and de-flip
+        inv_perm = self._inverse_permutation(perm)
+        # After inverse permutation flips need to be in the final axis order
+        # The flip axes in the forward result correspond to the target axes.
+        # To undo: first undo flips (same flips since flip is its own inverse),
+        # then apply inverse permutation.
+        unflipped = apply_orientation_transform(forward, (0, 1, 2), flips)  # flip back
+        recovered = apply_orientation_transform(unflipped, inv_perm, (1, 1, 1))
+
+        np.testing.assert_array_equal(recovered, vol)
+
+    def test_roundtrip_RAS(self):
+        vol = _make_gradient_vol((3, 5, 7))
+        perm, flips = parse_orientation_code("RAS")
+
+        forward = apply_orientation_transform(vol, perm, flips)
+
+        inv_perm = self._inverse_permutation(perm)
+        unflipped = apply_orientation_transform(forward, (0, 1, 2), flips)
+        recovered = apply_orientation_transform(unflipped, inv_perm, (1, 1, 1))
+
+        np.testing.assert_array_equal(recovered, vol)
+
+    def test_roundtrip_all_flipped_ILP(self):
+        """A code with all axes needing a flip."""
+        vol = _make_gradient_vol((4, 6, 8))
+        perm, flips = parse_orientation_code("ILP")
+
+        forward = apply_orientation_transform(vol, perm, flips)
+
+        inv_perm = self._inverse_permutation(perm)
+        unflipped = apply_orientation_transform(forward, (0, 1, 2), flips)
+        recovered = apply_orientation_transform(unflipped, inv_perm, (1, 1, 1))
+
+        np.testing.assert_array_equal(recovered, vol)
+
+
+# ---------------------------------------------------------------------------
+# Semantic correctness: after reorientation the expected anatomical axis
+# lands in the expected output dimension.
+# ---------------------------------------------------------------------------
+
+
+class TestOrientationSemantics:
+    """
+    For a volume whose signal varies along a known anatomical axis,
+    confirm that after reorientation the variation is in the expected
+    output dimension.
+    """
+
+    def test_SAR_dim0_is_superior(self):
+        """With 'SAR', dim0 is already Superior.  Reorientation is identity."""
+        # Volume increases only along dim0 (Superior direction)
+        vol = np.zeros((10, 5, 5), dtype=np.float32)
+        vol[:, 2, 2] = np.arange(10)
+
+        perm, flips = parse_orientation_code("SAR")
+        result = apply_orientation_transform(vol, perm, flips)
+
+        # After identity reorientation, variation should still be along dim0
+        assert result.shape[0] == 10
+        col = result[:, 2, 2]
+        assert col[-1] > col[0], "Superior direction should still increase along dim0"
+
+    def test_IAR_superior_flipped_to_dim0(self):
+        """With 'IAR', dim0 is Inferior → after reorientation it becomes Superior (flipped)."""
+        vol = np.zeros((10, 5, 5), dtype=np.float32)
+        vol[:, 2, 2] = np.arange(10)  # value increases in Inferior direction
+
+        perm, flips = parse_orientation_code("IAR")
+        result = apply_orientation_transform(vol, perm, flips)
+
+        # 'IAR': I at dim0 → target dim0 with flip=-1 (Inferior→Superior).
+        # Values increasing along Inferior (dim0 source) should decrease along dim0 output.
+        slice_col = result[:, 2, 2]
+        assert slice_col[0] > slice_col[-1], "After I→S flip, values should decrease along output dim0 (Superior direction)"
+
+    def test_PIR_output_shape(self):
+        """PIR → output shape should be a permutation of input shape."""
+        shape = (10, 15, 20)
+        vol = np.zeros(shape)
+        perm, flips = parse_orientation_code("PIR")
+        result = apply_orientation_transform(vol, perm, flips)
+        # perm=(1,2,0): output shape = (input[1], input[2], input[0]) = (15, 20, 10)
+        assert result.shape == (shape[perm[0]], shape[perm[1]], shape[perm[2]])
+
+
+# ---------------------------------------------------------------------------
+# reorder_resolution
+# ---------------------------------------------------------------------------
+
+
+class TestReorderResolution:
+    def test_identity_permutation(self):
+        res = (0.01, 0.02, 0.03)
+        assert reorder_resolution(res, (0, 1, 2)) == res
+
+    def test_cyclic_permutation(self):
+        res = (0.01, 0.02, 0.03)
+        reordered = reorder_resolution(res, (1, 2, 0))
+        # index 0 of output ← res[1], index 1 ← res[2], index 2 ← res[0]
+        assert reordered == (0.02, 0.03, 0.01)
+
+    def test_reverse_permutation(self):
+        res = (1.0, 2.0, 3.0)
+        reordered = reorder_resolution(res, (2, 1, 0))
+        assert reordered == (3.0, 2.0, 1.0)
+
+    def test_result_is_tuple(self):
+        res = (0.025, 0.025, 0.025)
+        result = reorder_resolution(res, (0, 1, 2))
+        assert isinstance(result, tuple)
+
+    def test_matches_orientation_permutation(self):
+        """reorder_resolution must be consistent with parse_orientation_code."""
+        # For 'PIR': perm=(1, 0, 2)
+        # Source resolution: (0.01, 0.02, 0.03) in (P, I, R) order
+        # After reorientation to (S, A, R):
+        #   target_dim0 = source_dim1 (I), so resolution[target0] = 0.02
+        #   target_dim1 = source_dim0 (P), so resolution[target1] = 0.01
+        #   target_dim2 = source_dim2 (R), so resolution[target2] = 0.03
+        perm, _ = parse_orientation_code("PIR")
+        source_res = (0.01, 0.02, 0.03)
+        result = reorder_resolution(source_res, perm)
+        assert result == (0.02, 0.01, 0.03)
+
+    def test_reorder_preserves_len(self):
+        perm, _ = parse_orientation_code("AIR")
+        res = (0.025, 0.025, 0.025)
+        result = reorder_resolution(res, perm)
+        assert len(result) == 3
+
+
+# ---------------------------------------------------------------------------
+# Integration: parse → apply → reorder gives anatomically consistent result
+# ---------------------------------------------------------------------------
+
+
+class TestIntegration:
+    def test_isotropic_resolution_unchanged_by_reorder(self):
+        """For isotropic data, resolution is the same regardless of permutation."""
+        perm, _ = parse_orientation_code("PIR")
+        res = (0.025, 0.025, 0.025)
+        reordered = reorder_resolution(res, perm)
+        assert all(r == 0.025 for r in reordered)
+
+    def test_volume_shape_after_permutation_matches_reordered_resolution(self):
+        """
+        After applying orientation transform, each output dimension's physical
+        size (shape * resolution) should equal the source physical size for that
+        anatomical axis.
+        """
+        shape = (10, 20, 30)  # (P direction, I direction, R direction) in PIR
+        res = (0.01, 0.02, 0.03)  # resolutions in (P, I, R) order
+
+        vol = np.ones(shape)
+        perm, flips = parse_orientation_code("PIR")
+        result = apply_orientation_transform(vol, perm, flips)
+        reordered_res = reorder_resolution(res, perm)
+
+        # Physical extent in each target dimension
+        for i in range(3):
+            src_dim = perm[i]
+            assert result.shape[i] == shape[src_dim]
+            assert reordered_res[i] == res[src_dim]


### PR DESCRIPTION
> **Stacked PR 4/25 — review order:** #115 → #97 → #98 → #99 → #100 → **#101** → #108 → #106 → #107 → #87 → #116 → #110 → #111 → #40 → #112 → #130 → #131 → #118 → #132 → #121 → #122 → #123 → #124 → #128 → #133 → #134 → #135
>
> Base: `pr-g-diagnostics-analysis`. Stacked on #100; retargets to `main` as upstream PRs merge.

---

## PR #101 — feat: Allen atlas improvements and RAS alignment

Two commits: initial Allen/RAS work, then a fix for the RAS orientation logic plus a full test suite.

### Changes
- **`scripts/linum_align_to_ras.py`** (new, then refined) — align a reconstructed OME-Zarr volume to RAS orientation. Second commit fixes the orientation-code mapping (some axis flips were inverted) and tightens the auto-crop bounding box so background padding is removed consistently.
- **`linumpy/io/allen.py`** — improved Allen atlas download / caching; adds `numpy_to_sitk_image()` and `sitk_image_to_numpy()` helpers used by the align-to-RAS pipeline and by #100's diagnostics.
- **`scripts/linum_download_allen.py`** — cache location made consistent with `linumpy/io/allen.py`; retries on transient HTTP errors.

### Tests
- `linumpy/tests/test_io_allen.py` — full unit coverage for `linumpy/io/allen.py` including the new SimpleITK helpers
- `scripts/tests/test_align_to_ras.py` — regression tests covering the orientation-code mapping and the auto-crop bbox fixes

### Notes
- Uses `linumpy/utils/orientation.py` from #97







