### PR TITLE
Enable multi-GPU linum-basic illumination correction in pipeline

### DIFF
--- a/workflows/reconst_3d/lib/Helpers.groovy
+++ b/workflows/reconst_3d/lib/Helpers.groovy
@@ -360,4 +360,22 @@ class Helpers {
         echo "[${tag}] CUDA_VISIBLE_DEVICES=\$CUDA_VISIBLE_DEVICES"
         """
     }
+
+    /**
+     * Expose every GPU to the task for intra-process multi-GPU work (e.g.
+     * linum-basic ``fit_mosaic`` z-level fan-out).  Pair with ``maxForks = 1``
+     * on the calling process so concurrent tasks do not oversubscribe devices.
+     *
+     * When ``gpu_count <= 1`` this falls back to :meth:`gpuPinBlock`.
+     */
+    static String gpuExposeAllBlock(params, String tag) {
+        if (!params.use_gpu) return ''
+        def n = params.gpu_count as int
+        if (n <= 1) return gpuPinBlock(params, tag)
+        def devices = (0..(n - 1)).join(',')
+        return """
+        export CUDA_VISIBLE_DEVICES=${devices}
+        echo "[${tag}] CUDA_VISIBLE_DEVICES=\$CUDA_VISIBLE_DEVICES (all GPUs for multi-GPU fit)"
+        """
+    }
 }

--- a/workflows/reconst_3d/nextflow.config
+++ b/workflows/reconst_3d/nextflow.config
@@ -57,6 +57,7 @@ params {
     fix_illum_darkfield_percentile = 10   // Per-pixel percentile across the tile pool used to estimate the additive darkfield when fix_illum_darkfield = true.
     fix_illum_smoothness_flatfield = 0.05 // BaSiC regularization weight for the flatfield. BaSiCPy default is 1.0. Lower values allow finer spatial detail in the estimated flatfield.
     fix_illum_per_z_fit = false      // Fit a separate BaSiC flatfield per axial (depth) plane instead of one global model. Captures depth-dependent illumination variation due to focal curvature. Slower (~N_z x BaSiC fits).
+    fix_illum_multi_gpu = true       // linum-basic only: fan z-level fits across all GPUs (device=cuda). Requires gpu_count > 1; sets maxForks=1 for fix_illumination_basic so each slice owns every GPU.
     crop_interface_out_depth = 600   // Maximum tissue depth to retain after interface crop (µm)
 
     // Axial PSF / beam-profile correction. Runs after stitching, before
@@ -487,9 +488,11 @@ process {
     }
 
     withName: "fix_illumination_basic" {
-        // linum-basic shares the same per-fork GPU footprint as the BaSiCPy path.
-        maxForks = params.use_gpu ? 4 : null
-        // Don't set CUDA_VISIBLE_DEVICES - let linumpy.gpu auto-select GPU with most free memory
+        // Multi-GPU mode: one fork per slice uses all GPUs via linum-basic z-fan-out.
+        // Single-GPU pin mode: up to 4 concurrent slices, one GPU each.
+        maxForks = params.use_gpu
+            ? ((params.fix_illum_multi_gpu && (params.gpu_count as int) > 1) ? 1 : 4)
+            : null
     }
 
     withName: "normalize" {

--- a/workflows/reconst_3d/soct_3d_reconst.nf
+++ b/workflows/reconst_3d/soct_3d_reconst.nf
@@ -643,7 +643,10 @@ process fix_illumination_basic {
     def darkfield_flag = params.fix_illum_darkfield ? "--use_darkfield" : "--no-use_darkfield"
     def tile_fov_flag = params.tile_fov_mm != null ? "--tile_fov_mm ${params.tile_fov_mm}" : ""
     def per_z_fit_flag = params.fix_illum_per_z_fit ? "--per_z_fit" : "--no-per_z_fit"
-    def gpu_pin_block = Helpers.gpuPinBlock(params, "fix_illumination_basic slice=${slice_id}")
+    def use_multi_gpu = params.use_gpu && params.fix_illum_multi_gpu && (params.gpu_count as int) > 1
+    def gpu_pin_block = use_multi_gpu
+        ? Helpers.gpuExposeAllBlock(params, "fix_illumination_basic slice=${slice_id}")
+        : Helpers.gpuPinBlock(params, "fix_illumination_basic slice=${slice_id}")
     """
     ${gpu_pin_block}
     linum-fix-illumination-basic ${mosaic_grid} "mosaic_grid_z${slice_id}_illum_fix.ome.zarr" \


### PR DESCRIPTION
## Summary
- Add `fix_illum_multi_gpu` param (default `true`): when `gpu_count > 1`, `fix_illumination_basic` exposes all GPUs (`CUDA_VISIBLE_DEVICES=0,1,...`) instead of pinning one GPU per task.
- Set `maxForks = 1` for `fix_illumination_basic` in multi-GPU mode so each slice owns every GPU (pairs with linum-basic z-fan-out).
- Add `Helpers.gpuExposeAllBlock()` for the expose-all-GPUs shell preamble.

Requires linum-basic multi-GPU support (companion PR on Linum-BaSiC).

## Server config
Ensure subject `nextflow.config` has:
```groovy
gpu_count = 2
fix_illum_multi_gpu = true   // default in workflows/reconst_3d/nextflow.config
fix_illum_backend = 'linum-basic'
```

## Test plan
- [x] `nextflow lint` on `soct_3d_reconst.nf`
- [ ] Deploy linum-basic PR to server (`uv pip install -e` from branch)
- [ ] Re-run `fix_illumination_basic` on sub-22 with `-resume`; confirm log shows `CUDA_VISIBLE_DEVICES=0,1` and ~2× faster per slice