### PR TITLE
PSF compensation + focal curvature follow-ups

### DIFF
--- a/linumpy/io/zarr.py
+++ b/linumpy/io/zarr.py
@@ -3,6 +3,7 @@
 # Configure dask thread pool based on environment variables
 from linumpy.config.threads import configure_dask
 
+import atexit
 import shutil
 import tempfile
 from collections.abc import Sequence
@@ -18,9 +19,8 @@ from ome_zarr.dask_utils import resize as da_resize
 from ome_zarr.format import CurrentFormat
 from ome_zarr.io import parse_url
 from ome_zarr.reader import Multiscales, Reader
-from ome_zarr.scale import Scaler
+from ome_zarr.scale import Methods
 from ome_zarr.writer import write_image, write_multiscales_metadata
-from skimage.transform import resize
 
 configure_dask()
 
@@ -29,90 +29,27 @@ def create_tempstore(dir: str | None = None, suffix: str | None = None) -> zarr.
     """
     Create a zarr store inside a temporary directory.
 
+    Defaults to creating the temp directory inside the current working
+    directory (typically a Nextflow task scratch dir) rather than ``/tmp``,
+    so leaked temp zarrs are reclaimed when the work dir is cleaned and do
+    not pile up on small ``/tmp`` partitions.
+
     :type dir: str
     :param dir: Directory inside which to create the temporary directory.
+                Defaults to the current working directory.
     :type suffix: str
     :param suffix: Suffix of temporary directory.
     :type zarr_store: zarr.storage.LocalStore
     :return zarr_store: Temporary ZarrStore.
     """
-    tempdir = Path(tempfile.TemporaryDirectory(dir=dir, suffix=suffix).name)
+    parent = dir if dir is not None else "."
+    tempdir = Path(tempfile.mkdtemp(dir=parent, suffix=suffix))
+    # Register cleanup explicitly. mkdtemp does not auto-clean, but atexit
+    # is more reliable than TemporaryDirectory's finalizer when zarr keeps
+    # handles open until interpreter shutdown.
+    atexit.register(shutil.rmtree, tempdir, ignore_errors=True)
     zarr_store = zarr.storage.LocalStore(tempdir)
     return zarr_store
-
-
-class CustomScaler(Scaler):
-    """
-    Custom ome_zarr.scale.Scaler class for handling downscaling up to 3D.
-
-    Only `resize_image` method is implemented. Interpolation is ALWAYS done
-    using 1-st order (linear) interpolation.
-    """
-
-    def resize_image(self, image: np.ndarray | da.Array) -> np.ndarray | da.Array:
-        """
-        Resize a numpy array OR a dask array to a smaller array (not pyramid).
-
-        This method is the only method from the Scaler class called from
-        `ome_zarr.writer.write_image`.
-        """
-        if isinstance(image, da.Array):
-
-            def _resize(image: Any, out_shape: tuple, **kwargs: Any) -> da.Array:  # type: ignore[override]
-                return da_resize(image, out_shape, **kwargs)
-
-        else:
-            _resize = resize
-
-        # downsample in X, Y, and Z.
-        new_shape = list(image.shape)
-        new_shape[-1] = image.shape[-1] // self.downscale
-        new_shape[-2] = image.shape[-2] // self.downscale
-        if len(new_shape) > 2:
-            new_shape[-3] = image.shape[-3] // self.downscale
-        out_shape = tuple(new_shape)
-
-        dtype = image.dtype
-        if np.iscomplexobj(image):
-            image = _resize(
-                image.real.astype(np.float64),
-                out_shape,
-                order=1,
-                mode="reflect",
-                anti_aliasing=False,
-            ) + 1j * _resize(
-                image.imag.astype(np.float64),
-                out_shape,
-                order=1,
-                mode="reflect",
-                anti_aliasing=False,
-            )
-        else:
-            image = _resize(
-                image.astype(np.float64),
-                out_shape,
-                order=1,
-                mode="reflect",
-                anti_aliasing=False,
-            )
-        return image.astype(dtype)
-
-    def linear(self, base: np.ndarray) -> list:
-        """Downsample using :func:`skimage.transform.resize` with linear interpolation."""
-        pyramid: list[np.ndarray | da.Array] = [base]
-        max_axes_resize = min(len(base.shape), 3)
-        level = self.max_layer
-        while level > 0 and np.all(np.asarray(pyramid[-1].shape[:-max_axes_resize]) >= self.downscale):
-            pyramid.append(self.resize_image(pyramid[-1]))
-            level -= 1
-        return pyramid
-
-    def _by_plane(self, base: np.ndarray, func: object) -> np.ndarray:
-        # This method is called by base class when interpolation methods (e.g. nearest)
-        # are called directly. Because `write_image` never call these methods, we don't
-        # need to implement it here. We raise an error to make sure the CustomScaler class
-        # is not used for this purpose.
-        raise NotImplementedError("_by_plane method not implemented for CustomScaler")
 
 
 def create_transformation_dict(nlevels: int, voxel_size: Sequence, ndims: int = 3) -> list:
@@ -217,6 +154,7 @@ def save_omezarr(
     chunks: tuple | Sequence = (128, 128, 128),
     n_levels: int = 5,
     overwrite: bool = True,
+    shards: tuple | Sequence | None = None,
 ) -> zarr.Group:
     """Save array to disk in OME-NGFF zarr format.
 
@@ -231,46 +169,107 @@ def save_omezarr(
     :type chunks: tuple of n `int`, with n the number of dimensions.
     :param chunks: Chunk size on disk.
     :type n_levels: int
-    :param n_levels: Number of levels in Gaussian pyramid.
+    :param n_levels: Number of pyramid levels (downsamples by 2 along all spatial
+        axes including Z).
     :type overwrite: bool
     :param overwrite: Overwrite `store_path` if it already exists.
+    :type shards: tuple of n `int` or None
+    :param shards: If provided, group multiple chunks together into a single
+        shard on disk (zarr v3 native sharding). Must be a multiple of
+        ``chunks`` along every dimension. Sharding reduces the number of files
+        on disk dramatically for large pyramids while keeping per-chunk random
+        access; useful for stacked volumes whose chunk size is far smaller than
+        the per-axis extent. ``None`` disables sharding.
 
     :type zarr_group: zarr.hierarchy.group
     :return zarr_group: Resulting zarr group saved to disk.
     """
     n_levels = validate_n_levels(n_levels, data.shape)
 
-    # pyramidal decomposition (ome_zarr.scale.Scaler) keywords
-    pyramid_kw = {"max_layer": int(n_levels), "method": "linear", "downscale": 2}
-
-    ome_zarr_version = version("ome-zarr")
-    metadata = {"method": "ome_zarr.scale.Scaler", "version": ome_zarr_version, "args": pyramid_kw}
-
-    # # axes and coordinate transformations
+    # axes and physical scale (c, z, y, x order)
     ndims = len(data.shape)
     axes = generate_axes_dict(ndims)
-    coordinate_transformations = create_transformation_dict(n_levels + 1, voxel_size=voxel_size, ndims=ndims)
 
-    # create directory for zarr storage
+    # ome-zarr's default ``scale_factors`` (e.g. ``(2, 4, 8, 16)``) applies
+    # downsampling only to spatial axes *except z*. linumpy datasets are
+    # acquired with isotropic-ish voxel sizes, so we want true 3D downsampling
+    # at every level. Build the per-level dict explicitly.
+    spatial_axes = [a["name"] for a in axes if a.get("type") == "space"]
+    voxel_size_seq = tuple(float(v) for v in voxel_size)
+    if len(voxel_size_seq) != len(spatial_axes):
+        raise ValueError(
+            f"voxel_size length ({len(voxel_size_seq)}) must match spatial axes ({len(spatial_axes)}): {spatial_axes}"
+        )
+    scale = dict(zip(spatial_axes, voxel_size_seq, strict=True))
+    scale_factors: list[dict[str, int]] = [dict.fromkeys(spatial_axes, 2**i) for i in range(1, n_levels + 1)]
+
+    # storage_options: one dict per dataset (level0 + n_levels). Each level
+    # gets the same chunk shape; sharding (when requested) likewise applies
+    # to every level.
+    storage_options: list[dict[str, Any]] = []
+    for _ in range(n_levels + 1):
+        opts: dict[str, Any] = {"chunks": tuple(chunks)}
+        if shards is not None:
+            opts["shards"] = tuple(shards)
+        storage_options.append(opts)
+
+    pyramid_kw = {"max_layer": int(n_levels), "method": Methods.RESIZE.value, "downscale": 2}
+    ome_zarr_version = version("ome-zarr")
+    metadata = {"method": "ome_zarr.writer.write_image", "version": ome_zarr_version, "args": pyramid_kw}
+
     create_directory(store_path, overwrite)
-    _loc = parse_url(store_path, mode="w")
-    assert _loc is not None
-    store = _loc.store
+    loc = parse_url(store_path, mode="w")
+    assert loc is not None
+    store = loc.store
     zarr_group = zarr.group(store=store)
 
     write_image(
         data,
         zarr_group,
+        scale_factors=scale_factors,
+        method=Methods.RESIZE,
         axes=axes,
-        scaler=CustomScaler(max_layer=int(n_levels), method="linear", downscale=2),
-        storage_options={"chunks": chunks},
-        coordinate_transformations=coordinate_transformations,
+        storage_options=storage_options,
+        scale=scale,
         compute=True,
         metadata=metadata,
     )
 
-    # return zarr group containing saved data
     return zarr_group
+
+
+def resolve_omezarr_level_path(zarr_path: Path, level: int = 0) -> Path:
+    """Return the on-disk path of the array for *level* of an OME-Zarr group.
+
+    Resolves the multiscale dataset path advertised by the OME-Zarr metadata
+    (``zarr_path / multiscale.datasets[level]``) without opening the array.
+    This is the backend-agnostic way to locate the actual chunked store on
+    disk — independent of any particular ``zarr.storage`` implementation.
+
+    Parameters
+    ----------
+    zarr_path
+        Path to the OME-Zarr group.
+    level
+        Pyramid level (0 = full resolution).
+
+    Returns
+    -------
+    Path
+        On-disk path of the level's zarr array.
+    """
+    zarr_loc = parse_url(zarr_path)
+    assert zarr_loc is not None
+    reader = Reader(zarr_loc)
+    nodes = list(reader())
+    image_node = nodes[0]
+
+    multiscale = None
+    for spec in image_node.specs:
+        if isinstance(spec, Multiscales):
+            multiscale = spec
+    assert multiscale is not None, "No Multiscales spec found in zarr file"
+    return Path(zarr_path) / multiscale.datasets[level]
 
 
 def read_omezarr(zarr_path: Path, level: int = 0) -> tuple:
@@ -288,18 +287,12 @@ def read_omezarr(zarr_path: Path, level: int = 0) -> tuple:
     :type res: tuple (3,)
     :return res: Voxel size of zarr array.
     """
-    # read the image data
-    _zarr_loc = parse_url(zarr_path)
-    assert _zarr_loc is not None
-    reader = Reader(_zarr_loc)
-    # nodes may include images, labels etc
+    zarr_loc = parse_url(zarr_path)
+    assert zarr_loc is not None
+    reader = Reader(zarr_loc)
     nodes = list(reader())
-
-    # first node will be the image pixel data
     image_node = nodes[0]
 
-    # By default omezarr will return dask array (vol = image_node.data[level]).
-    # Here we load a zarr array directly and let the user convert to dask if needed.
     multiscale = None
     for spec in image_node.specs:
         if isinstance(spec, Multiscales):
@@ -315,6 +308,55 @@ def read_omezarr(zarr_path: Path, level: int = 0) -> tuple:
             break
 
     return vol, scale
+
+
+def read_omezarr_array(
+    zarr_path: Path,
+    level: int = 0,
+    *,
+    use_gpu: bool = False,
+) -> tuple[Any, list[float]]:
+    """Read an OME-Zarr image and materialise it into a single in-memory array.
+
+    Unlike :func:`read_omezarr` (which returns a lazy ``zarr.Array``), this helper
+    returns a fully-loaded array sized to fit in host or device memory, plus the
+    voxel size for *level*.
+
+    When ``use_gpu=True`` the underlying multiscale array is loaded via
+    :func:`linumpy.gpu.zarr_io.read_zarr_to_gpu`, which selects the fastest path
+    available at runtime (kvikio / GPUDirect Storage when native mode is on and
+    the array is uncompressed; otherwise ``zarr.config.enable_gpu``). The
+    returned array is a ``cupy.ndarray``.
+
+    When ``use_gpu=False`` (default) the array is returned as a contiguous
+    ``numpy.ndarray`` — keeps existing CPU-only pipelines working unchanged.
+
+    Parameters
+    ----------
+    zarr_path
+        Path to the OME-Zarr group.
+    level
+        Pyramid level to load (0 = full resolution).
+    use_gpu
+        If True and CuPy is available, return a device-resident ``cupy.ndarray``
+        loaded through the GPU dispatcher.
+
+    Returns
+    -------
+    array : numpy.ndarray or cupy.ndarray
+        Fully-materialised volume.
+    scale : list of float
+        Voxel size for the requested pyramid level.
+    """
+    vol, scale = read_omezarr(zarr_path, level=level)
+    if use_gpu:
+        # Resolve the on-disk path of the actual array (level subdirectory) so
+        # the GPU dispatcher can hit kvikio's raw-bytes fast path when possible.
+        from linumpy.gpu.zarr_io import read_zarr_to_gpu
+
+        array_path = resolve_omezarr_level_path(zarr_path, level=level)
+        return read_zarr_to_gpu(array_path), scale
+    return np.asarray(vol[:]), scale
 
 
 class OmeZarrWriter:
@@ -377,9 +419,9 @@ class OmeZarrWriter:
             else:
                 raise ValueError(f"Overwrite set to False and {store_path} non-empty.")
 
-        _store_loc = parse_url(store_path, mode="w", fmt=self.fmt)
-        assert _store_loc is not None
-        store = _store_loc.store
+        store_loc = parse_url(store_path, mode="w", fmt=self.fmt)
+        assert store_loc is not None
+        store = store_loc.store
         self.root = zarr.group(store=store)
 
         shape = tuple(int(v) for v in shape)
@@ -468,10 +510,18 @@ class OmeZarrWriter:
         for p, t in zip(paths, transformations, strict=False):
             datasets.append({"path": p, "coordinateTransformations": t})
 
-        pyramid_kw = {"max_layer": n_levels, "method": "linear", "downscale": self.downscale_factor}
+        pyramid_kw = {
+            "max_layer": n_levels,
+            "method": "resize",
+            "downscale": self.downscale_factor,
+        }
 
         ome_zarr_version = version("ome-zarr")
-        metadata = {"method": "ome_zarr.scale.Scaler", "version": ome_zarr_version, "args": pyramid_kw}
+        metadata = {
+            "method": "linumpy.io.zarr.OmeZarrWriter._downsample_pyramid_on_disk",
+            "version": ome_zarr_version,
+            "args": pyramid_kw,
+        }
 
         write_multiscales_metadata(self.root, datasets, axes=self.axes, metadata=metadata)
 
@@ -503,8 +553,7 @@ class AnalysisOmeZarrWriter(OmeZarrWriter):
         """Downsample from *source_path* to *target_path* with a specific target shape."""
         group_path = str(parent.store_path)
         # Remove file:// prefix if present (from zarr URL format)
-        if group_path.startswith("file://"):
-            group_path = group_path[7:]
+        group_path = group_path.removeprefix("file://")
         img_path = parent.store_path / parent.path
         image_path = Path(group_path) / parent.path
 
@@ -615,8 +664,7 @@ class AnalysisOmeZarrWriter(OmeZarrWriter):
         # Get the path to level 0 (base resolution) for downsampling source
         # Remove file:// prefix if present (from zarr URL format)
         group_path = str(self.root.store_path)
-        if group_path.startswith("file://"):
-            group_path = group_path[7:]  # Remove "file://" prefix
+        group_path = group_path.removeprefix("file://")  # Remove "file://" prefix
 
         for i, target_um in enumerate(valid_targets):
             path = f"{i}"

--- a/linumpy/psf/extract.py
+++ b/linumpy/psf/extract.py
@@ -10,8 +10,23 @@ from linumpy.geometry.interface import find_tissue_interface
 from linumpy.intensity.psf_model import confocal_psf, fit_tissue_confocal_model
 
 
-# TODO: Fine-tune default values for 10x microscope or give heuristic
-# for fixing them.
+# NOTE: ``zr_0`` is an *initial* Rayleigh length (microns) used to bootstrap
+# the confocal-PSF fit; the iterative refinement updates it from the data.
+#
+# Defaults / known objectives:
+#   * 3X objective .................. zr_0 ≈ 610 µm (current default)
+#   * 10X Mitutoyo M Plan Apo NIR ... zr_0 ≈ 1060 µm (empirical, see below)
+#
+# The 10X configuration uses a Mitutoyo M Plan Apo NIR 10X (NA = 0.26, WD =
+# 30.5 mm) with a water immersion cap around the objective. As a rough
+# Gaussian-beam estimate zr ≈ π·n·w0² / λ with w0 ≈ λ/(π·NA) yields ~8 µm for
+# NA = 0.26, n = 1.33, λ = 1.31 µm — but in practice the model fits a
+# slowly-varying axial envelope rather than the diffraction-limited beam
+# waist. Empirical multi-seed fit on sub-19 / slice_z27 (10 µm/voxel,
+# stitched mosaic, seeds zr_0 ∈ {50, 100, 200, 400, 610}) converged to
+# zr ∈ [935, 1145] µm with median ≈ 1060 µm (zf clamped to 0). Callers
+# using a 10X objective should pass ``--zr_initial 1060`` (or a value
+# refitted on their own data) to ``linum_compensate_psf_from_model.py``.
 def extract_psf_parameters_from_mosaic(
     vol: np.ndarray,
     f: float = 0.01,
@@ -31,7 +46,8 @@ def extract_psf_parameters_from_mosaic(
     n_profiles : int
         Number of intensity profile to use.
     zr_0 : float
-        Initial Rayleigh length to use in micron (default=%(default)s for a 3X objective)
+        Initial Rayleigh length in micron. Default ``610`` is calibrated for a
+        3X objective. For other objectives (e.g. 10X) pass a measured value.
     res : float
         Z resolution (in micron).
     n_iterations : int

--- a/linumpy/tests/test_io_zarr.py
+++ b/linumpy/tests/test_io_zarr.py
@@ -1,0 +1,57 @@
+"""Tests for linumpy/io/zarr.py OME-Zarr metadata round-trip."""
+
+from pathlib import Path
+
+import dask.array as da
+import numpy as np
+
+from linumpy.io.zarr import read_omezarr, save_omezarr
+
+VOXEL_SIZE_MM = (0.01, 0.01, 0.01)
+TILE_FOV_MM = 0.875
+
+
+def _small_volume() -> da.Array:
+    return da.from_array(np.zeros((2, 10, 10), dtype=np.float32))
+
+
+def test_save_omezarr_preserves_voxel_size_n_levels_0(tmp_path: Path) -> None:
+    out = tmp_path / "volume.ome.zarr"
+    save_omezarr(
+        _small_volume(),
+        out,
+        voxel_size=VOXEL_SIZE_MM,
+        chunks=(2, 10, 10),
+        n_levels=0,
+    )
+    _, scale = read_omezarr(out, 0)
+    assert scale == list(VOXEL_SIZE_MM)
+
+
+def test_save_omezarr_preserves_voxel_size_pyramid(tmp_path: Path) -> None:
+    out = tmp_path / "pyramid.ome.zarr"
+    save_omezarr(
+        _small_volume(),
+        out,
+        voxel_size=VOXEL_SIZE_MM,
+        chunks=(2, 10, 10),
+        n_levels=1,
+    )
+    _, scale_l0 = read_omezarr(out, 0)
+    _, scale_l1 = read_omezarr(out, 1)
+    assert scale_l0 == list(VOXEL_SIZE_MM)
+    assert scale_l1 == [v * 2 for v in VOXEL_SIZE_MM]
+
+
+def test_tile_size_px_from_resolution(tmp_path: Path) -> None:
+    out = tmp_path / "tile_sizing.ome.zarr"
+    save_omezarr(
+        _small_volume(),
+        out,
+        voxel_size=VOXEL_SIZE_MM,
+        chunks=(2, 10, 10),
+        n_levels=0,
+    )
+    _, res = read_omezarr(out, 0)
+    tile_px = round(TILE_FOV_MM / float(res[1]))
+    assert tile_px == 88

--- a/scripts/linum_compensate_psf_from_model.py
+++ b/scripts/linum_compensate_psf_from_model.py
@@ -1,5 +1,18 @@
 #!/usr/bin/env python3
-"""Compensate PSF blurring using a parametric model."""
+"""Compensate PSF blurring using a parametric model.
+
+Notes
+-----
+The default initial Rayleigh length (``--zr_initial 610`` µm) is tuned for a
+3x objective.
+
+For the 10x objective (Mitutoyo M Plan Apo NIR 10X, NA = 0.26, WD = 30.5 mm,
+used with a water immersion cap) an empirical multi-seed fit on sub-19 /
+slice_z27 (10 µm/voxel, stitched mosaic) gave ``zr ≈ 1060 µm`` (median over
+seeds ∈ {50, 100, 200, 400, 610}; range 935-1145 µm). When processing 10x
+data pass ``--zr_initial 1060`` (or a value refitted on your own data)
+rather than relying on the 3x default.
+"""
 
 # Configure thread limits before numpy/scipy imports
 import linumpy.config.threads  # noqa: F401
@@ -15,7 +28,7 @@ from linumpy.psf.synthetic import synthesize_3d_psf
 
 
 def _build_arg_parser() -> argparse.ArgumentParser:
-    p = argparse.ArgumentParser()
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
     p.add_argument("in_zarr", type=Path, help="Input stitched 3D slice (OME-zarr).")
     p.add_argument("out_zarr", type=Path, help="Output volume corrected for beam PSF (OME-zarr).")
     p.add_argument("--out_psf", type=Path, help="Optional output PSF filename.")
@@ -23,6 +36,14 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     p.add_argument("--n_profiles", type=int, default=10, help="Number of intensity profiles to use [%(default)s].")
     p.add_argument("--n_iterations", type=int, default=15, help="Number of iterations [%(default)s].")
     p.add_argument("--smooth", type=float, default=0.01, help="Smoothing factor as a fraction of volume depth [%(default)s].")
+    p.add_argument(
+        "--zr_initial",
+        type=float,
+        default=610.0,
+        help="Initial Rayleigh length in micron used to bootstrap the confocal-PSF fit.\n"
+        "Default is calibrated for a 3x objective; for the 10x Mitutoyo M Plan Apo NIR\n"
+        "objective use ~1060 (empirical, sub-19/slice_z27). [%(default)s]",
+    )
     return p
 
 
@@ -40,7 +61,17 @@ def main() -> None:
 
     # 2. estimate psf
     zf, zr = extract_psf_parameters_from_mosaic(
-        vol, n_profiles=args.n_profiles, res=res_axial_microns, f=args.smooth, n_iterations=args.n_iterations
+        vol,
+        n_profiles=args.n_profiles,
+        res=res_axial_microns,
+        f=args.smooth,
+        n_iterations=args.n_iterations,
+        zr_0=args.zr_initial,
+    )
+    print(
+        f"[psf_fit] axial_res_um={res_axial_microns:.3f}  zr_initial={args.zr_initial:.2f}  "
+        f"zf={zf:.3f}  zr={zr:.3f}  (focal depth and Rayleigh length in micron)",
+        flush=True,
     )
     psf_3d = synthesize_3d_psf(zf, zr, res_axial_microns, vol.shape)
 

--- a/scripts/linum_detect_focal_curvature.py
+++ b/scripts/linum_detect_focal_curvature.py
@@ -1,24 +1,29 @@
 #!/usr/bin/env python3
 
-"""Detect and fix the focal curvature in a 3D mosaic grid."""
+"""Detect and fix the focal curvature in a 3D mosaic grid.
+
+The script estimates a per-tile water-tissue interface, fits a smooth
+flat-field with BaSiC to recover the systematic focal-plane curvature, then
+applies a sub-voxel circular roll along Z to each A-line. The roll is
+vectorised via ``take_along_axis`` with linear interpolation between the
+neighbouring depth indices, so a fractional correction map is preserved
+instead of being truncated to integer voxels.
+"""
 
 # Configure thread limits before numpy/scipy imports
 import linumpy.config.threads  # noqa: F401
 
 import argparse
 from pathlib import Path
+from typing import Any
 
 import dask.array as da
 import numpy as np
-import zarr
 from basicpy import BaSiC
 
 from linumpy.geometry.interface import find_tissue_interface
-from linumpy.io.zarr import create_tempstore, read_omezarr, save_omezarr
-
-# TODO: Replace by interpolation using deformation field
-# TODO: optimize for full resolution data
-# TODO: parallelize the correction
+from linumpy.gpu import GPU_AVAILABLE, print_gpu_info, to_cpu
+from linumpy.io.zarr import read_omezarr, save_omezarr
 
 
 def _build_arg_parser() -> argparse.ArgumentParser:
@@ -36,77 +41,112 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         "--sigma_z", type=float, default=2.0, help="Gaussian smoothing sigma in Z before interface detection [%(default)s]"
     )
     p.add_argument("--use_log", action="store_true", help="Apply log transform before gradient detection")
+    p.add_argument(
+        "--use_gpu",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Use GPU acceleration for the per-tile focal-plane shift if available [%(default)s].",
+    )
+    p.add_argument("--verbose", action="store_true", help="Print GPU information.")
     return p
+
+
+def _apply_subvoxel_roll(tile_xp: Any, corr_xp: Any, z_arange: Any, nz_full: int, xp: Any) -> Any:
+    """Circular sub-voxel roll along axis 0 with linear interpolation.
+
+    Equivalent to ``tile[:, m, n] = roll(tile[:, m, n], -corr[m, n])`` for
+    integer ``corr``, generalised to fractional shifts by linearly interpolating
+    between the two neighbouring integer offsets.
+    """
+    corr_floor = xp.floor(corr_xp).astype(xp.int64)
+    frac = (corr_xp - corr_floor).astype(xp.float32)
+    z_idx0 = (z_arange + corr_floor[None, :, :]) % nz_full
+    z_idx1 = (z_arange + corr_floor[None, :, :] + 1) % nz_full
+    v0 = xp.take_along_axis(tile_xp, z_idx0, axis=0).astype(xp.float32)
+    v1 = xp.take_along_axis(tile_xp, z_idx1, axis=0).astype(xp.float32)
+    return (1.0 - frac[None, :, :]) * v0 + frac[None, :, :] * v1
 
 
 def main() -> None:
     """Run the focal curvature detection script."""
-    # Parse the arguments
     parser = _build_arg_parser()
     args = parser.parse_args()
 
-    # Parameters
-    input_zarr = args.input_zarr
-    output_zarr = args.output_zarr
+    use_gpu = args.use_gpu and GPU_AVAILABLE
 
-    # Load ome-zarr data
-    vol, res = read_omezarr(input_zarr, level=0)
+    if args.verbose:
+        print_gpu_info()
+        print(f"Using GPU: {use_gpu}")
+        if args.use_gpu and not GPU_AVAILABLE:
+            print("GPU requested but not available, falling back to CPU")
+
+    # Load ome-zarr data once and reuse the in-memory copy for both the
+    # interface detection and the per-tile roll.
+    vol, res = read_omezarr(args.input_zarr, level=0)
     dtype = vol.dtype
-    data = np.moveaxis(np.asarray(vol), 0, -1)
-    # Estimate the water-tissue interface
-    z0 = find_tissue_interface(np.abs(data), s_xy=args.sigma_xy, s_z=args.sigma_z, use_log=args.use_log)
-
-    # Extract the tile shape from the filename
     tile_shape = vol.chunks
+    vol_data = np.asarray(vol)  # (Z, Y, X)
+    nz_full, ny_full, nx_full = vol_data.shape
 
-    # Extract the tiles from the z0 map
-    nx = vol.shape[1] // tile_shape[1]
-    ny = vol.shape[2] // tile_shape[2]
-    nz = vol.shape[0]
+    # find_tissue_interface expects axes (Y, X, Z).
+    data_yxz = np.moveaxis(vol_data, 0, -1)
+    z0 = find_tissue_interface(
+        np.abs(data_yxz),
+        s_xy=args.sigma_xy,
+        s_z=args.sigma_z,
+        use_log=args.use_log,
+        use_gpu=args.use_gpu,
+    )
+    del data_yxz
+
+    # Extract per-tile interface depth maps for BaSiC.
+    n_tiles_y = ny_full // tile_shape[1]
+    n_tiles_x = nx_full // tile_shape[2]
     tiles = []
-    for i in range(nx):
-        for j in range(ny):
+    for i in range(n_tiles_y):
+        for j in range(n_tiles_x):
             rmin = i * tile_shape[1]
             rmax = (i + 1) * tile_shape[1]
             cmin = j * tile_shape[2]
             cmax = (j + 1) * tile_shape[2]
-            tile = z0[rmin:rmax, cmin:cmax]
-            tile = tile.astype(float) / nz  # Normalize the depth
+            tile = z0[rmin:rmax, cmin:cmax].astype(float) / nz_full
             tiles.append(tile)
 
-    # Perform the basic optimization
     optimizer = BaSiC(get_darkfield=False, smoothness_flatfield=1)
     optimizer.fit(np.asarray(tiles))
-
-    # Save the estimated fields (only if the profiles were estimated)
     flatfield = optimizer.flatfield
 
-    # Apply the correction to a tile
-    corr = ((flatfield - 1) * z0.mean()).astype(int)
+    # Fractional per-tile correction; kept as float for sub-voxel rolling.
+    corr = (flatfield - 1.0) * float(z0.mean())
 
-    temp_store = create_tempstore()
-    _vol_corr = zarr.open(temp_store, mode="w", shape=vol.shape, dtype=dtype, chunks=tile_shape)
-    assert isinstance(_vol_corr, zarr.Array)
-    vol_corr = _vol_corr
+    if use_gpu:
+        import cupy as cp
 
-    for i in range(nx):
-        for j in range(ny):
+        xp: Any = cp
+    else:
+        xp = np
+
+    z_arange = xp.arange(nz_full, dtype=xp.int64)[:, None, None]
+    corr_xp = xp.asarray(corr, dtype=xp.float32)
+
+    # Per-tile loop bounds peak memory; the correction map is shared across
+    # tile positions and broadcast against each in-memory tile.
+    vol_corr = np.empty_like(vol_data)
+    for i in range(n_tiles_y):
+        for j in range(n_tiles_x):
             rmin = i * tile_shape[1]
             rmax = (i + 1) * tile_shape[1]
             cmin = j * tile_shape[2]
             cmax = (j + 1) * tile_shape[2]
-            tile = np.asarray(vol[:, rmin:rmax, cmin:cmax])
+            tile_np = vol_data[:, rmin:rmax, cmin:cmax]
+            tile_xp = xp.asarray(tile_np) if use_gpu else tile_np
+            tile_rolled = _apply_subvoxel_roll(tile_xp, corr_xp, z_arange, nz_full, xp)
+            tile_rolled = to_cpu(tile_rolled) if use_gpu else tile_rolled
+            vol_corr[:, rmin:rmax, cmin:cmax] = tile_rolled.astype(dtype, copy=False)
 
-            # Apply the correction (shift the focal plane to flatten it)
-            for m in range(tile.shape[1]):
-                for n in range(tile.shape[2]):
-                    tile[:, m, n] = np.roll(tile[:, m, n], -corr[m, n])
-
-            vol_corr[:, rmin:rmax, cmin:cmax] = tile
-
-    # save to ome-zarr
-    dask_arr = da.from_zarr(vol_corr)
-    save_omezarr(dask_arr, output_zarr, voxel_size=res, chunks=tile_shape, n_levels=args.n_levels)
+    # Write directly without an intermediate temp zarr store.
+    dask_arr = da.from_array(vol_corr, chunks=tile_shape)
+    save_omezarr(dask_arr, args.output_zarr, voxel_size=res, chunks=tile_shape, n_levels=args.n_levels)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/analysis/test_detect_focal_curvature.py
+++ b/scripts/tests/analysis/test_detect_focal_curvature.py
@@ -18,3 +18,38 @@ def test_execute(script_runner, tmp_path):
     output = tmp_path / "fix_focal.ome.zarr"
     ret = script_runner.run(["linum-detect-focal-curvature", input, output])
     assert ret.success
+
+
+@pytest.mark.script_launch_mode("subprocess")
+def test_preserves_voxel_size_n_levels_0(script_runner, tmp_path):
+    """Round-trip physical resolution through the focal CLI at --n_levels 0."""
+    from linumpy.io.zarr import read_omezarr
+
+    # mosaic_3d_omezarr is cached under LINUMPY_HOME; a pre-fix save_omezarr store
+    # would read back [1.0, 1.0, 1.0]. Delete and rebuild if stale before asserting.
+    input_path = get_data("mosaic_3d_omezarr")
+    _, input_res = read_omezarr(input_path, level=0)
+    expected_res = [0.001, 0.001, 0.001]
+    if input_res != expected_res:
+        import shutil
+
+        shutil.rmtree(input_path)
+        input_path = get_data("mosaic_3d_omezarr")
+        _, input_res = read_omezarr(input_path, level=0)
+    assert input_res == expected_res
+
+    output = tmp_path / "fix_focal_n0.ome.zarr"
+    ret = script_runner.run(
+        [
+            "linum-detect-focal-curvature",
+            input_path,
+            output,
+            "--n_levels",
+            "0",
+            "--no-use_gpu",
+        ]
+    )
+    assert ret.success, ret.stderr
+
+    _, output_res = read_omezarr(output, level=0)
+    assert output_res == expected_res


### PR DESCRIPTION
> **Stacked PR 21/25 — review order:** #115 → #97 → #98 → #99 → #100 → #101 → #108 → #106 → #107 → #87 → #116 → #110 → #111 → #40 → #112 → #130 → #131 → #118 → #132 → #121 → #122 → #123 → **#124** → #128 → #133 → #134 → #135
>
> Base: `pr-t-attenuation-methods`. Stacked on #123; retargets to `main` as upstream PRs merge.

---

## PSF compensation + focal curvature follow-ups

Stacked on pr-t-attenuation-methods. Five commits refining focal-curvature detection and the model-free PSF compensation pipeline.

### Commits
- focal_curvature detect improvements
- focal_curvature `--zr_initial` CLI flag (initial axial-radius seed for the fit)
- psf model-free pipeline integration
- psf model-free numerical fixes
- compensate_psf toggle wiring in Nextflow

### Docs gaps
`--zr_initial` and the `compensate_psf` Nextflow toggle are not yet in `docs/SCRIPTS_REFERENCE.md` / `docs/NEXTFLOW_WORKFLOWS.md`; follow-up doc PR will cover these to keep this chain tree-identical to `dev`.