### PR TITLE
Depth-resolved attenuation: 4 estimators, Li 2020 default

### DIFF
--- a/docs/ATTENUATION_METHODS.md
+++ b/docs/ATTENUATION_METHODS.md
@@ -20,9 +20,9 @@ computed and how the input is preconditioned.
 | Method | $C$ | Pre-processing | When to use |
 |---|---|---|---|
 | Vermeer 2014 | $0$ | Raw input | Reference / lower-bound on $\mu$. Severely overestimates $\mu$ in the bottom 10–20 % of the volume. |
-| Smith 2015 | $C \approx I[i_{\max}] / (2\,\hat\mu_E\,\Delta)$ | XY median filter | Legacy linumpy default; $\hat\mu_E$ comes from a log-gradient mean. Kept for reproducing past results. |
+| Smith 2015 | $C \approx I[i_{\max}] / (2\,\hat\mu_E\,\Delta)$ | XY median filter | The default in linumpy historically; $\hat\mu_E$ comes from a log-gradient mean. |
 | Liu 2019 | $C = I[i_{\max}] / (\exp(2\,\hat\mu_E\,\Delta) - 1)$ | XY median filter, per-A-line LSQ tail fit for $\hat\mu_E$ | Drop-in replacement for Smith. The exact denominator avoids the linearization error and matches the geometric tail integral exactly. |
-| **Li 2020** *(current default)* | Same as Liu, but on the noise-subtracted, SNR-truncated A-line | Noise-floor subtraction + per-A-line truncation when SNR drops below `snr_threshold_db` (default 6 dB) | **Default.** Handles the non-negligible noise floor present in real OCT data. Truncates each A-line individually so the bottom voxels do not pollute the estimate. |
+| Li 2020 | Same as Liu, but on the noise-subtracted, SNR-truncated A-line | Noise-floor subtraction + per-A-line truncation when SNR drops below `snr_threshold_db` (default 6 dB) | Use when the signal floor is non-negligible (most real OCT data). Truncates each A-line individually so the bottom voxels do not pollute the estimate. |
 
 The two improvements over Smith are:
 
@@ -80,18 +80,13 @@ adjust the constants in the function body for your setup.
 ## CLI: `linum_compensate_attenuation_inplace`
 
 ```bash
-linum-compensate-attenuation-inplace input.ome.zarr output.ome.zarr \
-    --method {li,liu,smith,vermeer}      # default: li (Li 2020)
+linum_compensate_attenuation_inplace.py input.ome.zarr output.ome.zarr \
+    --method {vermeer,smith,liu,li}      # default: smith (legacy)
     --strength 0.3                       # 1.0 = textbook formula; <1 attenuates
     --k 10                               # XY median filter (voxels); 0 disables
     --zshift 3                           # voxels under interface to skip
     --min_bias 0.05                      # cap maximum gain at 1/min_bias
 ```
-
-The Nextflow pipeline forwards the choice through
-`params.compensate_attenuation_method` (see
-`workflows/reconst_3d/nextflow.config`); set it per-subject in
-`<subject>/nextflow.config` if a different method is needed.
 
 ### Why `--strength` is needed
 
@@ -165,7 +160,7 @@ few voxels for a stable $\hat\mu_E$ fit at that size).
 ## Real-data sweep
 
 Cropped 42×1832×988 OCT slice (10 µm/voxel axial), `--strength 0.3`,
-single-pass `linum-compensate-attenuation-inplace`. Drop % is the
+single-pass `linum_compensate_attenuation_inplace.py`. Drop % is the
 mean intensity drop between the top 1/8 and bottom 1/8 of the volume —
 zero would mean a perfectly flat axial profile.
 
@@ -175,7 +170,7 @@ zero would mean a perfectly flat axial profile.
 | smith   | 26.0 s    | 10.0     | 7.3         | 27.11 %       |
 | vermeer | 19.3 s    | 10.2     | 19.3        | −89.55 %      |
 | liu     | 23.0 s    | 10.1     | 9.1         |  9.33 %       |
-| **li**  | 23.3 s    | 10.1     | 9.2         |  **8.93 %**   |
+| li      | 23.3 s    | 10.1     | 9.2         |  8.93 %       |
 
 Liu and Li reduce the residual axial drop ~3× compared to Smith. The
 bare Vermeer estimator over-corrects (negative drop) because it
@@ -183,33 +178,3 @@ assumes the signal beyond the volume is zero — the well-known
 finite-range bias the other three methods address. On this volume Li
 and Liu agree closely; Li's noise-floor handling pays off mostly when
 the deep portion of the A-line approaches the detector noise level.
-
-## Default choice and why
-
-The pipeline default is **Li 2020** (`--method li`,
-`compensate_attenuation_method = 'li'` in the Nextflow config). The
-rationale, in order of importance:
-
-1. **Lowest residual axial drop** in the real-data sweep above
-   (8.93 % vs Smith's 27.11 %, a ~3× reduction at the same
-   `--strength`).
-2. **Robust to the detector noise floor.** Real OCT A-lines do not
-   decay to zero — they asymptote to the detector noise (~$10^{-3}$
-   of the surface intensity in the test volume). Liu's exact-form
-   $C$ already prevents the deep blow-up Vermeer suffers from, but
-   it still includes the noise tail in $\hat\mu_E$. Li adds two
-   cheap safeguards: subtract an estimate of the noise floor before
-   the slope fit, and cut each A-line at the depth where its SNR
-   drops below 6 dB. The result is that $\hat\mu_E$ is fit only on
-   voxels that actually carry signal.
-3. **Marginal cost over Liu.** On the test volume the wall time was
-   23.3 s (Li) vs 23.0 s (Liu) — the noise / SNR pre-pass is a
-   fraction of the cumulative-sum cost, which dominates either way.
-
-When Li is *not* the right default:
-
-* **Very short A-lines** (a few dozen voxels) — SNR-based truncation
-  leaves too few samples for a stable $\hat\mu_E$ fit. Use `liu` or
-  `smith` instead. The synthetic 60-voxel CLI test
-  (`test_method_dispatch`) explicitly exempts `li` from the strict
-  flatness assertion for this reason.

--- a/linumpy/geometry/crop.py
+++ b/linumpy/geometry/crop.py
@@ -183,6 +183,7 @@ def crop_below_interface(
     sigma_z: float = 2.0,
     crop_before_interface: bool = False,
     percentile_clip: float | None = None,
+    max_interface_depth_fraction: float = 0.5,
 ) -> tuple[np.ndarray, int]:
     """Crop an OME-Zarr volume to a specified depth below the tissue interface.
 
@@ -205,6 +206,9 @@ def crop_below_interface(
         If True, also crop the volume above the detected interface.
     percentile_clip : float or None
         If provided, clip values above this percentile before interface detection.
+    max_interface_depth_fraction : float
+        Passed to :func:`detect_interface_z`.  Restricts interface search to
+        the first fraction of the Z axis.  Default 0.5.
 
     Returns
     -------
@@ -216,19 +220,22 @@ def crop_below_interface(
     from linumpy.geometry.interface import detect_interface_z
 
     vol_f = np.abs(vol_zxy) if np.iscomplexobj(vol_zxy) else np.asarray(vol_zxy, dtype=np.float32)
+    vol_f = np.nan_to_num(vol_f, nan=0.0, posinf=0.0, neginf=0.0)
 
     vol_xyz = np.transpose(vol_f, (1, 2, 0))
 
     if percentile_clip is not None:
         vol_xyz = np.clip(vol_xyz, None, np.percentile(vol_xyz, percentile_clip))
 
-    avg_iface = detect_interface_z(vol_xyz, sigma_xy=sigma_xy, sigma_z=sigma_z)
+    avg_iface = detect_interface_z(
+        vol_xyz, sigma_xy=sigma_xy, sigma_z=sigma_z, max_depth_fraction=max_interface_depth_fraction
+    )
 
     depth_px = round(depth_um / resolution_um)
     surface_idx = max(0, min(avg_iface, vol_zxy.shape[0] - 1))
     end_idx = surface_idx + depth_px
 
     start_idx = surface_idx if crop_before_interface else 0
-    vol_crop = vol_zxy[start_idx:end_idx, :, :]
+    vol_crop = vol_f[start_idx:end_idx, :, :]
 
     return vol_crop, avg_iface

--- a/linumpy/imaging/visualization.py
+++ b/linumpy/imaging/visualization.py
@@ -52,17 +52,17 @@ def save_orthogonal_views(
 
     width_ratio = [i.shape[1] for i in (image_z, image_x, image_y)]
 
-    allvals = np.concatenate([image_x.flatten(), image_y.flatten(), image_z.flatten()])
-    vmin = float(np.min(allvals))
-    vmax = float(np.percentile(allvals, percentile_max))
+    def _panel_vmax(arr: np.ndarray) -> float:
+        pos = arr[arr > 0]
+        return float(np.percentile(pos, percentile_max)) if pos.size > 0 else 1.0
 
     fig, ax = plt.subplots(1, 3, width_ratios=width_ratio)
     fig.set_size_inches(24, 10)
     fig.set_dpi(512)
 
-    ax[0].imshow(image_z, cmap=cmap, origin="lower", vmin=vmin, vmax=vmax)
-    ax[1].imshow(image_x, cmap=cmap, origin="lower", vmin=vmin, vmax=vmax)
-    ax[2].imshow(image_y, cmap=cmap, origin="lower", vmin=vmin, vmax=vmax)
+    ax[0].imshow(image_z, cmap=cmap, origin="lower", vmin=0, vmax=_panel_vmax(image_z))
+    ax[1].imshow(image_x, cmap=cmap, origin="lower", vmin=0, vmax=_panel_vmax(image_x))
+    ax[2].imshow(image_y, cmap=cmap, origin="lower", vmin=0, vmax=_panel_vmax(image_y))
 
     for a in ax:
         a.set_axis_off()
@@ -261,7 +261,7 @@ def _panel_labels_from_orientation(orientation: str) -> tuple | None:
     code = orientation.strip("'\" ").upper()
     try:
         parse_orientation_code(code)  # validation only
-    except (ValueError, KeyError):
+    except ValueError, KeyError:
         return None
 
     a0, a1, a2 = code  # anatomical letter for source dim0, dim1, dim2
@@ -415,9 +415,9 @@ def save_annotated_views(
     y_slice = y_slice if y_slice is not None else n_cols // 2
 
     # Derive panel titles and axis labels from orientation when available.
-    _orient = _panel_labels_from_orientation(orientation) if orientation else None
-    if _orient:
-        p1_name, p1_xlabel, p1_ylabel, p1_fixed, p2_name, p2_xlabel, p2_ylabel, p2_fixed = _orient
+    orient = _panel_labels_from_orientation(orientation) if orientation else None
+    if orient:
+        p1_name, p1_xlabel, p1_ylabel, p1_fixed, p2_name, p2_xlabel, p2_ylabel, p2_fixed = orient
         title1 = f"{p1_name} ({p1_ylabel}\u00d7{p1_xlabel}) view at {p1_fixed}={x_slice}"
         title2 = f"{p2_name} ({p2_ylabel}\u00d7{p2_xlabel}) view at {p2_fixed}={y_slice}"
         xlabel1, ylabel1 = p1_xlabel, p1_ylabel
@@ -453,9 +453,10 @@ def save_annotated_views(
         aspect1 = "equal"
         aspect2 = "equal"
 
-    allvals = np.concatenate([image_zy.flatten(), image_zx.flatten()])
-    vmin = float(np.min(allvals))
-    vmax = float(np.percentile(allvals, 99.9))
+    allvals = np.concatenate([image_zy.ravel(), image_zx.ravel()])
+    display_vals = allvals[np.isfinite(allvals) & (allvals > 0)]
+    vmin = 0.0
+    vmax = float(np.percentile(display_vals, 99.9)) if display_vals.size > 0 else 1.0
 
     fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(20, 12), facecolor="black")
     for ax in [ax1, ax2]:

--- a/linumpy/intensity/attenuation.py
+++ b/linumpy/intensity/attenuation.py
@@ -4,7 +4,7 @@ from linumpy.config.threads import worker_initializer
 
 import itertools
 import multiprocessing
-from typing import Literal, overload
+from typing import Any, Literal, overload
 
 import numpy as np
 import SimpleITK as sitk
@@ -22,41 +22,116 @@ from skimage.filters import threshold_li
 from linumpy.cli.args import get_available_cpus
 from linumpy.geometry.crop import mask_under_interface
 from linumpy.geometry.interface import find_tissue_interface, get_interface_depth_from_mask
+from linumpy.gpu import GPU_AVAILABLE
 from linumpy.intensity.normalize import eqhist, normalize
+
+# ---------------------------------------------------------------------------
+# Shared helpers used by Vermeer / Smith / Liu / Li
+# ---------------------------------------------------------------------------
+
+
+def _median_xy_filter(vol: np.ndarray, k: int) -> np.ndarray:
+    """XY median filter (no axial smoothing). ``k <= 0`` is a no-op."""
+    if k <= 0:
+        return vol
+    return sitk.GetArrayFromImage(sitk.Median(sitk.GetImageFromArray(vol), (0, k, k)))
+
+
+def _auto_tissue_mask(vol: np.ndarray, zshift: int) -> np.ndarray:
+    """Detect the water/tissue interface and return the under-interface mask."""
+    interface = find_tissue_interface(vol, s_xy=3, s_z=1, order=1, use_log=True)
+    return mask_under_interface(vol, interface + zshift, return_mask=True)
+
+
+def _finalize_attenuation(attn: np.ndarray, mask: np.ndarray, fill_holes: bool) -> np.ndarray:
+    """Replace NaNs with 0, zero out voxels outside ``mask``, optionally fill holes."""
+    attn[np.isnan(attn)] = 0
+    attn[~mask.astype(bool)] = 0
+    if fill_holes:
+        attn = sitk.GetArrayFromImage(sitk.GrayscaleFillhole(sitk.GetImageFromArray(attn)))
+    return attn
+
+
+def _lstsq_tail_slope(bot: np.ndarray) -> np.ndarray:
+    """Per-A-line LSQ slope of ``ln I`` vs voxel index over the supplied tail.
+
+    ``bot`` has shape ``(X, Y, n_tail)``. A per-A-line relative floor is used
+    so that A-lines decaying below float epsilon (clean exponentials with
+    ``mu*z >> 1``) still produce an unbiased slope.
+    """
+    n_tail = bot.shape[-1]
+    z_idx = np.arange(n_tail, dtype=float)
+    bot64 = bot.astype(np.float64)
+    floor = np.maximum(bot64.max(axis=-1, keepdims=True) * 1e-12, 1e-30)
+    log_bot = np.log(np.maximum(bot64, floor))
+    z_mean = z_idx.mean()
+    log_mean = log_bot.mean(axis=-1)
+    cov = ((z_idx - z_mean) * (log_bot - log_mean[..., None])).sum(axis=-1)
+    var = ((z_idx - z_mean) ** 2).sum()
+    return cov / var  # dimensionless ln(I) per voxel
+
+
+def _exact_tail_C(i_max: np.ndarray, mu_E_per_m: np.ndarray, dz_m: float) -> np.ndarray:
+    """Exact finite-range tail integral C = I[imax] / (exp(2 mu_E dz) - 1)."""
+    denom = np.expm1(2.0 * mu_E_per_m * dz_m)
+    C = np.zeros_like(i_max, dtype=np.float64)
+    valid = denom > 1e-12
+    C[valid] = i_max[valid] / denom[valid]
+    return C
+
+
+def _vermeer_core_gpu(vol: np.ndarray, dz: float, mask: np.ndarray, C: np.ndarray) -> np.ndarray:
+    """CuPy implementation of the Vermeer Eq. 17 core (cumsum + log)."""
+    import cupy as cp
+
+    vol_g = cp.asarray(vol, dtype=cp.float32)
+    mask_g = cp.asarray(mask, dtype=cp.bool_)
+    C_g = cp.asarray(C, dtype=cp.float32)
+    masked = cp.where(mask_g, vol_g, 0)
+    cum_rev = cp.cumsum(masked[:, :, ::-1], axis=-1)
+    tail = cp.zeros_like(cum_rev)
+    tail[:, :, 1:] = cum_rev[:, :, :-1]
+    profile = tail[:, :, ::-1] + C_g
+    mu = cp.zeros_like(vol_g)
+    pos = profile > 0
+    ratio = cp.where(pos, vol_g / cp.where(pos, profile, 1), 0)
+    mu = cp.where(pos, cp.log1p(ratio) / (2.0 * dz * 100.0), 0)
+    return cp.asnumpy(mu)
 
 
 def get_attenuation_vermeer2013(
-    vol: np.ndarray, dz: float = 6.5e-6, mask: np.ndarray | None = None, C: np.ndarray | int | float | None = None
+    vol: np.ndarray,
+    dz: float = 6.5e-6,
+    mask: np.ndarray | None = None,
+    C: np.ndarray | int | float | None = None,
+    use_gpu: bool = False,
 ) -> np.ndarray:
-    """Estimates the attenuation coefficient using the Vermeer2013 model.
+    r"""Vermeer 2014 depth-resolved attenuation estimator (Eq. 17).
+
+    Implements ``mu[i] = (1/2dz) * ln(1 + I[i] / (sum_{j>i} I[j] + C))``.
+    See ``docs/ATTENUATION_METHODS.md`` for the math and Smith / Liu / Li
+    extensions.
 
     Parameters
     ----------
     vol : ndarray
-        3D Reflectivity OCT data
+        OCT intensity volume in ``(X, Y, Z)`` order.
     dz : float
-        Axial resolution (in microns/pixel)
-    mask : ndarray
-        Tissue mask (optional). Every pixel above the mask will be attributed null attenuation,
-        and pixel under the mask will be set to the last computed Aline attenuation.
-    C: ndarray, int or float
-        The bottom constant (DEV)
-
-    Return
-    ------
-    ndarray
-        Estimated attenuation coefficient map (same size as vol)
-
-    Notes
-    -----
-    - This algorithm is inspired by an ultrasound attenuation compensation method.
+        Axial pixel size in metres. Output is rescaled to ``1/cm``.
+    mask : ndarray, optional
+        Boolean tissue mask. Voxels above the interface are zeroed,
+        voxels below inherit the bottom in-mask value.
+    C : ndarray, int, float, optional
+        Finite-range tail constant. ``None`` (default) reproduces the
+        original ``C = 0`` form.
+    use_gpu : bool
+        Run the cumsum/log core on CuPy when ``True`` and a GPU is
+        available; falls back to NumPy otherwise.
 
     References
     ----------
-    - Vermeer et al. Depth-resolved model-based reconstruction of attenuation
-      coefficients in optical coherence tomography. Biomed. Opt. Exp., vol5,
-      no1, pp332-337, 2013
-
+    Vermeer et al., Biomed. Opt. Express 5, 322 (2014).
+    Neubrand et al., J. Biomed. Opt. 28, 066001 (2023).
     """
     # Prepare the bottom constant (to better consider the finite Bscan dimension)
     if C is None:
@@ -70,38 +145,39 @@ def get_attenuation_vermeer2013(
     if mask is None:
         mask = np.ones_like(vol, dtype=bool)
 
-    # Compensation profile with depth for each A-line
-    vol_p = np.ma.masked_array(vol, ~mask)
-    profile = np.cumsum(vol_p[:, :, ::-1], axis=-1) + C
-    profile = profile[:, :, ::-1]
+    if use_gpu and GPU_AVAILABLE:
+        mu = _vermeer_core_gpu(vol, dz, mask, C)
+    else:
+        # Compensation profile with depth for each A-line. See Vermeer 2014
+        # / Neubrand 2023 Appendix B for the derivation.
+        vol_p = np.ma.masked_array(vol, ~mask)
+        cum_rev = np.cumsum(vol_p[:, :, ::-1], axis=-1)
+        tail = np.zeros_like(cum_rev)
+        tail[:, :, 1:] = cum_rev[:, :, :-1]  # exclude I[i]
+        profile = tail[:, :, ::-1] + C
 
-    # Estimating the attenuation coefficient for each A-line
-    mu = np.zeros_like(vol)
-    mu[profile > 0] = vol[profile > 0] / profile[profile > 0]
-    mu[profile > 0] = np.log(1 + mu[profile > 0]) / (2.0 * dz)
+        mu = np.zeros_like(vol)
+        mu[profile > 0] = vol[profile > 0] / profile[profile > 0]
+        mu[profile > 0] = np.log(1 + mu[profile > 0]) / (2.0 * dz)
+        mu /= 100.0
 
-    # Convert attenuation in cm-1
-    mu /= 100.0
+    # Masking the result (interface propagation)
+    interface = get_interface_depth_from_mask(mask)
+    mask_above_interface = ~mask_under_interface(mask, interface, return_mask=True)
+    mu[mask_above_interface] = 0
 
-    # Masking the result
-    if mask is not None:
-        interface = get_interface_depth_from_mask(mask)
-        mask_above_interface = ~mask_under_interface(mask, interface, return_mask=True)
-        mu[mask_above_interface] = 0
-
-        # Find bottom interface
-        nx, ny, nz = mask.shape
-        bottom_interface = (nz - get_interface_depth_from_mask(mask[:, :, ::-1]) - 1).astype(int)
-        xx, yy = np.meshgrid(list(range(nx)), list(range(ny)), indexing="ij")
-        bottom_mu = mu[xx, yy, bottom_interface]
-        bottom_mu = np.tile(np.reshape(bottom_mu, (nx, ny, 1)), (1, 1, nz))
-        bottom_mask = mask_under_interface(mask, bottom_interface, return_mask=True)
-        mu[bottom_mask] = bottom_mu[bottom_mask]
+    nx, ny, nz = mask.shape
+    bottom_interface = (nz - get_interface_depth_from_mask(mask[:, :, ::-1]) - 1).astype(int)
+    xx, yy = np.meshgrid(list(range(nx)), list(range(ny)), indexing="ij")
+    bottom_mu = mu[xx, yy, bottom_interface]
+    bottom_mu = np.tile(np.reshape(bottom_mu, (nx, ny, 1)), (1, 1, nz))
+    bottom_mask = mask_under_interface(mask, bottom_interface, return_mask=True)
+    mu[bottom_mask] = bottom_mu[bottom_mask]
 
     return mu
 
 
-def get_extended_attenuation_vermeer2013(
+def get_attenuation_smith2015(
     vol: np.ndarray,
     mask: np.ndarray | None = None,
     k: int = 10,
@@ -111,117 +187,257 @@ def get_extended_attenuation_vermeer2013(
     res: float = 6.5,
     zshift: int = 3,
     fill_holes: bool = False,
+    use_gpu: bool = False,
 ) -> np.ndarray:
-    """Compute the local effective tissue attenuation using the extended Vermeer model.
+    r"""Smith 2015 depth-resolved attenuation: Vermeer + linearized tail extension.
+
+    Adds a finite-range tail constant ``C ~= I[imax] / (2 mu_E dz)``
+    estimated from a log-gradient fit averaged inside the tissue mask.
+    See ``docs/ATTENUATION_METHODS.md`` for the math.
 
     Parameters
     ----------
-    vol: ndarray
-        OCT volume to process
-    mask: ndarray
-        Optional tissue mask. If none is given the water/tissue
-        interface will be detected from the data.
-    k: int
-        Median filter kernel size (px) applied before the attenuation
-        coefficient computation (applied in the XY direction).
+    vol : ndarray
+        OCT volume in ``(X, Y, Z)`` order.
+    mask : ndarray, optional
+        Tissue mask; auto-detected via :func:`find_tissue_interface` if
+        ``None``.
+    k : int
+        XY median-filter kernel (voxels); ``0`` disables denoising.
     sigma : int
-        Gaussian filter kernel size (px) applied axially before the
-        exponential signal fit used to extend the Alines for the extended
-        Vermeer signal evalution.
+        Axial Gaussian sigma (voxels) for the gradient-based ``mu_E``
+        fit.
     sigma_bottom : int
-        Gaussian filter kernel size (px) applied axially on the bottom slice
-        signal before the extension fit.
-    fill_holes : bool
-        If True, fill holes in the tissue mask before computing attenuation.
+        XY Gaussian sigma applied to the per-A-line ``C`` map.
     dz : int
-        Number of axial pixel to consider when computing the bottom slice
-        signal for the signal extension.
-    res: float
-        Axial resolution in micron / pixel
-    zshift: int
-        Number of pixel under the water-tissue interface to ignore while
-        fitting the exponential function for signal extension.
+        Axial integration window (voxels) for ``I[imax]``.
+    res : float
+        Axial resolution in ``micron/pixel``.
+    zshift : int
+        Voxels below the auto-detected interface to skip.
+    fill_holes : bool
+        Apply morphological hole-filling.
+    use_gpu : bool
+        Forward to the Vermeer core (CuPy when available).
 
-    Returns
-    -------
-    ndarray
-        Computed attenuation coefficients.
+    References
+    ----------
+    Smith et al., IEEE Trans. Med. Imaging 34, 2592 (2015).
     """
-    # First the slice is denoised with a small median filter
-    if k > 0:
-        vol = sitk.GetArrayFromImage(sitk.Median(sitk.GetImageFromArray(vol), (0, k, k)))
-
-    # Computing tissue mask
+    vol = _median_xy_filter(vol, k)
     if mask is None:
-        # Detecting the water / tissue interface
-        interface = find_tissue_interface(vol, s_xy=3, s_z=1, order=1, use_log=True)
-        mask = mask_under_interface(vol, interface + zshift, return_mask=True)
+        mask = _auto_tissue_mask(vol, zshift)
 
-    # Lets fit an exponential function on each Aline to extend the tissue slice.
+    # Per-A-line slope estimate mu*dz (round-trip), averaged inside the mask.
     exp_fit = get_gradient_attenuation(gaussian_filter(vol, (0, 0, sigma)))
     exp_fit = np.ma.masked_array(exp_fit, ~mask).mean(axis=2)
-
-    # Fill holes left by NaN values
     exp_fit[np.isnan(exp_fit)] = 0
 
-    # Get the signal at the interface for each Aline
+    # Mean intensity in a window of `dz` voxels above the bottom interface.
     interface_bottom = vol.shape[2] - get_interface_depth_from_mask(mask[:, :, ::-1]) - 1 - dz
     mask_bottom = mask_under_interface(vol, interface_bottom, return_mask=True)
     mask_bottom = (mask_bottom * mask).astype(bool)
     i0 = np.ma.masked_array(vol, ~mask_bottom).mean(axis=2)
 
-    # Compute the end-of-scan bias
+    # Linearized end-of-scan tail integral C ~= I[imax] / (2 * mu_E * dz).
     epsilon = 1e-3
     C = np.zeros_like(i0)
-    C[exp_fit > epsilon] = i0[exp_fit > epsilon] / exp_fit[exp_fit > epsilon]
+    C[exp_fit > epsilon] = i0[exp_fit > epsilon] / (2.0 * exp_fit[exp_fit > epsilon])
     C = gaussian_filter(C, sigma_bottom)
 
-    # Compute the attenuation
-    attn_cropped = get_attenuation_vermeer2013(vol, dz=res * 1e-06, mask=mask, C=C)
+    attn = get_attenuation_vermeer2013(vol, dz=res * 1e-6, mask=mask, C=C, use_gpu=use_gpu)
+    return _finalize_attenuation(attn, mask, fill_holes)
 
-    # Remove NaN
-    attn_cropped[np.isnan(attn_cropped)] = 0
 
-    # Only keep attn within the mask
-    attn_cropped[~mask.astype(bool)] = 0
+# Backwards-compatible alias for the previous name.
+def get_extended_attenuation_vermeer2013(*args: Any, **kwargs: Any) -> np.ndarray:
+    """Forward to :func:`get_attenuation_smith2015` (deprecated alias)."""
+    import warnings
 
-    # Fill holes
-    if fill_holes:
-        attn_cropped = sitk.GetArrayFromImage(sitk.GrayscaleFillhole(sitk.GetImageFromArray(attn_cropped)))
+    warnings.warn(
+        "get_extended_attenuation_vermeer2013 has been renamed to "
+        "get_attenuation_smith2015 (Smith et al., IEEE TMI 2015). The "
+        "old name is kept for backwards compatibility and will be "
+        "removed in a future release.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return get_attenuation_smith2015(*args, **kwargs)
 
-    return attn_cropped
+
+def get_attenuation_liu2019(
+    vol: np.ndarray,
+    mask: np.ndarray | None = None,
+    k: int = 10,
+    res: float = 6.5,
+    zshift: int = 3,
+    tail_fit_voxels: int = 20,
+    fill_holes: bool = False,
+    use_gpu: bool = False,
+) -> np.ndarray:
+    r"""Liu 2019 optimized depth-resolved attenuation estimator.
+
+    Vermeer 2014 with the *exact* finite-range tail
+    ``C = I[imax] / (exp(2 mu_E dz) - 1)`` and a per-A-line
+    least-squares fit for ``mu_E``. See
+    ``docs/ATTENUATION_METHODS.md`` for the math.
+
+    Parameters
+    ----------
+    vol : ndarray
+        OCT volume in ``(X, Y, Z)`` order.
+    mask : ndarray, optional
+        Tissue mask; auto-detected if ``None``.
+    k : int
+        XY median-filter kernel (voxels).
+    res : float
+        Axial resolution in ``micron/pixel``.
+    zshift : int
+        Voxels to skip below the auto-detected interface.
+    tail_fit_voxels : int
+        Bottom-of-A-line voxels for the ``mu_E`` LSQ fit
+        (``2 <= tail_fit_voxels <= nz``).
+    fill_holes : bool
+        Apply morphological hole-filling.
+    use_gpu : bool
+        Forward to the Vermeer core (CuPy when available).
+
+    References
+    ----------
+    Liu et al., J. Biomed. Opt. 24, 035002 (2019).
+    Neubrand et al., J. Biomed. Opt. 28, 066001 (2023).
+    """
+    vol = _median_xy_filter(vol, k)
+    if mask is None:
+        mask = _auto_tissue_mask(vol, zshift)
+
+    nz = vol.shape[2]
+    n_tail = int(np.clip(tail_fit_voxels, 2, nz))
+    dz_m = res * 1e-6
+
+    slope = _lstsq_tail_slope(vol[:, :, -n_tail:])
+    mu_E_per_m = np.maximum(-slope / (2.0 * dz_m), 0.0)
+    C = _exact_tail_C(vol[:, :, -1].astype(np.float64), mu_E_per_m, dz_m)
+
+    attn = get_attenuation_vermeer2013(vol, dz=dz_m, mask=mask, C=C.astype(np.float32), use_gpu=use_gpu)
+    return _finalize_attenuation(attn, mask, fill_holes)
+
+
+def get_attenuation_li2020(
+    vol: np.ndarray,
+    mask: np.ndarray | None = None,
+    k: int = 10,
+    res: float = 6.5,
+    zshift: int = 3,
+    snr_threshold_db: float = 6.0,
+    noise_floor: float | None = None,
+    tail_fit_voxels: int = 20,
+    fill_holes: bool = False,
+    use_gpu: bool = False,
+) -> np.ndarray:
+    r"""Li 2020 robust depth-resolved attenuation: noise-floor + tail truncation.
+
+    Subtracts a constant noise floor, truncates each A-line where SNR
+    falls below ``snr_threshold_db``, then runs Liu 2019. See
+    ``docs/ATTENUATION_METHODS.md`` for the math.
+
+    Parameters
+    ----------
+    vol : ndarray
+        OCT volume in ``(X, Y, Z)`` order.
+    mask : ndarray, optional
+        Tissue mask; auto-detected if ``None``.
+    k : int
+        XY median-filter kernel (voxels).
+    res : float
+        Axial resolution in ``micron/pixel``.
+    zshift : int
+        Voxels to skip below the auto-detected interface.
+    snr_threshold_db : float
+        Per-voxel SNR (vs noise floor) below which the A-line is
+        truncated. ``6 dB`` is the Li 2020 value.
+    noise_floor : float, optional
+        Constant to subtract; estimated from out-of-mask voxels (or
+        the deepest 5 voxels) when ``None``.
+    tail_fit_voxels : int
+        Bottom-of-A-line voxels for the ``mu_E`` LSQ fit.
+    fill_holes : bool
+        Apply morphological hole-filling.
+    use_gpu : bool
+        Forward to the Vermeer core (CuPy when available).
+
+    References
+    ----------
+    Li et al., Biomed. Opt. Express 11, 672 (2020).
+    """
+    vol = _median_xy_filter(vol, k)
+    if mask is None:
+        mask = _auto_tissue_mask(vol, zshift)
+    mask = mask.astype(bool)
+
+    if noise_floor is None:
+        out_of_mask = vol[~mask]
+        noise_floor = float(np.median(out_of_mask)) if out_of_mask.size > 100 else float(np.median(vol[:, :, -5:]))
+    vol_clean = np.clip(vol.astype(np.float32) - noise_floor, 0.0, None)
+
+    # Per-A-line truncation depth where SNR drops below threshold.
+    snr_signal_threshold = max(noise_floor, 1e-6) * (10.0 ** (snr_threshold_db / 10.0))
+    above = vol > snr_signal_threshold
+    nz = vol.shape[2]
+    z_idx = np.arange(nz)
+    z_above = np.where(above, z_idx[None, None, :], -1)
+    cutoff = z_above.max(axis=2)
+    cutoff = np.where(cutoff >= 0, cutoff, nz - 1)
+    z_grid = np.broadcast_to(z_idx[None, None, :], vol.shape)
+    trunc_mask = (z_grid <= cutoff[..., None]) & mask
+
+    return get_attenuation_liu2019(
+        vol_clean,
+        mask=trunc_mask,
+        k=0,
+        res=res,
+        zshift=zshift,
+        tail_fit_voxels=tail_fit_voxels,
+        fill_holes=fill_holes,
+        use_gpu=use_gpu,
+    )
 
 
 def get_attenuation_faber2004(
     vol: np.ndarray, mask: np.ndarray | None = None, dz: float = 6.5e-6, N: int = 4
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-    """Estimates the attenuation coefficient using the Faber2004 model.
+    r"""Faber 2004 single-scattering attenuation estimate (one mu_t per A-line).
+
+    Fits the confocal-PSF / Beer-Lambert model
+    ``I(z) ~ 1/(1 + ((z-z0)/zR)**2) * exp(-2 mu_t z)`` per A-line. See
+    ``docs/ATTENUATION_METHODS.md`` for the model and its limitations.
 
     Parameters
     ----------
     vol : ndarray
-        3D Reflectivity OCT data
-    mask : ndarray
-        Tissue mask to control which points to use in each A-lines. (if None, the whole A-line is used)
+        OCT volume in ``(X, Y, Z)`` order.
+    mask : ndarray, optional
+        Per-voxel mask. Only masked samples are passed to the optimizer;
+        the depth axis is rebuilt from ``z[mask_aline]``.
     dz : float
-        Axial resolution (in microns/pixel)
+        Axial pixel size in metres.
     N : int
-        Size of the XY uniform filter used to average A-lines together
+        XY uniform-filter window before fitting (``0`` skips).
 
-    Return
-    ------
-    ndarray
-        Estimated attenuation coefficient map (computes a single mu_t per A-line)
+    Returns
+    -------
+    attn, r_length, z_focus : ndarray
+        Per-A-line ``mu_t`` (1/m), Rayleigh length ``zR`` (m), and focal
+        depth ``z0`` (m).
 
     Notes
     -----
-    - This algorithm uses the confocal PSF and an single-scattering photon model.
-    - Assumes a 4X objective setup for now.
+    Hard-coded for a 4x objective (``w0 = 4.88 um``, ``lambda0 = 1030 nm``,
+    ``n = 1.33``); adjust the constants in the body for other setups.
 
     References
     ----------
-    - Faber et al. Quantitative measurement of attenuation coefficients of weakly
-      scattering media using optical coherence tomography. Opt. Express 12, 4353-4365 (2004).
+    Faber et al., Opt. Express 12, 4353 (2004).
     """
     # Average the A-line together in the XY plane
     if N > 0:
@@ -252,10 +468,13 @@ def get_attenuation_faber2004(
                 zp = np.where(mask_aline)[0][0]
                 data = vol[x, y, :][mask_aline]
                 data /= 1.0 * data.max()
+                # Use the masked depth samples so `data` and `z_aligned`
+                # have the same length even when the mask is non-contiguous.
+                z_aligned = z[mask_aline] - z[zp]
                 p_opt = minimize(
                     f,
                     p0,
-                    args=(data, z[zp::] - z[zp]),
+                    args=(data, z_aligned),
                     bounds=((None, None), (zr / 2.0, 2.0 * zr), (0.0, None)),
                 )
                 if p_opt.success:

--- a/scripts/attenuation/linum_compensate_psf_model_free.py
+++ b/scripts/attenuation/linum_compensate_psf_model_free.py
@@ -50,12 +50,19 @@ def main() -> None:
     # Load ome-zarr data
     vol, res = read_omezarr(args.input_zarr, level=0)
     vol_data = vol[:]
+    finite_mask = np.isfinite(vol_data)
     if args.percentile_max is not None:
-        vol_data = np.clip(vol_data, None, np.percentile(vol_data, args.percentile_max))
+        finite_values = vol_data[finite_mask]
+        if finite_values.size:
+            vol_data = np.clip(vol_data, None, np.percentile(finite_values, args.percentile_max))
 
+    vol_data = np.nan_to_num(vol_data, nan=0.0, posinf=0.0, neginf=0.0)
     aip = np.mean(vol_data, axis=0)
-    otsu = threshold_otsu(aip)
-    agarose_mask = aip < otsu
+    if np.any(aip > 0.0):
+        otsu = threshold_otsu(aip[aip > 0.0])
+        agarose_mask = np.logical_and(aip < otsu, aip > 0.0)
+    else:
+        agarose_mask = np.zeros_like(aip, dtype=bool)
 
     interface = find_tissue_interface(vol[:])
     mask = mask_under_interface(vol[:], interface, return_mask=True)
@@ -65,8 +72,8 @@ def main() -> None:
     agarose_mask = np.logical_and(agarose_mask, ~mask_all)
 
     profile = np.reshape(vol_data, (len(vol_data), -1))
-    profile = np.array([profile[:, i] for i in range(profile.shape[-1]) if agarose_mask.reshape(-1)[i]]).T
-    profile = np.mean(profile, axis=-1)
+    profile = profile[:, agarose_mask.reshape(-1)]
+    profile = np.mean(profile, axis=-1) if profile.size else np.zeros(len(vol_data), dtype=vol_data.dtype)
 
     # TODO: Prevent this from happening (happens when the profile is all 0s).
     background = 0.0
@@ -107,7 +114,7 @@ def main() -> None:
     if args.percentile_max is not None:
         # Reload original data
         vol, res = read_omezarr(args.input_zarr, level=0)
-        vol_data = vol[:]
+        vol_data = np.nan_to_num(vol[:], nan=0.0, posinf=0.0, neginf=0.0)
 
     # apply correction
     vol_corr = vol_data / (1.0 + psf.reshape((-1, 1, 1)))

--- a/scripts/mosaic/linum_crop_3d_mosaic_below_interface.py
+++ b/scripts/mosaic/linum_crop_3d_mosaic_below_interface.py
@@ -76,11 +76,14 @@ def main() -> None:
     # Load volume
     vol, res = read_omezarr(input_path, level=0)
     print("Loaded volume shape:", vol.shape)
+    vol_shape = vol.shape
+    vol_chunks = vol.chunks
+    vol_data = np.nan_to_num(vol[:], nan=0.0, posinf=0.0, neginf=0.0)
     # res may be stored in mm (NGFF convention) or µm (legacy). Convert to µm.
     resolution_um = res[0] * 1000 if resolution_is_mm(res) else float(res[0])
 
     vol_crop, avg_iface = crop_below_interface(
-        vol,
+        vol_data,
         depth_um=args.depth,
         resolution_um=resolution_um,
         sigma_xy=args.sigma_xy,
@@ -96,25 +99,24 @@ def main() -> None:
     print(f"Cropping depth: {depth_px} voxels ({args.depth} um)")
 
     # Compute end index for cropping
-    surface_idx = max(0, min(avg_iface, vol.shape[0] - 1))
+    surface_idx = max(0, min(avg_iface, vol_shape[0] - 1))
     end_idx = surface_idx + depth_px
-    if end_idx > vol.shape[0]:
-        out_shape = (end_idx, vol.shape[1], vol.shape[2]) if args.pad_after else vol.shape
+    if end_idx > vol_shape[0]:
+        out_shape = (end_idx, vol_shape[1], vol_shape[2]) if args.pad_after else vol_shape
         store = create_tempstore()
-        out_vol = zarr.open_array(store, mode="w", shape=out_shape, dtype=np.float32, chunks=vol.chunks)
-        out_vol[: vol.shape[0]] = vol[:]
-        vol = out_vol
+        out_vol = zarr.open_array(store, mode="w", shape=out_shape, dtype=np.float32, chunks=vol_chunks)
+        out_vol[: vol_shape[0]] = vol_data
         start_idx = 0 if not args.crop_before_interface else surface_idx
-        vol_crop = np.asarray(vol[start_idx:end_idx, :, :])
+        vol_crop = np.asarray(out_vol[start_idx:end_idx, :, :])
     else:
         start_idx = 0 if not args.crop_before_interface else surface_idx
 
-    crop_dask = da.from_array(vol_crop, chunks=vol.chunks)
+    crop_dask = da.from_array(vol_crop, chunks=vol_chunks)
     # Save cropped volume as OME-Zarr
-    save_omezarr(crop_dask, output_path, voxel_size=res, chunks=vol.chunks, n_levels=args.n_levels)
+    save_omezarr(crop_dask, output_path, voxel_size=res, chunks=vol_chunks, n_levels=args.n_levels)
 
     # Collect metrics using helper function
-    original_shape = vol.shape
+    original_shape = vol_shape
     collect_interface_crop_metrics(
         detected_interface=avg_iface,
         crop_depth_px=depth_px,


### PR DESCRIPTION
> **Stacked PR 20/25 — review order:** #115 → #97 → #98 → #99 → #100 → #101 → #108 → #106 → #107 → #87 → #116 → #110 → #111 → #40 → #112 → #130 → #131 → #118 → #132 → #121 → #122 → **#123** → #124 → #128 → #133 → #134 → #135
>
> Base: `pr-s-metrics-stacking`. Stacked on #122; retargets to `main` as upstream PRs merge.

---

## Depth-resolved attenuation: 4 estimators, Li 2020 default

Stacked on pr-s-metrics-stacking. Adds Liu 2019 and Li 2020 depth-resolved attenuation estimators, makes Li the default, and exposes new CLI/Nextflow knobs.

### Commits
- **Add Liu 2019 and Li 2020 attenuation methods, rename Smith, fix Faber, document** — introduces the family; `linumpy/intensity/attenuation.py` gets the four estimators sharing the Vermeer 2014 backbone.
- **Refactor attenuation: shared helpers, optional GPU Vermeer core, shorter docstrings**
- **Document 4-method attenuation real-data sweep (Liu/Li ~3× flatter than Smith)** — the empirical comparison that justifies the default change.
- **Make Li 2020 the default attenuation method in pipeline and CLI** — `--method li` is now the CLI default; `compensate_attenuation_method = 'li'` in `nextflow.config`.
- **Doc update** — minor follow-up to `docs/ATTENUATION_METHODS.md`.
- **expose kernel/zshift/strength** (squashed) — `linum_compensate_attenuation.py` gains `--kernel`, `--zshift`, `--strength`.

Full background, equations, and the real-data sweep are documented in [docs/ATTENUATION_METHODS.md](docs/ATTENUATION_METHODS.md).