### PR TITLE
fix_illum: pool tiles across Z + darkfield/fit knobs (chain tip = dev)

### DIFF
--- a/scripts/linum_fix_illumination_3d.py
+++ b/scripts/linum_fix_illumination_3d.py
@@ -1,62 +1,174 @@
 #!/usr/bin/env python3
-"""Detect and fix the lateral illumination inhomogeneities for each 3D tile of a mosaic grid.
+"""Detect and fix the lateral illumination inhomogeneities of a 3D mosaic grid.
 
-GPU acceleration is used through BaSiCPy (PyTorch backend) when available (--use_gpu, default on).
-When GPU is not available or --no-use_gpu is passed, BaSiCPy runs on CPU and
-multiple processes (--n_processes) can be used to parallelize over Z-planes.
+A single BaSiC flat-/dark-field model is fit on tiles pooled across all axial
+(Z) planes of the input mosaic, then applied uniformly to every plane. This
+removes the per-plane flatfield jitter that produced visible tile-period
+banding in stitched volumes when the model was fit independently per Z.
+
+GPU acceleration is used through BaSiCPy (PyTorch backend) when available.
 """
 
 import linumpy.config.threads  # noqa: F401
 
-import os
+import argparse
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
-# When using multiprocessing with pqdm, we need to limit threads per worker
-# to prevent thread oversubscription.
-if "OMP_NUM_THREADS" not in os.environ:
-    os.environ["OMP_NUM_THREADS"] = "1"
-
-import argparse
-import tempfile
-
 import dask.array as da
-import imageio as io
 import numpy as np
 import zarr
 from basicpy import BaSiC
+from scipy.ndimage import gaussian_filter
 from tqdm.auto import tqdm
 
-from linumpy.cli.args import add_processes_arg, parse_processes_arg
+from linumpy.cli.args import add_processes_arg
 from linumpy.io.zarr import create_tempstore, read_omezarr, save_omezarr
-
-# TODO: add option to export the flatfields and darkfields
 
 
 def _build_arg_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
     p.add_argument("input_zarr", help="Full path to the input zarr file")
     p.add_argument("output_zarr", help="Full path to the output zarr file")
-    p.add_argument("--max_iterations", type=int, default=500, help="Maximum number of iterations for BaSiC. [%(default)s]")
+    p.add_argument(
+        "--max_iterations",
+        type=int,
+        default=500,
+        help="Maximum number of iterations for BaSiC. [%(default)s]",
+    )
     p.add_argument(
         "--percentile_max",
         type=float,
         help="Values above this percentile will be clipped when\nestimating the flatfield (inside range [0-100]).",
     )
     p.add_argument(
+        "--n_levels",
+        type=int,
+        default=5,
+        help="Number of levels in pyramid representation. [%(default)s]",
+    )
+    p.add_argument(
+        "--use_darkfield",
+        default=False,
+        action=argparse.BooleanOptionalAction,
+        help="Estimate an additive darkfield (per-pixel offset) in addition to\n"
+        "the multiplicative flatfield. We do NOT use BaSiC's built-in\n"
+        "`get_darkfield` because on OCT data it diverges (flatfield ends up\n"
+        "all NaN). Instead the darkfield is estimated as a per-pixel low\n"
+        "percentile of the (non-empty) tile pool, subtracted, then BaSiC is\n"
+        "fit on the residual for the flatfield. [%(default)s]",
+    )
+    p.add_argument(
+        "--darkfield_percentile",
+        type=float,
+        default=5.0,
+        help="Per-pixel percentile across the tile pool used to estimate the\n"
+        "additive darkfield when --use_darkfield is set. [%(default)s]",
+    )
+    p.add_argument(
+        "--fit_max_samples",
+        type=int,
+        default=2000,
+        help="Upper bound on the number of tile samples drawn (uniformly\n"
+        "across axial planes) to fit BaSiC. Caps memory at\n"
+        "fit_max_samples * tile_shape * 4 bytes. [%(default)s]",
+    )
+    p.add_argument(
+        "--smoothness_flatfield",
+        type=float,
+        default=1.0,
+        help="BaSiC regularization weight for the flatfield (higher = smoother,\n"
+        "less spatial detail). BaSiCPy default is 1.0. Lower values (e.g. 0.05)\n"
+        "allow the flatfield to capture finer spatial structure at the cost of\n"
+        "overfitting noise. [%(default)s]",
+    )
+    p.add_argument(
+        "--tile_fov_mm",
+        type=float,
+        default=0.0,
+        help="Acquisition tile field-of-view in millimetres. When > 0, the tile\n"
+        "size for BaSiC is computed as round(tile_fov_mm / pixel_size_mm)\n"
+        "instead of using the zarr chunk size. Use the same value as\n"
+        "params.tile_fov_mm in the Nextflow config. [%(default)s]",
+    )
+    p.add_argument(
+        "--per_z_fit",
+        default=False,
+        action=argparse.BooleanOptionalAction,
+        help="Fit a separate BaSiC flatfield model for each axial (Z/depth) plane\n"
+        "using only tiles from that plane. This captures depth-dependent\n"
+        "illumination variation caused by focal curvature. When disabled (default)\n"
+        "a single model is fit across all Z planes (faster, less tile jitter). [%(default)s]",
+    )
+    p.add_argument(
+        "--darkfield_smooth_sigma",
+        type=float,
+        default=0.0,
+        help="Gaussian sigma for spatially smoothing the estimated darkfield image.\n"
+        "Reduces pixel-level noise in the per-pixel percentile estimate. 0 disables. [%(default)s]",
+    )
+    p.add_argument(
+        "--darkfield_z_window",
+        type=lambda v: -1 if v.strip().lower() == "all" else int(v),
+        default=0,
+        help="Number of neighbouring Z planes to include in the darkfield estimation pool\n"
+        "(per_z_fit only). 0 = current plane only. 1 = z+-1 (3x tiles). 'all' = every\n"
+        "Z plane (physically valid: darkfield is depth-independent). [%(default)s]",
+    )
+    p.add_argument(
+        "--flatfield_smooth_sigma",
+        type=float,
+        default=0.0,
+        help="Gaussian sigma for smoothing the BaSiC flatfield after fitting.\n"
+        "Suppresses residual high-frequency tile-period noise in the flatfield. 0 disables. [%(default)s]",
+    )
+    p.add_argument(
         "--use_gpu",
         default=True,
         action=argparse.BooleanOptionalAction,
-        help="Enable GPU acceleration via BaSiCPy (PyTorch backend).\n"
-        "When enabled, tiles are processed sequentially (CUDA cannot be\n"
-        "forked across processes). When disabled, --n_processes is honoured.\n"
-        "[%(default)s]",
+        help="Kept for backward compatibility. BaSiCPy auto-selects the\n"
+        "available device; this flag has no effect. [%(default)s]",
     )
     add_processes_arg(p)
     return p
 
 
-def process_tile(params: dict) -> tuple:
-    """Process a tile and add it to the output mosaic."""
+def _split_into_tiles(plane: np.ndarray, tile_shape: tuple[int, int]) -> np.ndarray:
+    """Split a (Y, X) plane into a (N, ty, tx) stack of tiles in row-major order."""
+    ty, tx = tile_shape
+    ny = plane.shape[0] // ty
+    nx = plane.shape[1] // tx
+    tiles = np.empty((ny * nx, ty, tx), dtype=plane.dtype)
+    for i in range(ny):
+        for j in range(nx):
+            tiles[i * nx + j] = plane[i * ty : (i + 1) * ty, j * tx : (j + 1) * tx]
+    return tiles
+
+
+def _assemble_from_tiles(
+    tiles: np.ndarray,
+    plane_shape: tuple[int, int],
+    tile_shape: tuple[int, int],
+    background: np.ndarray | None = None,
+) -> np.ndarray:
+    """Inverse of `_split_into_tiles`: stitch tiles back into a (Y, X) plane.
+
+    Pixels outside the last complete tile row/column (remainder when
+    plane_shape is not divisible by tile_shape) are filled with *background*
+    when provided, otherwise with zeros.
+    """
+    ty, tx = tile_shape
+    ny = plane_shape[0] // ty
+    nx = plane_shape[1] // tx
+    out = np.zeros(plane_shape, dtype=tiles.dtype) if background is None else np.array(background, dtype=tiles.dtype)
+    for i in range(ny):
+        for j in range(nx):
+            out[i * ty : (i + 1) * ty, j * tx : (j + 1) * tx] = tiles[i * nx + j]
+    return out
+
+
+def main() -> None:
+    """Run function operation."""
     from linumpy.config.threads import configure_all_libraries
 
     # configure_all_libraries() also caps PyTorch intra-/inter-op threads
@@ -64,129 +176,249 @@ def process_tile(params: dict) -> tuple:
     # lets it default to ~half the host cores, oversubscribing the node.
     configure_all_libraries()
 
-    file = params["slice_file"]
-    z = params["z"]
-    tile_shape = params["tile_shape"]
-    max_iterations = params["max_iterations"]
-    p_upper = params["p_upper"]
-    vol = io.v3.imread(str(file))
-    file_output = Path(file).parent / file.name.replace(".tiff", "_corrected.tiff")
-
-    nx = vol.shape[0] // tile_shape[0]
-    ny = vol.shape[1] // tile_shape[1]
-
-    tiles = []
-    for i in range(nx):
-        for j in range(ny):
-            rmin = i * tile_shape[0]
-            rmax = (i + 1) * tile_shape[0]
-            cmin = j * tile_shape[1]
-            cmax = (j + 1) * tile_shape[1]
-            tiles.append(vol[rmin:rmax, cmin:cmax])
-
-    tiles_for_fit = np.asarray(tiles)
-    if np.iscomplexobj(tiles[0]):
-        tiles_for_fit = np.abs(tiles_for_fit).astype(np.float64)
-    if p_upper is not None:
-        tiles_for_fit = np.clip(tiles_for_fit, None, p_upper)
-    optimizer = BaSiC(get_darkfield=False, max_iterations=max_iterations)
-    optimizer.fit(tiles_for_fit)
-
-    try:
-        # TODO: Hasn't been validated for complex input since basicpy has replaced pybasic
-        if np.iscomplexobj(tiles[0]):
-            tiles_real = [t.real for t in tiles]
-            tiles_imag = [t.imag for t in tiles]
-            sign_real = [np.sign(t) for t in tiles_real]
-            sign_imag = [np.sign(t) for t in tiles_imag]
-            tiles_real_corr = optimizer.transform(np.asarray(tiles_real))
-            tiles_imag_corr = optimizer.transform(np.asarray(tiles_imag))
-            tiles_corrected = [
-                (t_real * s_real) + 1j * (t_imag * s_imag)
-                for t_real, t_imag, s_real, s_imag in zip(tiles_real_corr, tiles_imag_corr, sign_real, sign_imag, strict=False)
-            ]
-        else:
-            tiles_corrected = optimizer.transform(np.asarray(tiles))
-    except RuntimeError:
-        print(f"Got runtime error at z={z}")
-        tiles_corrected = np.asarray(tiles)
-
-    vol_output = np.zeros_like(vol)
-    for i in range(nx):
-        for j in range(ny):
-            rmin = i * tile_shape[0]
-            rmax = (i + 1) * tile_shape[0]
-            cmin = j * tile_shape[1]
-            cmax = (j + 1) * tile_shape[1]
-            t = tiles_corrected[i * ny + j]
-            if np.isnan(t).any():
-                print(f"NaN values found in tile {i}, {j} at z={z}. Replacing with zeros.")
-                t = np.nan_to_num(t, nan=0.0, posinf=0.0, neginf=0.0)
-            vol_output[rmin:rmax, cmin:cmax] = t
-
-    io.imsave(str(file_output), vol_output)
-    return z, file_output
-
-
-def main() -> None:
-    """Run function operation."""
     p = _build_arg_parser()
     args = p.parse_args()
 
     input_zarr = Path(args.input_zarr)
     output_zarr = Path(args.output_zarr)
-    n_cpus = parse_processes_arg(args.n_processes)
 
     vol, resolution = read_omezarr(input_zarr, level=0)
-    p_upper = None
-    if args.percentile_max is not None:
-        p_upper = np.percentile(vol[:], args.percentile_max)
-    n_slices = vol.shape[0]
+    n_axial = vol.shape[0]
+    plane_shape = vol.shape[1:]
+    is_complex = np.iscomplexobj(vol[0])
 
-    tmp_dir = tempfile.TemporaryDirectory(suffix="_linum_fix_illumination_3d_slices", dir=output_zarr.parent)
-    params_list = []
-    for z in tqdm(range(n_slices), "Preprocessing slices"):
-        slice_file = Path(tmp_dir.name) / f"slice_{z:03d}.tiff"
-        img = vol[z]
-        io.imsave(str(slice_file), img)
-        params_list.append(
-            {
-                "z": z,
-                "slice_file": slice_file,
-                "tile_shape": vol.chunks[1:],
-                "max_iterations": args.max_iterations,
-                "p_upper": p_upper,
-            }
-        )
-
-    if args.use_gpu and n_cpus > 1:
-        print(f"Note: GPU mode uses sequential processing (ignoring n_processes={n_cpus})")
-
-    if args.use_gpu or n_cpus <= 1:
-        corrected_files = [process_tile(param) for param in tqdm(params_list, desc="Processing tiles")]
+    if args.tile_fov_mm > 0:
+        pixel_size_mm = float(resolution[1])
+        tile_px = round(args.tile_fov_mm / pixel_size_mm)
+        tile_shape: tuple[int, int] = (tile_px, tile_px)
+        print(f"tile_fov_mm={args.tile_fov_mm}: tile_size_px={tile_px} (pixel_size={pixel_size_mm}mm/px)")
     else:
-        from pqdm.processes import pqdm
+        tile_shape = tuple(vol.chunks[1:])
 
-        corrected_files = pqdm(
-            params_list, process_tile, n_jobs=n_cpus, desc="Processing tiles", exception_behaviour="immediate"
-        )
+    ny = plane_shape[0] // tile_shape[0]
+    nx = plane_shape[1] // tile_shape[1]
+    tiles_per_plane = ny * nx
+    if tiles_per_plane == 0:
+        msg = f"Tile shape {tile_shape} does not fit in plane shape {plane_shape}."
+        raise ValueError(msg)
+
+    def _filter_tiles(tiles: np.ndarray) -> np.ndarray:
+        """Remove all-zero padding tiles from a (N, ty, tx) stack."""
+        keep = np.mean(tiles != 0, axis=(1, 2)) > 0.5
+        return tiles[keep]
+
+    def _prep_fit_pool(tiles_arr: np.ndarray, darkfield_ref: np.ndarray | None) -> np.ndarray:
+        """Clip at percentile_max and subtract darkfield_ref if provided."""
+        if args.percentile_max is not None:
+            p_upper = np.percentile(tiles_arr, args.percentile_max)
+            tiles_arr = np.clip(tiles_arr, None, p_upper)
+        if darkfield_ref is not None:
+            tiles_arr = np.clip(tiles_arr - darkfield_ref[None, :, :], 0.0, None)
+        return tiles_arr
+
+    def _fit_basic(tiles_arr: np.ndarray) -> np.ndarray | None:
+        """Fit BaSiC on tiles_arr; return flatfield or None on failure."""
+        opt = BaSiC(get_darkfield=False, max_iterations=args.max_iterations, smoothness_flatfield=args.smoothness_flatfield)
+        opt.fit(tiles_arr)
+        ff = np.asarray(opt.flatfield)
+        if np.isnan(ff).any() or ff.max() <= 0:
+            return None
+        if args.flatfield_smooth_sigma > 0:
+            ff = gaussian_filter(ff.astype(np.float32), sigma=args.flatfield_smooth_sigma).astype(np.float32)
+        return ff
+
+    def _apply_flatfield(tiles: np.ndarray, ff: np.ndarray, df: np.ndarray | None) -> np.ndarray:
+        x = tiles.astype(np.float32, copy=False)
+        if df is not None:
+            x = x - df[None, :, :]
+        return x / ff[None, :, :]
 
     temp_store = create_tempstore(suffix=".zarr")
     vol_output = zarr.open(temp_store, mode="w", shape=vol.shape, dtype=vol.dtype, chunks=vol.chunks)
 
-    # TODO: Rebuilding volume step could be faster
-    for z, f in tqdm(corrected_files, "Rebuilding volume"):
-        slice_vol = io.v3.imread(str(f))
-        vol_output[z] = slice_vol[:]
+    if not args.per_z_fit:
+        # ── Global fit: pool tiles from all axial planes, fit once ──────────
+        # This avoids per-plane jitter that causes tile-period banding after
+        # attenuation correction, at the cost of ignoring depth-dependent
+        # illumination variation due to focal curvature.
+        fit_max_samples = max(args.fit_max_samples, tiles_per_plane)
+        n_planes_for_fit = min(n_axial, max(1, fit_max_samples // tiles_per_plane))
+        fit_z = np.arange(n_axial) if n_planes_for_fit >= n_axial else np.linspace(0, n_axial - 1, n_planes_for_fit, dtype=int)
+
+        fit_pool = []
+        for z in tqdm(fit_z, desc="Loading fit samples"):
+            plane = np.asarray(vol[int(z)])
+            if is_complex:
+                plane = np.abs(plane).astype(np.float64)
+            fit_pool.append(_split_into_tiles(plane, tile_shape))
+        fit_pool_arr = np.concatenate(fit_pool, axis=0)
+        del fit_pool
+
+        n_before_filter = fit_pool_arr.shape[0]
+        fit_pool_arr = _filter_tiles(fit_pool_arr)
+        print(
+            f"Filtered fit pool: {n_before_filter} -> {fit_pool_arr.shape[0]} tiles "
+            f"(dropped {n_before_filter - fit_pool_arr.shape[0]} all-zero/padding tiles)."
+        )
+        if fit_pool_arr.shape[0] == 0:
+            msg = "No non-empty tiles available for BaSiC fit; mosaic grid is empty."
+            raise RuntimeError(msg)
+
+        if args.use_darkfield:
+            darkfield = np.percentile(fit_pool_arr, args.darkfield_percentile, axis=0).astype(np.float32)
+            if args.darkfield_smooth_sigma > 0:
+                darkfield = gaussian_filter(darkfield, sigma=args.darkfield_smooth_sigma).astype(np.float32)
+            print(
+                f"Estimated darkfield (p{args.darkfield_percentile}, sigma={args.darkfield_smooth_sigma}): "
+                f"min={darkfield.min():.4g} max={darkfield.max():.4g} mean={darkfield.mean():.4g}"
+            )
+        else:
+            darkfield = None
+
+        fit_pool_arr = _prep_fit_pool(fit_pool_arr, darkfield)
+
+        print(
+            f"Fitting BaSiC (global; darkfield_pre_subtracted={args.use_darkfield}) on "
+            f"{fit_pool_arr.shape[0]} tile samples drawn from {len(fit_z)} / {n_axial} axial planes."
+        )
+        flatfield = _fit_basic(fit_pool_arr)
+        del fit_pool_arr
+        if flatfield is None:
+            msg = "BaSiC flatfield fit failed. Refusing to proceed."
+            raise RuntimeError(msg)
+
+        ff_stats = f"flatfield: min={flatfield.min():.4g} max={flatfield.max():.4g} mean={flatfield.mean():.4g}"
+        df_stats = (
+            f"darkfield: min={darkfield.min():.4g} max={darkfield.max():.4g} mean={darkfield.mean():.4g}"
+            if darkfield is not None
+            else "darkfield: disabled"
+        )
+        print(f"Fit done. {ff_stats}  {df_stats}")
+
+        for z in tqdm(range(n_axial), desc="Applying flatfield"):
+            plane = np.asarray(vol[z])
+            if is_complex:
+                real_tiles = _split_into_tiles(plane.real.astype(np.float64), tile_shape)
+                imag_tiles = _split_into_tiles(plane.imag.astype(np.float64), tile_shape)
+                sign_real = np.sign(real_tiles)
+                sign_imag = np.sign(imag_tiles)
+                real_corr = _apply_flatfield(np.abs(real_tiles), flatfield, darkfield) * sign_real
+                imag_corr = _apply_flatfield(np.abs(imag_tiles), flatfield, darkfield) * sign_imag
+                tiles_corrected = real_corr + 1j * imag_corr
+            else:
+                tiles = _split_into_tiles(plane, tile_shape)
+                empty_mask = np.all(tiles == 0, axis=(1, 2))
+                tiles_corrected = _apply_flatfield(tiles, flatfield, darkfield)
+                if empty_mask.any():
+                    tiles_corrected[empty_mask] = 0.0
+
+            if np.isnan(tiles_corrected).any():
+                tiles_corrected = np.nan_to_num(tiles_corrected, nan=0.0, posinf=0.0, neginf=0.0)
+
+            vol_output[z] = _assemble_from_tiles(tiles_corrected, plane_shape, tile_shape, background=plane).astype(vol.dtype)
+
+    else:
+        # ── Per-Z fit: fit a separate BaSiC model per axial (depth) plane ───
+        # Captures depth-dependent illumination variation caused by focal
+        # curvature.  Each plane's tile pool is used for both the darkfield
+        # estimate and the flatfield fit.  Planes with too few non-empty tiles
+        # (e.g. near the bottom of the tissue) fall back to the uncorrected
+        # plane.
+        print(f"Per-Z BaSiC fit: {n_axial} planes, {tiles_per_plane} tiles/plane ({tiles_per_plane} tile samples per fit).")
+        min_tiles_for_fit = max(4, tiles_per_plane // 4)
+        n_workers = args.n_processes if args.n_processes and args.n_processes > 0 else 1
+        print(f"  Using {n_workers} parallel worker(s).")
+
+        def _process_plane_perz(z: int) -> tuple[int, np.ndarray]:
+            plane = np.asarray(vol[z])
+            plane_abs = np.abs(plane).astype(np.float64) if is_complex else plane
+
+            tiles = _split_into_tiles(plane_abs, tile_shape)
+            tiles_fit = _filter_tiles(tiles)
+
+            if tiles_fit.shape[0] < min_tiles_for_fit:
+                return z, plane
+
+            if args.use_darkfield:
+                if args.darkfield_z_window != 0:
+                    # -1 = all planes; >0 = z±window neighbours
+                    z_range = (
+                        range(n_axial)
+                        if args.darkfield_z_window == -1
+                        else range(
+                            max(0, z - args.darkfield_z_window),
+                            min(n_axial, z + args.darkfield_z_window + 1),
+                        )
+                    )
+                    df_parts = []
+                    for zz in z_range:
+                        p_nb = np.asarray(vol[zz])
+                        p_nb_abs = np.abs(p_nb).astype(np.float64) if is_complex else p_nb
+                        t = _split_into_tiles(p_nb_abs, tile_shape)
+                        ok = np.mean(t != 0, axis=(1, 2)) > 0.5
+                        df_parts.append(t[ok].astype(np.float32))
+                    df_pool = np.concatenate(df_parts, axis=0)
+                    darkfield_z = np.percentile(df_pool, args.darkfield_percentile, axis=0).astype(np.float32)
+                    del df_pool
+                else:
+                    darkfield_z = np.percentile(tiles_fit, args.darkfield_percentile, axis=0).astype(np.float32)
+                if args.darkfield_smooth_sigma > 0:
+                    darkfield_z = gaussian_filter(darkfield_z, sigma=args.darkfield_smooth_sigma).astype(np.float32)
+            else:
+                darkfield_z = None
+
+            tiles_fit = _prep_fit_pool(tiles_fit.astype(np.float32), darkfield_z)
+            flatfield_z = _fit_basic(tiles_fit)
+
+            if flatfield_z is None:
+                return z, plane
+
+            if is_complex:
+                real_tiles = _split_into_tiles(plane.real.astype(np.float64), tile_shape)
+                imag_tiles = _split_into_tiles(plane.imag.astype(np.float64), tile_shape)
+                sign_real = np.sign(real_tiles)
+                sign_imag = np.sign(imag_tiles)
+                real_corr = _apply_flatfield(np.abs(real_tiles), flatfield_z, darkfield_z) * sign_real
+                imag_corr = _apply_flatfield(np.abs(imag_tiles), flatfield_z, darkfield_z) * sign_imag
+                tiles_corrected = real_corr + 1j * imag_corr
+            else:
+                empty_mask = np.all(tiles == 0, axis=(1, 2))
+                tiles_corrected = _apply_flatfield(tiles.astype(np.float32), flatfield_z, darkfield_z)
+                if empty_mask.any():
+                    tiles_corrected[empty_mask] = 0.0
+
+            if np.isnan(tiles_corrected).any():
+                tiles_corrected = np.nan_to_num(tiles_corrected, nan=0.0, posinf=0.0, neginf=0.0)
+
+            return z, _assemble_from_tiles(tiles_corrected, plane_shape, tile_shape, background=plane).astype(vol.dtype)
+
+        with ThreadPoolExecutor(max_workers=n_workers) as executor:
+            futures = {executor.submit(_process_plane_perz, z): z for z in range(n_axial)}
+            for fut in tqdm(as_completed(futures), total=n_axial, desc="Per-Z fit+apply"):
+                z_idx, corrected_plane = fut.result()
+                vol_output[z_idx] = corrected_plane
 
     out_dask = da.from_zarr(vol_output)
-    min_value = out_dask.min().compute()
-    if min_value < 0:
-        print(f"Minimum value in the output volume is {min_value}. Clipping at 0.")
+    # Sanity-check the corrected volume before saving. A collapsed (~all-zero)
+    # output usually means BaSiC over-fit the darkfield because the fit pool
+    # included padding tiles, or the percentile clip nuked the dynamic range.
+    out_min = float(out_dask.min().compute())
+    out_max = float(out_dask.max().compute())
+    nonzero_frac = float((out_dask != 0).mean().compute())
+    print(f"Corrected volume stats: min={out_min:.4g} max={out_max:.4g} nonzero_frac={nonzero_frac:.4f}")
+    if nonzero_frac < 0.01 or out_max <= 0:
+        msg = (
+            f"Illumination correction collapsed the volume "
+            f"(nonzero_frac={nonzero_frac:.4f}, max={out_max:.4g}). "
+            f"Likely cause: BaSiC over-fit (often with --use_darkfield and "
+            f"too few non-empty tiles). Refusing to write all-zero output."
+        )
+        raise RuntimeError(msg)
+    if out_min < 0:
+        print(f"Minimum value in the output volume is {out_min}. Clipping at 0.")
         out_dask = da.clip(out_dask, 0.0, None)
 
-    save_omezarr(out_dask, output_zarr, voxel_size=resolution, chunks=vol.chunks)
-    tmp_dir.cleanup()
+    save_omezarr(out_dask, output_zarr, voxel_size=resolution, chunks=vol.chunks, n_levels=args.n_levels)
 
 
 if __name__ == "__main__":

--- a/scripts/linum_sweep_illumination.py
+++ b/scripts/linum_sweep_illumination.py
@@ -106,6 +106,7 @@ def run_one_config(
     smoothness_flatfield: float | None,
     working_size: int | None,
     apply_z: list[int],
+    preview_z: int,
     per_z_fit: bool = False,
     darkfield_smooth_sigma: float = 0.0,
     darkfield_z_window: int = 0,
@@ -120,9 +121,9 @@ def run_one_config(
     Returns
     -------
     corrected : dict mapping z-index -> corrected (float32, clipped >= 0)
-    flatfield : (ty, tx) float32 array (representative, from first successful fit)
-    darkfield : (ty, tx) float32 array or None
-    stats     : dict with fit diagnostics
+    flatfield : (ty, tx) float32 array — the model applied to ``preview_z``
+    darkfield : (ty, tx) float32 array or None — the model applied to ``preview_z``
+    stats     : dict with fit diagnostics for ``preview_z``
     """
     n_axial = vol.shape[0]
     plane_shape: tuple[int, int] = (vol.shape[1], vol.shape[2])
@@ -202,9 +203,9 @@ def run_one_config(
     else:
         # ── Per-Z fit ────────────────────────────────────────────────────────
         min_tiles = max(4, tiles_per_plane // 4)
-        flatfield = None
-        darkfield = None
-        n_fit = 0
+        ff_per_z: dict[int, np.ndarray] = {}
+        df_per_z: dict[int, np.ndarray | None] = {}
+        nfit_per_z: dict[int, int] = {}
 
         def _process_plane(z: int) -> tuple[int, np.ndarray, np.ndarray | None, np.ndarray | None, int]:
             plane = vol[z]
@@ -254,14 +255,20 @@ def run_one_config(
             for fut in tqdm(as_completed(plane_futures), total=len(apply_z), desc="  Per-Z fit+apply", leave=False):
                 z_idx, plane_result, ff_z, df_z, n = fut.result()
                 corrected[z_idx] = plane_result
-                if ff_z is not None and flatfield is None:
-                    flatfield = ff_z
-                    darkfield = df_z
-                    n_fit = n
+                if ff_z is not None:
+                    ff_per_z[z_idx] = ff_z
+                    df_per_z[z_idx] = df_z
+                    nfit_per_z[z_idx] = n
 
-        if flatfield is None:
+        if not ff_per_z:
             msg = "Per-Z fit: no plane had enough tiles for a successful BaSiC fit."
             raise RuntimeError(msg)
+
+        # Pick the preview slice's model if available, else the nearest fitted plane.
+        chosen_z = preview_z if preview_z in ff_per_z else min(ff_per_z.keys(), key=lambda z: abs(z - preview_z))
+        flatfield = ff_per_z[chosen_z]
+        darkfield = df_per_z[chosen_z]
+        n_fit = nfit_per_z[chosen_z]
 
     df = darkfield  # alias for stats
     stats: dict = {
@@ -637,6 +644,7 @@ def main() -> None:
                 smoothness_flatfield=smooth_ff,
                 working_size=int(ws) if ws is not None else None,
                 apply_z=apply_z,
+                preview_z=z_slice,
                 per_z_fit=per_z,
                 darkfield_smooth_sigma=df_sig if df_sig is not None else 0.0,
                 darkfield_z_window=df_zw,


### PR DESCRIPTION
> **Stacked PR 23/25 — review order:** #115 → #97 → #98 → #99 → #100 → #101 → #108 → #106 → #107 → #87 → #116 → #110 → #111 → #40 → #112 → #130 → #131 → #118 → #132 → #121 → #122 → #123 → #124 → #128 → **#133** → #134 → #135
>
> Base: `pr-w-linum-basic`. Stacked on #128; retargets to `main` as upstream PRs merge.

---

## fix_illum: pool tiles across Z + darkfield/fit knobs

Stacked on pr-v-psf-focal. Phase 6 infra work continues on #134 (`pr-x-infra-quality`).

### Commits
- **feat(fix_illum): pool tiles across Z, expose darkfield/fit_max_samples/max_iterations** (squashed from 5 commits) — `linum_compensate_illumination.py` now pools tiles across Z slices for a more stable flat-field estimate and exposes three new knobs in `nextflow.config`:
  - `fix_illum_darkfield` (bool) — fit a darkfield term
  - `fix_illum_fit_max_samples` (int) — cap samples per fit for speed
  - `fix_illum_max_iterations` (int) — BaSiC solver iteration cap
- **chore: update uv.lock** (squashed)

### Docs gaps
The three new `fix_illum_*` params are not yet in `docs/NEXTFLOW_WORKFLOWS.md`; follow-up doc PR.

### Chain summary
This is PR 23/24. Phase 6 infrastructure & quality commits route to #134 on the chain tip.