### PR TITLE
perf: cap PyTorch threads, bump fix_illumination forks, skip intermediate pyramids

### DIFF
--- a/scripts/linum_fix_illumination_3d.py
+++ b/scripts/linum_fix_illumination_3d.py
@@ -57,9 +57,12 @@ def _build_arg_parser() -> argparse.ArgumentParser:
 
 def process_tile(params: dict) -> tuple:
     """Process a tile and add it to the output mosaic."""
-    from linumpy.config.threads import apply_threadpool_limits
+    from linumpy.config.threads import configure_all_libraries
 
-    apply_threadpool_limits()
+    # configure_all_libraries() also caps PyTorch intra-/inter-op threads
+    # (used by BaSiCPy). apply_threadpool_limits() alone misses torch and
+    # lets it default to ~half the host cores, oversubscribing the node.
+    configure_all_libraries()
 
     file = params["slice_file"]
     z = params["z"]


### PR DESCRIPTION
> **Stacked PR 14/25 — review order:** #115 → #97 → #98 → #99 → #100 → #101 → #108 → #106 → #107 → #87 → #116 → #110 → #111 → #40 → #112 → **#130** → #131 → #118 → #132 → #121 → #122 → #123 → #124 → #128 → #133 → #134 → #135
>
> Base: `pr-m-gpu-kvikio`. Stacked on #112; retargets to `main` as upstream PRs merge.

---

## PR — Pipeline performance tuning

Three measurement-driven perf improvements to the `reconst_3d` Nextflow pipeline:

1. **`fix_illumination` thread cap.** `linum_fix_illumination_3d.py` now calls `configure_all_libraries()` to cap PyTorch threads, preventing oversubscription when running multiple forks.
2. **`fix_illumination` maxForks 1 → 4.** Measured: BaSiCPy/PyTorch uses ~374 MiB per fork; 4 forks ≈ 1.5 GB, well under per-GPU capacity.
3. **Skip pyramids on intermediate ome-zarr outputs.** `--n_levels 0` on intermediate steps avoids wasted multiscale generation that's only needed on final outputs.
