### PR TITLE
CI guardrails: coverage gate + PR-size check + full CI suite

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,118 @@
+name: Build and Publish Docker image
+
+on:
+  push:
+    branches: ["main", "dev"]
+    tags: ["v*"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7.0.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4.2.0
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4.3.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v6.2.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=edge,enable=${{ github.ref == 'refs/heads/dev' }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v7.3.0
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  docker-smoke-2-5d:
+    needs: build-and-push
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+
+    env:
+      IMAGE_REPO: ghcr.io/linum-uqam/linumpy
+      IMAGE_TAG: ${{ github.ref == 'refs/heads/dev' && 'edge' || 'latest' }}
+
+    steps:
+      - uses: actions/checkout@v7.0.0
+
+      - uses: actions/setup-java@v5.4.0
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v4.3.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull linumpy container image
+        run: |
+          IMAGE="${IMAGE_REPO}:${IMAGE_TAG}"
+          for attempt in $(seq 1 12); do
+            if docker pull "$IMAGE"; then
+              echo "LINUMPY_IMAGE=$IMAGE" >> "$GITHUB_ENV"
+              exit 0
+            fi
+            echo "Pull attempt ${attempt}/12 failed; waiting 30s for registry..."
+            sleep 30
+          done
+          echo "Failed to pull ${IMAGE_REPO}:${IMAGE_TAG}"
+          exit 1
+
+      - name: Install Nextflow
+        run: |
+          wget -qO nextflow https://github.com/nextflow-io/nextflow/releases/latest/download/nextflow
+          chmod +x nextflow
+          sudo mv nextflow /usr/local/bin/
+
+      - name: Run 2.5D Docker smoke (convert_to_omezarr real executor)
+        run: |
+          nextflow run workflows/reconst_2.5d/soct_2.5d_reconst.nf \
+            -c workflows/reconst_2.5d/soct_2.5d_reconst_docker.config \
+            -with-docker "$LINUMPY_IMAGE" \
+            --directory workflows/reconst_2.5d/tests/data \
+            -stub \
+            -process.convert_to_omezarr.stub false \
+            2>&1 | tee nextflow-docker-smoke.log
+
+      - name: Upload Nextflow smoke log
+        if: always()
+        uses: actions/upload-artifact@v7.0.0
+        with:
+          name: nextflow-docker-smoke-log
+          path: nextflow-docker-smoke.log

--- a/.github/workflows/nextflow-ci.yml
+++ b/.github/workflows/nextflow-ci.yml
@@ -1,0 +1,55 @@
+name: Nextflow CI
+
+on:
+  push:
+    branches: ["main", "dev"]
+    paths:
+      - "workflows/**"
+      - ".github/workflows/nextflow-ci.yml"
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "workflows/**"
+      - ".github/workflows/nextflow-ci.yml"
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7.0.0
+
+      - uses: actions/setup-java@v5.4.0
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Install Nextflow
+        run: |
+          wget -qO nextflow https://github.com/nextflow-io/nextflow/releases/latest/download/nextflow
+          chmod +x nextflow
+          sudo mv nextflow /usr/local/bin/
+
+      - name: Install nf-test
+        run: |
+          NF_TEST_VERSION=0.9.5
+          wget -qO nf-test.tar.gz "https://github.com/askimed/nf-test/releases/download/v${NF_TEST_VERSION}/nf-test-${NF_TEST_VERSION}.tar.gz"
+          tar -xzf nf-test.tar.gz
+          mkdir -p "$HOME/.nf-test"
+          mv nf-test.jar "$HOME/.nf-test/nf-test.jar"
+          sudo mv nf-test /usr/local/bin/nf-test
+          sudo chmod +x /usr/local/bin/nf-test
+
+      - name: Lint Nextflow files
+        run: |
+          nextflow lint -project-dir workflows/preproc workflows/preproc/preproc_rawtiles.nf
+          nextflow lint -project-dir workflows/reconst_3d workflows/reconst_3d/soct_3d_reconst.nf
+          nextflow lint -project-dir workflows/reconst_2.5d workflows/reconst_2.5d/soct_2.5d_reconst.nf
+
+      - name: Validate Nextflow configs
+        run: |
+          nextflow config workflows/preproc/nextflow.config -profile standard || true
+          nextflow config workflows/reconst_3d/nextflow.config -profile standard || true
+
+      - name: Run nf-test stub runs
+        run: nf-test test --stop-on-first-failure workflows/preproc/tests/ workflows/reconst_3d/tests/ workflows/reconst_2.5d/tests/

--- a/.github/workflows/pr-size-check.yml
+++ b/.github/workflows/pr-size-check.yml
@@ -1,0 +1,74 @@
+# PR size check — warning only.
+# Posts a comment on PRs exceeding team size conventions (500 lines or 20 files).
+# This check NEVER fails the job: it is advisory, with reviewer discretion for
+# mechanical/refactoring PRs.
+name: PR size check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  size-check:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    steps:
+    - uses: actions/checkout@v7.0.0
+      with:
+        fetch-depth: 0
+
+    - name: Compute diff size and comment if oversized
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        BASE="${{ github.base_ref }}"
+        PR_NUMBER="${{ github.event.pull_request.number }}"
+
+        # Diff stat against the PR base ref.
+        # `git diff --stat` prints a final summary line like:
+        #   N files changed, M insertions(+), K deletions(-)
+        STAT=$(git diff --stat "origin/${BASE}...HEAD")
+        echo "::group::git diff --stat origin/${BASE}...HEAD"
+        echo "${STAT}"
+        echo "::endgroup::"
+
+        # Number of files changed = count of non-summary lines in the stat output.
+        FILES_CHANGED=$(echo "${STAT}" | grep -cE ' *\| ' || true)
+
+        # Total changed lines = insertions + deletions, parsed from the summary line.
+        INS=$(echo "${STAT}" | tail -n 1 | grep -oE '[0-9]+ insertion' | grep -oE '[0-9]+' || echo 0)
+        DELS=$(echo "${STAT}" | tail -n 1 | grep -oE '[0-9]+ deletion' | grep -oE '[0-9]+' || echo 0)
+        LINES_CHANGED=$((INS + DELS))
+
+        echo "Files changed: ${FILES_CHANGED}"
+        echo "Lines changed: ${LINES_CHANGED}"
+
+        MAX_FILES=20
+        MAX_LINES=500
+
+        if [ "${FILES_CHANGED}" -gt "${MAX_FILES}" ] || [ "${LINES_CHANGED}" -gt "${MAX_LINES}" ]; then
+          BODY=$(printf '%s\n' \
+            '### PR size advisory' \
+            '' \
+            "This PR exceeds the team's size conventions:" \
+            '' \
+            "- **Files changed:** ${FILES_CHANGED} (threshold: ${MAX_FILES})" \
+            "- **Lines changed:** ${LINES_CHANGED} (threshold: ${MAX_LINES})" \
+            '' \
+            'This is a **warning only** — the check does not fail. Reviewer discretion' \
+            'applies for mechanical/refactoring PRs. If this PR is intentional' \
+            'large-scale refactoring, no action is needed. Otherwise, consider splitting' \
+            'it into smaller PRs to ease review.')
+          gh pr comment "${PR_NUMBER}" --body "${BODY}"
+          echo "Posted size-advisory comment on PR #${PR_NUMBER}."
+        else
+          echo "PR within size conventions; no comment posted."
+        fi
+        # Never exit non-zero — this is a warning-only check.
+        exit 0

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,32 +3,28 @@ name: Build and Publish Toolkit
 on:
   push:
     tags:
-      - v1.*
-    workflow_dispatch:
+      - "v1.*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
 jobs:
   build_and_publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
-      - name: Set up Python 3.10
-        uses: actions/setup-python@v3
-        with:
-          python-version: "3.10"
-      - name: Install pypa/build
-        run: >-
-          python -m
-          pip install
-          build
-          --user
-      - name: Build a binary wheel and a source tarball
-        run: >-
-          python -m
-          build
-          --sdist
-          --wheel
-          --outdir dist/
-          .
+      - uses: actions/checkout@v7.0.0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.2.0
+
+      - name: Set up Python 3.14
+        run: uv python install 3.14
+
+      - name: Build sdist and wheel
+        run: uv build --sdist --wheel --out-dir dist/
+
       - name: Publish distribution to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@v1.14.0
         with:
           password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,37 +1,39 @@
-# This workflow will install Python dependencies, run tests and lint with a single version of Python
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
-
 name: Python application
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main", "dev"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main", "dev"]
 
 permissions:
   contents: read
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Install uv
-      uses: astral-sh/setup-uv@v5
-    - name: Set up Python 3.12
-      run: uv python install 3.12
-    - name: Install dependencies
-      run: uv sync
-    - name: Lint with ruff
-      run: |
-        uv run ruff check .
-        uv run ruff format --check .
-    - name: Type check with ty
-      continue-on-error: true
-      run: uv run ty check
-    - name: Test with pytest
-      run: |
-        uv run pytest
+      - uses: actions/checkout@v7.0.0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.2.0
+        with:
+          enable-cache: true
+
+      - name: Set up Python 3.14
+        run: uv python install 3.14
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Lint with ruff
+        run: |
+          uv run ruff check .
+          uv run ruff format --check .
+
+      - name: Type check with ty
+        run: uv run ty check
+
+      - name: Test with pytest
+        run: uv run pytest --cov=linumpy --cov-report=term-missing --cov-fail-under=25

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12
+FROM python:3.14
 
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -176,6 +176,14 @@ filterwarnings = [
     "ignore:linum_stack_slices_3d.py is deprecated:DeprecationWarning",
 ]
 
+# --- Coverage ---
+# linumpy/gpu/ is included in the coverage target. CPU-fallback/mock-CuPy tests
+# are written for GPU modules where feasible; actual CUDA execution is verified
+# manually on the GPU server, not via CI.
+[tool.coverage.run]
+source = ["linumpy"]
+omit = ["linumpy/tests/*"]
+
 [tool.setuptools.packages.find]
 include = ["linumpy*", "scripts*"]
 


### PR DESCRIPTION
## Summary

Adds the full CI suite to `linum-uqam/main` so every subsequent PR (including the rebuild PRs) is governed by automated quality gates.

## What's included

- **`.github/workflows/python-app.yml`** — lint (`ruff check`), format check (`ruff format --check`), type check (`ty check`), and `pytest --cov=linumpy --cov-report=term-missing --cov-fail-under=25`
- **`.github/workflows/pr-size-check.yml`** — advisory warning comment for PRs >500 lines or >20 files (`continue-on-error`, never fails the job)
- **`.github/workflows/nextflow-ci.yml`** — Nextflow lint + nf-test stub runs for `workflows/preproc` and `workflows/reconst_3d`
- **`.github/workflows/docker-publish.yml`** — Docker build/publish to `ghcr.io` + 2.5D smoke test
- **`.github/workflows/publish.yaml`** — replaced legacy `setup-python` flow with `uv`-based build
- **`Dockerfile`** — bumped `python:3.12` to `python:3.14` to match CI Python version
- **`pyproject.toml`** — workflow-related tooling config

All GitHub Actions pinned to latest releases: `actions/checkout@v7.0.0`, `astral-sh/setup-uv@v8.2.0`, `docker/setup-buildx-action@v4.2.0`, `docker/login-action@v4.3.0`, `docker/metadata-action@v6.2.0`, `docker/build-push-action@v7.3.0`, `actions/setup-java@v5.4.0`, `actions/upload-artifact@v7.0.0`, `pypa/gh-action-pypi-publish@v1.14.0`.

## Coverage threshold

`--cov-fail-under=25` is the **current `origin/main` baseline**. The 70% target is only achievable after the rebuild PRs (with their test commits) merge in a later plan; enforcing 70% now would block every rebuild PR.

## Merge order

This PR is the **second** of two — the config PR (#136: AGENTS.md, CODEOWNERS, CONTRIBUTING.md) was merged first so `CODEOWNERS` exists before the branch-protection review rule references it. Merge this PR next; branch protection is configured immediately after.

## Verification

- All 37 rebuilt branches already proven CI-clean against this exact workflow suite (Plan 02)
- `pr-size-check` is advisory only — non-blocking
