### PR TITLE
Add GPU acceleration subpackage linumpy.gpu (CuPy + CPU fallback)

### DIFF
--- a/linumpy/gpu/__init__.py
+++ b/linumpy/gpu/__init__.py
@@ -1,0 +1,455 @@
+"""
+GPU acceleration module for linumpy.
+
+This module provides GPU-accelerated versions of compute-intensive operations
+using CuPy. All functions have automatic fallback to CPU (NumPy) if:
+- CuPy is not installed
+- No CUDA-capable GPU is available
+- GPU memory is insufficient
+
+Usage::
+
+    from linumpy.gpu import GPU_AVAILABLE, get_array_module
+
+    # Check if GPU is available
+    if GPU_AVAILABLE:
+        print("GPU acceleration enabled")
+
+    # Get appropriate array module (cupy or numpy)
+    xp = get_array_module(use_gpu=True)
+
+    # Use GPU-accelerated functions
+    from linumpy.gpu.fft_ops import gpu_phase_correlation
+    from linumpy.gpu.interpolation import gpu_affine_transform
+    from linumpy.gpu.registration import GPUAcceleratedRegistration
+
+Configuration:
+    Set USE_GPU=false environment variable to disable GPU globally.
+"""
+
+import operator
+import os
+import warnings
+from typing import Any
+
+import numpy as np
+from numpy.typing import ArrayLike
+
+# Check for GPU availability
+GPU_AVAILABLE = False
+CUPY_AVAILABLE = False
+GPU_DEVICE_NAME = "N/A"
+GPU_MEMORY_GB = 0
+
+# Allow disabling GPU via environment variable
+_USE_GPU_ENV = os.environ.get("LINUMPY_USE_GPU", "true").lower()
+_GPU_DISABLED_BY_ENV = _USE_GPU_ENV in ("false", "0", "no")
+
+if not _GPU_DISABLED_BY_ENV:
+    try:
+        import cupy as cp
+
+        # Test if CUDA is actually available
+        try:
+            n_devices = cp.cuda.runtime.getDeviceCount()
+
+            if n_devices > 0:
+                # Pick a GPU. If CUDA_VISIBLE_DEVICES is set externally
+                # (e.g. by Nextflow), cupy already sees only the allowed
+                # cards and n_devices reflects that — just use device 0.
+                # Otherwise round-robin across physical devices using a
+                # file-locked counter. This is robust against the race
+                # where many forks start concurrently and would all pick
+                # the "GPU with most free memory" snapshot at the same
+                # time. It is also indifferent to which work items are in
+                # flight, unlike workload-id modulo schemes.
+                if n_devices == 1 or os.environ.get("CUDA_VISIBLE_DEVICES"):
+                    best_gpu_id = 0
+                else:
+                    import fcntl
+                    import tempfile
+                    from pathlib import Path
+
+                    counter_path = Path(tempfile.gettempdir()) / f"linumpy_gpu_counter_{os.getuid()}"
+                    # Open or create the counter, take an exclusive lock,
+                    # increment, release. This serialises the assignment
+                    # decision across all linumpy processes on the host.
+                    with counter_path.open("a+") as fp:
+                        fcntl.flock(fp.fileno(), fcntl.LOCK_EX)
+                        fp.seek(0)
+                        try:
+                            counter = int((fp.read() or "0").strip())
+                        except ValueError:
+                            counter = 0
+                        best_gpu_id = counter % n_devices
+                        fp.seek(0)
+                        fp.truncate()
+                        fp.write(str(counter + 1))
+                        fp.flush()
+                        fcntl.flock(fp.fileno(), fcntl.LOCK_UN)
+
+                cp.cuda.Device(best_gpu_id).use()
+
+                CUPY_AVAILABLE = True
+                GPU_AVAILABLE = True
+
+                # Get device info for selected GPU
+                device = cp.cuda.Device(best_gpu_id)
+                GPU_DEVICE_NAME = device.name if hasattr(device, "name") else f"GPU {device.id}"
+                mem_info = device.mem_info
+                GPU_MEMORY_GB = mem_info[1] / (1024**3)  # Total memory in GB
+
+                if n_devices > 1:
+                    import sys
+
+                    print(
+                        f"Selected GPU {best_gpu_id}/{n_devices}: {GPU_DEVICE_NAME} ({mem_info[0] / (1024**3):.1f} GB free)",
+                        file=sys.stderr,
+                    )
+            else:
+                CUPY_AVAILABLE = True
+                GPU_AVAILABLE = False
+
+        except cp.cuda.runtime.CUDARuntimeError as e:
+            warnings.warn(f"CuPy installed but CUDA not available: {e}", stacklevel=2)
+            CUPY_AVAILABLE = True
+            GPU_AVAILABLE = False
+
+    except ImportError:
+        pass
+else:
+    warnings.warn("GPU disabled via LINUMPY_USE_GPU environment variable", stacklevel=2)
+
+
+def get_array_module(use_gpu: bool = True) -> Any:
+    """
+    Get the appropriate array module (cupy or numpy).
+
+    Parameters
+    ----------
+    use_gpu : bool
+        Whether to use GPU if available.
+
+    Returns
+    -------
+    module
+        cupy if GPU available and use_gpu=True, else numpy
+    """
+    if use_gpu and GPU_AVAILABLE:
+        import cupy as cp
+
+        return cp
+    else:
+        import numpy as np
+
+        return np
+
+
+def to_gpu(array: ArrayLike) -> Any:
+    """
+    Transfer array to GPU if available.
+
+    Parameters
+    ----------
+    array : np.ndarray
+        Input array
+
+    Returns
+    -------
+    array
+        CuPy array if GPU available, else original numpy array
+    """
+    if GPU_AVAILABLE:
+        import cupy as cp
+
+        if isinstance(array, cp.ndarray):
+            return array
+        return cp.asarray(array)
+    return array
+
+
+def to_cpu(array: ArrayLike) -> np.ndarray:
+    """
+    Transfer array to CPU (numpy).
+
+    Parameters
+    ----------
+    array : array-like
+        Input array (numpy or cupy)
+
+    Returns
+    -------
+    np.ndarray
+        NumPy array
+    """
+    if GPU_AVAILABLE:
+        import cupy as cp
+
+        if isinstance(array, cp.ndarray):
+            return cp.asnumpy(array)
+    return np.asarray(array)
+
+
+def is_cupy_array(array: ArrayLike) -> bool:
+    """Return True iff ``array`` is a CuPy ``ndarray``.
+
+    Importing CuPy is gated on availability so this stays cheap to call from
+    code paths that may be hit without CUDA.
+    """
+    if not GPU_AVAILABLE:
+        return False
+    try:
+        import cupy as cp
+    except ImportError:
+        return False
+    return isinstance(array, cp.ndarray)
+
+
+def gpu_info() -> dict[str, Any]:
+    """
+    Get information about GPU availability and configuration.
+
+    Returns
+    -------
+    dict
+        Dictionary with GPU information
+    """
+    return {
+        "gpu_available": GPU_AVAILABLE,
+        "cupy_installed": CUPY_AVAILABLE,
+        "device_name": GPU_DEVICE_NAME,
+        "memory_gb": GPU_MEMORY_GB,
+        "disabled_by_env": _GPU_DISABLED_BY_ENV,
+    }
+
+
+def print_gpu_info() -> None:
+    """Print GPU availability information."""
+    info = gpu_info()
+    print("=" * 50)
+    print("linumpy GPU Configuration")
+    print("=" * 50)
+    print(f"  GPU Available:     {info['gpu_available']}")
+    print(f"  CuPy Installed:    {info['cupy_installed']}")
+    print(f"  Device:            {info['device_name']}")
+    print(f"  Memory:            {info['memory_gb']:.1f} GB")
+    if info["disabled_by_env"]:
+        print("  NOTE: GPU disabled via environment variable")
+    print("=" * 50)
+
+
+def list_gpus() -> list[dict[str, int | str | float]]:
+    """
+    List all available GPUs with memory information.
+
+    Returns
+    -------
+    list of dict
+        List of GPU info dictionaries with keys:
+        - id: Device ID
+        - name: Device name
+        - total_gb: Total memory in GB
+        - free_gb: Free memory in GB
+        - used_gb: Used memory in GB
+        - utilization: Memory utilization (0-1)
+    """
+    if not CUPY_AVAILABLE:
+        return []
+
+    import cupy as cp
+
+    gpus = []
+    n_devices = cp.cuda.runtime.getDeviceCount()
+
+    for i in range(n_devices):
+        with cp.cuda.Device(i):
+            free, total = cp.cuda.runtime.memGetInfo()
+            device = cp.cuda.Device(i)
+            name = device.name if hasattr(device, "name") else f"GPU {i}"
+
+            gpus.append(
+                {
+                    "id": i,
+                    "name": name,
+                    "total_gb": total / (1024**3),
+                    "free_gb": free / (1024**3),
+                    "used_gb": (total - free) / (1024**3),
+                    "utilization": (total - free) / total,
+                }
+            )
+
+    return gpus
+
+
+def select_best_gpu(verbose: bool = True) -> int | None:
+    """
+    Select the GPU with the most free memory.
+
+    This function queries all available GPUs and switches to the one
+    with the most free memory. Useful when running on multi-GPU systems
+    where one GPU may already be in use.
+
+    Parameters
+    ----------
+    verbose : bool
+        Print selection information
+
+    Returns
+    -------
+    int or None
+        Selected GPU ID, or None if no GPU available
+
+    Examples
+    --------
+    >>> from linumpy.gpu import select_best_gpu
+    >>> select_best_gpu()
+    Selected GPU 1: NVIDIA RTX A6000 (45.2 GB free / 48.0 GB total)
+    1
+    """
+    global GPU_AVAILABLE, GPU_DEVICE_NAME, GPU_MEMORY_GB
+
+    if not CUPY_AVAILABLE:
+        if verbose:
+            print("No GPU available (CuPy not installed)")
+        return None
+
+    import cupy as cp
+
+    gpus = list_gpus()
+
+    if not gpus:
+        if verbose:
+            print("No GPUs found")
+        return None
+
+    # Find GPU with most free memory
+    best_gpu = max(gpus, key=operator.itemgetter("free_gb"))
+    best_id = int(best_gpu["id"])
+
+    # Switch to best GPU
+    cp.cuda.Device(best_id).use()
+
+    # Update module globals
+    GPU_AVAILABLE = True
+    GPU_DEVICE_NAME = best_gpu["name"]
+    GPU_MEMORY_GB = best_gpu["total_gb"]
+
+    if verbose:
+        print(
+            f"Selected GPU {best_id}: {best_gpu['name']} "
+            f"({best_gpu['free_gb']:.1f} GB free / {best_gpu['total_gb']:.1f} GB total)"
+        )
+
+        if len(gpus) > 1:
+            print(f"  (Selected from {len(gpus)} available GPUs)")
+
+    return best_id
+
+
+def select_gpu(device_id: int, verbose: bool = True) -> int | None:
+    """
+    Select a specific GPU by device ID.
+
+    Parameters
+    ----------
+    device_id : int
+        GPU device ID (0, 1, 2, ...)
+    verbose : bool
+        Print selection information
+
+    Returns
+    -------
+    int or None
+        Selected GPU ID, or None if invalid
+
+    Examples
+    --------
+    >>> from linumpy.gpu import select_gpu
+    >>> select_gpu(1)
+    Selected GPU 1: NVIDIA RTX A6000 (48.0 GB total)
+    1
+    """
+    global GPU_AVAILABLE, GPU_DEVICE_NAME, GPU_MEMORY_GB
+
+    if not CUPY_AVAILABLE:
+        if verbose:
+            print("No GPU available (CuPy not installed)")
+        return None
+
+    import cupy as cp
+
+    n_devices = cp.cuda.runtime.getDeviceCount()
+
+    if device_id < 0 or device_id >= n_devices:
+        if verbose:
+            print(f"Invalid GPU ID {device_id}. Available: 0-{n_devices - 1}")
+        return None
+
+    # Switch to specified GPU
+    cp.cuda.Device(device_id).use()
+
+    # Update module globals
+    with cp.cuda.Device(device_id):
+        _free, total = cp.cuda.runtime.memGetInfo()
+        device = cp.cuda.Device(device_id)
+        name = device.name if hasattr(device, "name") else f"GPU {device_id}"
+
+        GPU_AVAILABLE = True
+        GPU_DEVICE_NAME = name
+        GPU_MEMORY_GB = total / (1024**3)
+
+    if verbose:
+        print(f"Selected GPU {device_id}: {name} ({GPU_MEMORY_GB:.1f} GB total)")
+
+    return device_id
+
+
+def print_gpu_status() -> None:
+    """
+    Print detailed status of all available GPUs.
+
+    Shows memory usage for each GPU, highlighting the currently selected one.
+    """
+    if not CUPY_AVAILABLE:
+        print("No GPU available (CuPy not installed)")
+        return
+
+    import cupy as cp
+
+    gpus = list_gpus()
+    current_device = cp.cuda.Device().id
+
+    print("=" * 60)
+    print("GPU Status")
+    print("=" * 60)
+
+    for gpu in gpus:
+        marker = " *" if gpu["id"] == current_device else "  "
+        bar_width = 30
+        used_bars = int(gpu["utilization"] * bar_width)
+        bar = "█" * used_bars + "░" * (bar_width - used_bars)
+
+        print(f"{marker}GPU {gpu['id']}: {gpu['name']}")
+        print(f"    Memory: [{bar}] {gpu['utilization'] * 100:.1f}%")
+        print(f"    {gpu['used_gb']:.1f} GB used / {gpu['total_gb']:.1f} GB total ({gpu['free_gb']:.1f} GB free)")
+
+    print("=" * 60)
+    print("  * = currently selected")
+
+
+# Expose key components
+__all__ = [
+    "CUPY_AVAILABLE",
+    "GPU_AVAILABLE",
+    "GPU_DEVICE_NAME",
+    "GPU_MEMORY_GB",
+    "get_array_module",
+    "gpu_info",
+    "list_gpus",
+    "print_gpu_info",
+    "print_gpu_status",
+    "select_best_gpu",
+    "select_gpu",
+    "to_cpu",
+    "to_gpu",
+]

--- a/linumpy/gpu/array_ops.py
+++ b/linumpy/gpu/array_ops.py
@@ -1,0 +1,411 @@
+"""GPU-accelerated array operations for linumpy.
+
+Provides GPU versions of normalization, clipping, and thresholding.
+Note: Simple reductions (mean, max) should use numpy directly - GPU offers no benefit.
+"""
+
+import numpy as np
+
+from . import GPU_AVAILABLE, to_cpu
+
+
+def normalize_percentile(image: np.ndarray, p_low: float = 1, p_high: float = 99, use_gpu: bool = True) -> np.ndarray:
+    """
+    GPU-accelerated percentile-based normalization.
+
+    Parameters
+    ----------
+    image : np.ndarray
+        Input image
+    p_low : float
+        Lower percentile for normalization (0-100)
+    p_high : float
+        Upper percentile for normalization (0-100)
+    use_gpu : bool
+        Whether to use GPU
+
+    Returns
+    -------
+    np.ndarray
+        Normalized image in [0, 1] range
+    """
+    if use_gpu and GPU_AVAILABLE:
+        import cupy as cp
+
+        img_gpu = cp.asarray(image.astype(np.float32))
+
+        low, high = cp.percentile(img_gpu, [p_low, p_high])
+
+        if high - low < 1e-10:
+            return to_cpu(cp.zeros_like(img_gpu))
+
+        normalized = (img_gpu - low) / (high - low)
+        normalized = cp.clip(normalized, 0, 1)
+
+        return to_cpu(normalized)
+    else:
+        low, high = np.percentile(image, [p_low, p_high])
+        if high - low < 1e-10:
+            return np.zeros_like(image, dtype=np.float32)
+        normalized = (image - low) / (high - low)
+        return np.clip(normalized, 0, 1).astype(np.float32)
+
+
+def normalize_minmax(image: np.ndarray, use_gpu: bool = True) -> np.ndarray:
+    """
+    GPU-accelerated min-max normalization.
+
+    Parameters
+    ----------
+    image : np.ndarray
+        Input image
+    use_gpu : bool
+        Whether to use GPU
+
+    Returns
+    -------
+    np.ndarray
+        Normalized image in [0, 1] range
+    """
+    if use_gpu and GPU_AVAILABLE:
+        import cupy as cp
+
+        img_gpu = cp.asarray(image.astype(np.float32))
+
+        vmin, vmax = cp.min(img_gpu), cp.max(img_gpu)
+
+        if vmax - vmin < 1e-10:
+            return to_cpu(cp.zeros_like(img_gpu))
+
+        normalized = (img_gpu - vmin) / (vmax - vmin)
+
+        return to_cpu(normalized)
+    else:
+        vmin, vmax = np.min(image), np.max(image)
+        if vmax - vmin < 1e-10:
+            return np.zeros_like(image, dtype=np.float32)
+        return ((image - vmin) / (vmax - vmin)).astype(np.float32)
+
+
+def clip_percentile(image: np.ndarray, p_low: float = 0.5, p_high: float = 99.5, use_gpu: bool = True) -> np.ndarray:
+    """
+    GPU-accelerated percentile clipping.
+
+    Parameters
+    ----------
+    image : np.ndarray
+        Input image
+    p_low : float
+        Lower percentile to clip
+    p_high : float
+        Upper percentile to clip
+    use_gpu : bool
+        Whether to use GPU
+
+    Returns
+    -------
+    np.ndarray
+        Clipped image
+    """
+    if use_gpu and GPU_AVAILABLE:
+        import cupy as cp
+
+        img_gpu = cp.asarray(image)
+
+        low, high = cp.percentile(img_gpu, [p_low, p_high])
+        clipped = cp.clip(img_gpu, low, high)
+
+        return to_cpu(clipped)
+    else:
+        low, high = np.percentile(image, [p_low, p_high])
+        return np.clip(image, low, high)
+
+
+def compute_percentiles_memory_efficient(
+    image: np.ndarray, percentiles: list[float], use_gpu: bool = True, max_samples: int = 10_000_000
+) -> list[float]:
+    """
+    Compute percentiles using subsampling to reduce memory usage.
+
+    For large arrays, computing exact percentiles requires sorting the entire array,
+    which can cause memory issues. This function uses random subsampling to estimate
+    percentiles with minimal memory overhead.
+
+    Parameters
+    ----------
+    image : np.ndarray
+        Input image
+    percentiles : list
+        List of percentiles to compute (0-100)
+    use_gpu : bool
+        Whether to use GPU
+    max_samples : int
+        Maximum number of samples to use for percentile estimation
+
+    Returns
+    -------
+    list
+        Computed percentile values
+    """
+    flat = image.ravel()
+
+    # Subsample if the array is too large
+    if flat.size > max_samples:
+        # Use random sampling for memory efficiency
+        rng = np.random.default_rng(42)  # Fixed seed for reproducibility
+        indices = rng.choice(flat.size, size=max_samples, replace=False)
+        sample = flat[indices]
+    else:
+        sample = flat
+
+    if use_gpu and GPU_AVAILABLE:
+        import cupy as cp
+
+        try:
+            sample_gpu = cp.asarray(sample)
+            result = [float(cp.percentile(sample_gpu, p).get()) for p in percentiles]
+            del sample_gpu
+            cp.get_default_memory_pool().free_all_blocks()
+            return result
+        except cp.cuda.memory.OutOfMemoryError:
+            # Fall back to CPU if GPU runs out of memory
+            pass
+
+    return [float(np.percentile(sample, p)) for p in percentiles]
+
+
+def compute_nonzero_percentile_memory_efficient(
+    image: np.ndarray, percentile: float, use_gpu: bool = True, max_samples: int = 10_000_000
+) -> float:
+    """
+    Compute percentile of non-zero values using subsampling.
+
+    Parameters
+    ----------
+    image : np.ndarray
+        Input image
+    percentile : float
+        Percentile to compute (0-100)
+    use_gpu : bool
+        Whether to use GPU
+    max_samples : int
+        Maximum number of samples to use
+
+    Returns
+    -------
+    float
+        Computed percentile value
+    """
+    flat = image.ravel()
+    nonzero_mask = flat > 0
+    nonzero_vals = flat[nonzero_mask]
+
+    if nonzero_vals.size == 0:
+        return 0.0
+
+    # Subsample if too large
+    if nonzero_vals.size > max_samples:
+        rng = np.random.default_rng(42)
+        indices = rng.choice(nonzero_vals.size, size=max_samples, replace=False)
+        sample = nonzero_vals[indices]
+    else:
+        sample = nonzero_vals
+
+    if use_gpu and GPU_AVAILABLE:
+        import cupy as cp
+
+        try:
+            sample_gpu = cp.asarray(sample)
+            result = float(cp.percentile(sample_gpu, percentile).get())
+            del sample_gpu
+            cp.get_default_memory_pool().free_all_blocks()
+            return result
+        except cp.cuda.memory.OutOfMemoryError:
+            pass
+
+    return float(np.percentile(sample, percentile))
+
+
+def apply_flatfield_correction(
+    image: np.ndarray, flatfield: np.ndarray, darkfield: np.ndarray | None = None, use_gpu: bool = True
+) -> np.ndarray:
+    """
+    GPU-accelerated flatfield correction.
+
+    Corrected = (Image - Darkfield) / (Flatfield - Darkfield)
+
+    Parameters
+    ----------
+    image : np.ndarray
+        Input image
+    flatfield : np.ndarray
+        Flatfield image
+    darkfield : np.ndarray, optional
+        Darkfield image
+    use_gpu : bool
+        Whether to use GPU
+
+    Returns
+    -------
+    np.ndarray
+        Corrected image
+    """
+    if use_gpu and GPU_AVAILABLE:
+        import cupy as cp
+
+        img_gpu = cp.asarray(image.astype(np.float32))
+        flat_gpu = cp.asarray(flatfield.astype(np.float32))
+
+        if darkfield is not None:
+            dark_gpu = cp.asarray(darkfield.astype(np.float32))
+            numerator = img_gpu - dark_gpu
+            denominator = flat_gpu - dark_gpu
+        else:
+            numerator = img_gpu
+            denominator = flat_gpu
+
+        # Avoid division by zero
+        denominator = cp.where(cp.abs(denominator) < 1e-10, 1.0, denominator)
+        corrected = numerator / denominator
+
+        return to_cpu(corrected)
+    else:
+        if darkfield is not None:
+            numerator = image.astype(np.float32) - darkfield
+            denominator = flatfield.astype(np.float32) - darkfield
+        else:
+            numerator = image.astype(np.float32)
+            denominator = flatfield.astype(np.float32)
+
+        denominator = np.where(np.abs(denominator) < 1e-10, 1.0, denominator)
+        return numerator / denominator
+
+
+def compute_std_projection(volume: np.ndarray, axis: int = 0, use_gpu: bool = True) -> np.ndarray:
+    """
+    GPU-accelerated standard deviation projection.
+
+    Parameters
+    ----------
+    volume : np.ndarray
+        Input volume
+    axis : int
+        Axis along which to compute std
+    use_gpu : bool
+        Whether to use GPU
+
+    Returns
+    -------
+    np.ndarray
+        Standard deviation projection
+    """
+    if use_gpu and GPU_AVAILABLE:
+        import cupy as cp
+
+        vol_gpu = cp.asarray(volume)
+        result = cp.std(vol_gpu, axis=axis)
+        return to_cpu(result)
+    else:
+        return np.std(volume, axis=axis)
+
+
+def threshold_otsu(image: np.ndarray, use_gpu: bool = True) -> float:
+    """
+    GPU-accelerated Otsu thresholding.
+
+    Parameters
+    ----------
+    image : np.ndarray
+        Input image
+    use_gpu : bool
+        Whether to use GPU
+
+    Returns
+    -------
+    float
+        Otsu threshold value
+    """
+    if use_gpu and GPU_AVAILABLE:
+        import cupy as cp
+
+        img_gpu = cp.asarray(image.astype(np.float32))
+
+        # Compute histogram
+        hist, bin_edges = cp.histogram(img_gpu.ravel(), bins=256)
+        bin_centers = (bin_edges[:-1] + bin_edges[1:]) / 2
+
+        hist = hist.astype(cp.float64)
+        hist_norm = hist / hist.sum()
+
+        # Cumulative sums
+        weight1 = cp.cumsum(hist_norm)
+        weight2 = cp.cumsum(hist_norm[::-1])[::-1]
+
+        # Cumulative means
+        mean1 = cp.cumsum(hist_norm * bin_centers) / weight1
+        mean2 = (cp.cumsum((hist_norm * bin_centers)[::-1]) / weight2[::-1])[::-1]
+
+        # Between-class variance
+        variance = weight1[:-1] * weight2[1:] * (mean1[:-1] - mean2[1:]) ** 2
+
+        # Find maximum
+        idx = cp.argmax(variance)
+        threshold = float(bin_centers[idx].get())
+
+        # Free GPU memory
+        del img_gpu, hist, bin_edges, bin_centers, hist_norm, weight1, weight2, mean1, mean2, variance
+        cp.get_default_memory_pool().free_all_blocks()
+
+        return threshold
+    else:
+        from skimage.filters import threshold_otsu as sk_otsu
+
+        return sk_otsu(image)
+
+
+def apply_xy_shift(image: np.ndarray, _reference: np.ndarray, dy: float, dx: float, use_gpu: bool = True) -> np.ndarray:
+    """
+    GPU-accelerated XY shift application.
+
+    Parameters
+    ----------
+    image : np.ndarray
+        Image to shift
+    reference : np.ndarray
+        Reference image (determines output shape)
+    dy : float
+        Y shift in pixels
+    dx : float
+        X shift in pixels
+    use_gpu : bool
+        Whether to use GPU
+
+    Returns
+    -------
+    np.ndarray
+        Shifted image
+    """
+    # Get a representative non-zero value for out-of-bounds fill
+    nonzero_vals = image[image > 0]
+    cval = float(np.percentile(nonzero_vals, 1)) if len(nonzero_vals) > 0 else 0.0
+
+    if use_gpu and GPU_AVAILABLE:
+        import cupy as cp
+        from cupyx.scipy.ndimage import shift as cp_shift
+
+        img_gpu = cp.asarray(image.astype(np.float32))
+
+        # Apply shift with edge value fill to avoid black dots
+        if image.ndim == 2:
+            shifted = cp_shift(img_gpu, [dy, dx], order=1, cval=cval)
+        else:  # 3D
+            shifted = cp_shift(img_gpu, [0, dy, dx], order=1, cval=cval)
+
+        return to_cpu(shifted)
+    else:
+        from scipy.ndimage import shift as scipy_shift
+
+        if image.ndim == 2:
+            return scipy_shift(image, [dy, dx], order=1, cval=cval)
+        else:
+            return scipy_shift(image, [0, dy, dx], order=1, cval=cval)

--- a/linumpy/gpu/bias_field.py
+++ b/linumpy/gpu/bias_field.py
@@ -1,0 +1,136 @@
+"""GPU-accelerated helpers for N4 bias field correction pre/post-processing.
+
+Provides block-mean downsampling, bias field upsampling, and chunked
+element-wise division on GPU (CuPy + PyTorch).  All functions fall back to
+CPU (NumPy + SciPy) when ``GPU_AVAILABLE`` is False.
+"""
+
+import numpy as np
+
+from . import GPU_AVAILABLE
+
+
+def downsample_gpu(vol: np.ndarray, shrink_factor: int, use_gpu: bool = True) -> np.ndarray:
+    """Block-mean spatial downsampling by an integer factor.
+
+    Parameters
+    ----------
+    vol : np.ndarray
+        Float32 input (Z, Y, X).
+    shrink_factor : int
+        Isotropic downsampling factor.  The output shape is
+        ``ceil(s / shrink_factor)`` on each axis.
+    use_gpu : bool
+        Use CuPy when GPU is available.
+
+    Returns
+    -------
+    np.ndarray
+        Downsampled float32 array.
+    """
+    if use_gpu and GPU_AVAILABLE:
+        try:
+            import cupy as cp
+
+            arr = cp.asarray(vol, dtype=cp.float32)
+            z, y, x = arr.shape
+            f = shrink_factor
+            # Trim to multiple of shrink_factor on each axis
+            arr = arr[: z - z % f or z, : y - y % f or y, : x - x % f or x]
+            z2, y2, x2 = arr.shape
+            out = arr.reshape(z2 // f, f, y2 // f, f, x2 // f, f).mean(axis=(1, 3, 5))
+            return cp.asnumpy(out).astype(np.float32)
+        except Exception:
+            pass  # fall through to CPU
+
+    # CPU fallback -- scipy zoom with anti-aliasing via block-mean
+    from scipy.ndimage import zoom
+
+    factor = 1.0 / shrink_factor
+    return zoom(vol.astype(np.float32), (factor, factor, factor), order=1, prefilter=False)
+
+
+def upsample_bias_gpu(
+    bias_low: np.ndarray,
+    target_shape: tuple[int, int, int],
+    use_gpu: bool = True,
+) -> np.ndarray:
+    """Trilinear upsampling of a low-resolution bias field to *target_shape*.
+
+    Parameters
+    ----------
+    bias_low : np.ndarray
+        Low-resolution bias field (Z', Y', X'), float32.
+    target_shape : tuple of int
+        Desired output shape (Z, Y, X).
+    use_gpu : bool
+        Use PyTorch trilinear interpolation when GPU is available.
+
+    Returns
+    -------
+    np.ndarray
+        Upsampled float32 bias field of shape *target_shape*.
+    """
+    if use_gpu and GPU_AVAILABLE:
+        try:
+            import torch
+
+            device = torch.device("cuda")
+            t = torch.from_numpy(bias_low[np.newaxis, np.newaxis]).to(device, dtype=torch.float32)
+            out = torch.nn.functional.interpolate(t, size=target_shape, mode="trilinear", align_corners=False)
+            return out[0, 0].cpu().numpy()
+        except Exception:
+            pass  # fall through to CPU
+
+    # CPU fallback
+    from scipy.ndimage import zoom
+
+    factors = tuple(t / s for t, s in zip(target_shape, bias_low.shape, strict=True))
+    return zoom(bias_low.astype(np.float32), factors, order=1, prefilter=False)
+
+
+def apply_bias_field_gpu(
+    vol: np.ndarray,
+    bias_field: np.ndarray,
+    chunk_z: int = 50,
+    floor: float = 1e-6,
+    use_gpu: bool = True,
+) -> np.ndarray:
+    """Element-wise division ``vol / bias_field`` processed in Z-chunks on GPU.
+
+    Parameters
+    ----------
+    vol : np.ndarray
+        Float32 input volume (Z, Y, X).
+    bias_field : np.ndarray
+        Multiplicative bias field, same shape as *vol*.
+    chunk_z : int
+        Number of Z-planes per GPU chunk.
+    floor : float
+        Minimum divisor to avoid division by zero.
+    use_gpu : bool
+        Use CuPy when GPU is available.
+
+    Returns
+    -------
+    np.ndarray
+        Corrected float32 volume, same shape as *vol*.
+    """
+    if use_gpu and GPU_AVAILABLE:
+        try:
+            import cupy as cp
+
+            out = np.empty_like(vol, dtype=np.float32)
+            for z_start in range(0, vol.shape[0], chunk_z):
+                z_end = min(z_start + chunk_z, vol.shape[0])
+                v = cp.asarray(vol[z_start:z_end], dtype=cp.float32)
+                b = cp.asarray(bias_field[z_start:z_end], dtype=cp.float32)
+                out[z_start:z_end] = cp.asnumpy(v / cp.maximum(b, floor))
+            return out
+        except Exception:
+            pass  # fall through to CPU
+
+    # CPU fallback
+    from linumpy.intensity.bias_field import apply_bias_field
+
+    return apply_bias_field(vol, bias_field, floor=floor)

--- a/linumpy/gpu/bspline.py
+++ b/linumpy/gpu/bspline.py
@@ -1,0 +1,367 @@
+"""Tensor-product cubic B-spline scattered-data approximation.
+
+Provides a simple GPU/CPU primitive for fitting a smooth 3-D field to
+scattered (weighted) voxel samples on a regular control-point lattice
+and evaluating the resulting field at arbitrary voxel grids.
+
+Used by :mod:`linumpy.gpu.n4` for the bias-field B-spline update step,
+but kept generic so other smoothing/warp primitives can reuse it.
+
+The fit implements the single-level Lee-Wolberg-Shin (1997) B-spline
+approximation that ITK uses inside ``BSplineScatteredDataPointSetToImageFilter``
+(the engine of N4).  For each scattered sample p with value v_p the
+locally-optimal value at surrounding control point c is::
+
+    phi_c(p) = w_c(p) * v_p / sum_d w_d(p)^2
+
+and the per-control-point coefficient is the squared-weight average::
+
+    coeff[c] = sum_p w_c(p)^2 * phi_c(p) / sum_p w_c(p)^2
+             = sum_p gamma_p * w_c(p)^3 * v_p / S(p)
+               -------------------------------------
+                       sum_p gamma_p * w_c(p)^2
+
+where ``S(p) = sum_d w_d(p)^2`` and gamma_p folds in the per-voxel
+mask/weight.  Because the tensor-product basis is separable,
+``w_c(p)^k`` factorises across axes and S(p) factorises into a product
+of per-axis sums of squared basis weights, so the fit reduces to three
+contiguous tensor contractions -- one through ``B^3`` for the numerator
+and one through ``B^2`` for the denominator.  This matches the ITK
+behaviour while remaining a single GPU-friendly tensordot chain.
+
+An earlier implementation used a Nadaraya-Watson kernel regression
+(``coeff[c] = sum_p w_c(p) * v_p / sum_p w_c(p)``).  That form has no
+implicit smoothness penalty and, at the dense control grids reached by
+later N4 fitting levels, lets the fit absorb tissue-scale features
+(e.g. white-matter contrast) into the bias estimate.  PSDB's squared
+weights regularise short-range support and recover the contrast.
+"""
+
+from typing import Any
+
+import numpy as np
+
+from linumpy.gpu import GPU_AVAILABLE, get_array_module
+
+
+def _is_gpu_array(arr: Any) -> bool:
+    """Return True if *arr* is a CuPy ndarray (so callers can keep results on GPU)."""
+    try:
+        import cupy as cp
+    except ImportError:
+        return False
+    return isinstance(arr, cp.ndarray)
+
+
+# ---------------------------------------------------------------------------
+# Cubic B-spline basis
+# ---------------------------------------------------------------------------
+
+
+def _cubic_bspline_basis(t: Any, xp: Any) -> Any:
+    """Return the four uniform cubic B-spline basis weights at offset *t*.
+
+    Parameters
+    ----------
+    t : array-like
+        Fractional offset(s) in [0, 1).  Any shape.
+    xp : module
+        Array module (numpy or cupy).
+
+    Returns
+    -------
+    array
+        Stack of shape ``t.shape + (4,)`` with weights ``[B0, B1, B2, B3]``.
+        Weights sum to 1 along the last axis.
+    """
+    t = xp.asarray(t, dtype=xp.float32)
+    t2 = t * t
+    t3 = t2 * t
+    one_m_t = 1.0 - t
+    b0 = (one_m_t * one_m_t * one_m_t) / 6.0
+    b1 = (3.0 * t3 - 6.0 * t2 + 4.0) / 6.0
+    b2 = (-3.0 * t3 + 3.0 * t2 + 3.0 * t + 1.0) / 6.0
+    b3 = t3 / 6.0
+    return xp.stack([b0, b1, b2, b3], axis=-1)
+
+
+# ---------------------------------------------------------------------------
+# Coordinate mapping
+# ---------------------------------------------------------------------------
+
+
+def _voxel_to_control_coords(n_voxels: int, n_control: int, xp: Any) -> Any:
+    """Map ``[0, n_voxels-1]`` voxel indices to control-grid coordinates.
+
+    Voxel 0 maps to control coordinate 0; voxel ``n_voxels - 1`` maps to
+    ``n_control - 3``.  This leaves one control-point of padding on each
+    side so the 4-tap cubic B-spline kernel has full support at the
+    boundaries.
+    """
+    if n_voxels == 1:
+        return xp.zeros(1, dtype=xp.float32)
+    span = float(n_control - 3)
+    if span <= 0:
+        raise ValueError(f"n_control={n_control} too small; need at least 4 control points to host a cubic B-spline.")
+    return xp.arange(n_voxels, dtype=xp.float32) * (span / float(n_voxels - 1))
+
+
+# ---------------------------------------------------------------------------
+# Per-axis basis matrix
+# ---------------------------------------------------------------------------
+
+
+def _build_axis_basis(n_voxels: int, n_control: int, xp: Any) -> Any:
+    """Return the dense (n_voxels, n_control) cubic-B-spline basis matrix.
+
+    Row ``i`` contains exactly four non-zero entries -- the four basis
+    weights at offsets ``-1, 0, 1, 2`` around ``floor(u_i)``, with OOB
+    stencil indices clamped to ``[0, n_control - 1]`` (boundary
+    partition-of-unity preservation, matching the original scattered
+    formulation).
+
+    The matrix is small (axes are at most a few hundred voxels by a few
+    dozen control points) so a dense layout is cheap and lets us turn
+    the fit/evaluate into three contiguous tensor contractions.
+    """
+    u = _voxel_to_control_coords(n_voxels, n_control, xp)
+    iu = xp.floor(u).astype(xp.int32)
+    t = u - iu.astype(xp.float32)
+    b = _cubic_bspline_basis(t, xp)  # (n_voxels, 4)
+
+    M = xp.zeros((n_voxels, n_control), dtype=xp.float32)
+    rows = xp.arange(n_voxels, dtype=xp.int32)
+    for d in range(4):
+        cols = xp.clip(iu + (d - 1), 0, n_control - 1)
+        # Multiple stencil offsets may map to the same column at the
+        # boundary; accumulate so partition-of-unity is preserved.
+        if xp is np:
+            np.add.at(M, (rows, cols), b[:, d])
+        else:
+            xp.add.at(M, (rows, cols), b[:, d])
+    return M
+
+
+# ---------------------------------------------------------------------------
+# Fit
+# ---------------------------------------------------------------------------
+
+
+def bspline_fit_precompute(
+    bases: tuple[Any, Any, Any],
+    *,
+    eps: float = 1e-8,
+) -> tuple[Any, Any, Any, Any, Any, Any, Any]:
+    """Build the iteration-invariant constants used by :func:`bspline_fit`.
+
+    The squared/cubed per-axis basis matrices and the separable per-voxel
+    denominator ``S(p) = (sum_c M_z[z,c]^2)(sum_c M_y[y,c]^2)(sum_c M_x[x,c]^2)``
+    depend only on *bases*, so callers that issue many fits at the same shape
+    (e.g. the N4 fitting loop) can build them once and pass them in via
+    :func:`bspline_fit`'s ``precomputed`` argument.
+
+    Returns ``(M_z2, M_y2, M_x2, M_z3, M_y3, M_x3, S_safe)`` where
+    ``S_safe = maximum(S, eps)`` -- the per-iteration ``maximum`` against
+    *eps* is folded into the precompute.
+    """
+    M_z, M_y, M_x = bases
+    xp = get_array_module(use_gpu=_is_gpu_array(M_z))
+    M_z2 = M_z * M_z
+    M_y2 = M_y * M_y
+    M_x2 = M_x * M_x
+    M_z3 = M_z2 * M_z
+    M_y3 = M_y2 * M_y
+    M_x3 = M_x2 * M_x
+    s_z = M_z2.sum(axis=1)
+    s_y = M_y2.sum(axis=1)
+    s_x = M_x2.sum(axis=1)
+    # Pre-clamp S to >= eps so :func:`bspline_fit` skips a per-call
+    # full-volume ``maximum`` op.
+    S_safe = xp.maximum(
+        s_z[:, None, None] * s_y[None, :, None] * s_x[None, None, :],
+        eps,
+    ).astype(xp.float32)
+    return M_z2, M_y2, M_x2, M_z3, M_y3, M_x3, S_safe
+
+
+def bspline_fit(
+    values: np.ndarray,
+    weights: np.ndarray | None,
+    mask: np.ndarray | None,
+    n_control_points: tuple[int, int, int],
+    *,
+    use_gpu: bool = True,
+    eps: float = 1e-8,
+    bases: tuple[Any, Any, Any] | None = None,
+    precomputed: tuple[Any, Any, Any, Any, Any, Any, Any] | None = None,
+) -> np.ndarray:
+    """Fit a tensor-product cubic B-spline to scattered voxel samples.
+
+    Parameters
+    ----------
+    values : np.ndarray
+        Sample values, shape (Z, Y, X), float32.
+    weights : np.ndarray or None
+        Per-voxel non-negative weights (same shape).  ``None`` = all ones.
+    mask : np.ndarray or None
+        Boolean mask selecting which voxels participate in the fit.
+        ``None`` = all voxels.
+    n_control_points : tuple of int
+        Control-grid size ``(Cz, Cy, Cx)``.  Each value must be ``>= 4``.
+    use_gpu : bool
+        Use CuPy when available; falls back to NumPy.
+    eps : float
+        Floor on the kernel-weight denominator to avoid division by zero
+        for control points with no support.
+    bases : tuple of arrays, optional
+        Pre-built per-axis basis matrices ``(M_z, M_y, M_x)`` from
+        :func:`_build_axis_basis` matching ``values.shape`` and
+        ``n_control_points``.  When provided, skips the per-call build;
+        useful when the caller (e.g. an N4 fitting level) issues many
+        fits at the same shape.
+    precomputed : tuple of arrays, optional
+        Output of :func:`bspline_fit_precompute` for the same *bases*.
+        When provided, skips rebuilding the squared/cubed bases and the
+        separable denominator ``S`` -- a per-iteration full-volume
+        allocation in the N4 fit loop.
+
+    Returns
+    -------
+    np.ndarray
+        Control coefficients, shape ``n_control_points``, float32 NumPy
+        array (always returned on the host).
+    """
+    if values.ndim != 3:
+        raise ValueError(f"values must be 3-D, got shape {values.shape}")
+    cz, cy, cx = n_control_points
+    if min(cz, cy, cx) < 4:
+        raise ValueError(f"n_control_points must each be >= 4, got {n_control_points}")
+
+    xp = get_array_module(use_gpu=use_gpu and GPU_AVAILABLE)
+
+    vals = xp.asarray(values, dtype=xp.float32)
+    w = xp.ones_like(vals) if weights is None else xp.asarray(weights, dtype=xp.float32)
+    if mask is not None:
+        w = w * xp.asarray(mask, dtype=xp.float32)
+
+    z_n, y_n, x_n = vals.shape
+
+    # Build dense per-axis basis matrices: M_axis[i, c] is the cubic
+    # B-spline weight that voxel ``i`` deposits onto control point ``c``.
+    # The 3-D scattered-data fit factorises along axes because the basis
+    # is separable, so the whole accumulation is three contiguous tensor
+    # contractions instead of 64 scatter-adds.  Bases can be precomputed
+    # by the caller (e.g. once per N4 level) and reused across many
+    # fit/evaluate calls to avoid rebuilding the same small matrices.
+    if bases is None:
+        M_z = _build_axis_basis(z_n, cz, xp)
+        M_y = _build_axis_basis(y_n, cy, xp)
+        M_x = _build_axis_basis(x_n, cx, xp)
+    else:
+        M_z, M_y, M_x = bases
+
+    # PSDB: separable tensor-product implementation of the Lee-Wolberg-Shin
+    # single-level scattered-data B-spline approximation.
+    #
+    #   coeff[c] = sum_p gamma_p * w_c(p)^3 * v_p / S(p)
+    #             ------------------------------------------
+    #                      sum_p gamma_p * w_c(p)^2
+    #
+    # Squared and cubed per-axis basis matrices fold the per-control-point
+    # weight powers into separable contractions.  S(p) factorises as the
+    # product of per-axis sums of squared basis weights.  These derive only
+    # from the bases, so an N4 fitting loop can build them once via
+    # :func:`bspline_fit_precompute` and pass them in.
+    if precomputed is None:
+        M_z2, M_y2, M_x2, M_z3, M_y3, M_x3, S_safe = bspline_fit_precompute((M_z, M_y, M_x), eps=eps)
+    else:
+        M_z2, M_y2, M_x2, M_z3, M_y3, M_x3, S_safe = precomputed
+
+    psi = (w * vals) / S_safe  # (Z, Y, X)
+
+    # num[Cz, Cy, Cx] = sum_{z,y,x} M_z3[z,Cz] M_y3[y,Cy] M_x3[x,Cx] * psi
+    num = xp.tensordot(psi, M_x3, axes=([2], [0]))  # (Nz, Ny, Cx)
+    num = xp.tensordot(num, M_y3, axes=([1], [0]))  # (Nz, Cx, Cy)
+    num = xp.tensordot(num, M_z3, axes=([0], [0]))  # (Cx, Cy, Cz)
+    num = xp.transpose(num, (2, 1, 0))  # (Cz, Cy, Cx)
+
+    # den[Cz, Cy, Cx] = sum_{z,y,x} M_z2[z,Cz] M_y2[y,Cy] M_x2[x,Cx] * w
+    den = xp.tensordot(w, M_x2, axes=([2], [0]))
+    den = xp.tensordot(den, M_y2, axes=([1], [0]))
+    den = xp.tensordot(den, M_z2, axes=([0], [0]))
+    den = xp.transpose(den, (2, 1, 0))
+
+    coeff = (num / xp.maximum(den, eps)).astype(xp.float32)
+
+    # Preserve caller's array module: cupy in -> cupy out, numpy in -> numpy out.
+    if _is_gpu_array(values):
+        return coeff
+    if xp is np:
+        return coeff
+    import cupy as cp
+
+    return cp.asnumpy(coeff).astype(np.float32)
+
+
+# ---------------------------------------------------------------------------
+# Evaluate
+# ---------------------------------------------------------------------------
+
+
+def bspline_evaluate(
+    control_coeffs: np.ndarray,
+    target_shape: tuple[int, int, int],
+    *,
+    use_gpu: bool = True,
+    bases: tuple[Any, Any, Any] | None = None,
+) -> np.ndarray:
+    """Evaluate a cubic B-spline given control coefficients on a regular grid.
+
+    Inverse of :func:`bspline_fit`'s coordinate mapping: target voxel 0
+    maps to control coordinate 0; target voxel ``N - 1`` maps to
+    ``Cn - 3``.
+
+    Parameters
+    ----------
+    control_coeffs : np.ndarray
+        Control-grid coefficients, shape ``(Cz, Cy, Cx)``.
+    target_shape : tuple of int
+        Output volume shape ``(Z, Y, X)``.
+    use_gpu : bool
+        Use CuPy when available.
+    bases : tuple of arrays, optional
+        Pre-built per-axis basis matrices ``(M_z, M_y, M_x)`` matching
+        ``target_shape`` and ``control_coeffs.shape``.  When provided,
+        skips the per-call build.
+
+    Returns
+    -------
+    np.ndarray
+        Evaluated field, shape ``target_shape``, float32.
+    """
+    xp = get_array_module(use_gpu=use_gpu and GPU_AVAILABLE)
+
+    coeff = xp.asarray(control_coeffs, dtype=xp.float32)
+    cz, cy, cx = coeff.shape
+    z_n, y_n, x_n = target_shape
+
+    if bases is None:
+        M_z = _build_axis_basis(z_n, cz, xp)  # (Nz, Cz)
+        M_y = _build_axis_basis(y_n, cy, xp)
+        M_x = _build_axis_basis(x_n, cx, xp)
+    else:
+        M_z, M_y, M_x = bases
+
+    # out[z, y, x] = sum_{Z,Y,X} M_z[z,Z] M_y[y,Y] M_x[x,X] * coeff[Z,Y,X]
+    out = xp.tensordot(coeff, M_x, axes=([2], [1]))  # (Cz, Cy, Nx)
+    out = xp.tensordot(out, M_y, axes=([1], [1]))  # (Cz, Nx, Ny)
+    out = xp.tensordot(out, M_z, axes=([0], [1]))  # (Nx, Ny, Nz)
+    out = xp.transpose(out, (2, 1, 0)).astype(xp.float32)  # (Nz, Ny, Nx)
+
+    if _is_gpu_array(control_coeffs):
+        return out
+    if xp is np:
+        return out
+    import cupy as cp
+
+    return cp.asnumpy(out).astype(np.float32)

--- a/linumpy/gpu/corrections.py
+++ b/linumpy/gpu/corrections.py
@@ -1,0 +1,85 @@
+"""GPU-accelerated correction operations for linumpy."""
+
+from typing import Any
+
+import numpy as np
+
+from . import GPU_AVAILABLE, to_cpu
+
+
+def fix_galvo_shift(volume: Any, shift: Any, axis: Any = 1, use_gpu: Any = True) -> Any:
+    """
+    GPU-accelerated galvo shift correction.
+
+    Parameters
+    ----------
+    volume : np.ndarray
+        Input volume
+    shift : int
+        Shift amount in pixels
+    axis : int
+        Axis along which to shift
+    use_gpu : bool
+        Whether to use GPU
+
+    Returns
+    -------
+    np.ndarray
+        Corrected volume
+    """
+    if shift == 0:
+        return volume
+
+    if use_gpu and GPU_AVAILABLE:
+        import cupy as cp
+
+        vol_gpu = cp.asarray(volume)
+        result = cp.roll(vol_gpu, shift, axis=axis)
+        return to_cpu(result)
+    else:
+        return np.roll(volume, shift, axis=axis)
+
+
+def detect_and_fix_galvo_shift(
+    volume: Any, n_pixel_return: Any = 40, threshold: Any = 0.5, axis: Any = 1, use_gpu: Any = True
+) -> Any:
+    """
+    Detect and conditionally fix galvo shift.
+
+    Note: Detection uses CPU (GPU offers no benefit). Only the fix uses GPU.
+
+    Parameters
+    ----------
+    volume : np.ndarray
+        Input volume (3D)
+    n_pixel_return : int
+        Number of pixels in galvo return region
+    threshold : float
+        Confidence threshold for applying fix (default 0.5, higher = more conservative)
+    axis : int
+        A-line axis
+    use_gpu : bool
+        Whether to use GPU for the fix operation
+
+    Returns
+    -------
+    np.ndarray
+        Corrected volume (or original if no fix needed)
+    dict
+        Detection results with 'shift', 'confidence', 'fixed' keys
+    """
+    from linumpy.geometry.galvo import detect_galvo_shift
+
+    # Compute AIP
+    aip = np.mean(volume, axis=0)
+
+    # Detect shift using CPU (GPU offers no benefit for detection)
+    shift, confidence = detect_galvo_shift(aip, n_pixel_return)
+
+    result = {"shift": shift, "confidence": confidence, "fixed": False}
+
+    if confidence >= threshold:
+        volume = fix_galvo_shift(volume, shift, axis=axis, use_gpu=use_gpu)
+        result["fixed"] = True
+
+    return volume, result

--- a/linumpy/gpu/fft_ops.py
+++ b/linumpy/gpu/fft_ops.py
@@ -1,0 +1,265 @@
+"""
+GPU-accelerated FFT operations for linumpy.
+
+Provides GPU versions of FFT-based operations including phase correlation
+for image registration and stitching.
+"""
+
+from typing import Any
+
+import numpy as np
+
+from . import GPU_AVAILABLE, to_cpu
+
+
+def phase_correlation(vol1: np.ndarray, vol2: np.ndarray, n_peaks: int = 8, use_gpu: bool = True) -> tuple[list[int], float]:
+    """
+    GPU-accelerated phase correlation for finding translation between images.
+
+    Parameters
+    ----------
+    vol1 : np.ndarray
+        Fixed image (2D or 3D)
+    vol2 : np.ndarray
+        Moving image (2D or 3D)
+    n_peaks : int
+        Number of peaks to sample for refinement
+    use_gpu : bool
+        Whether to use GPU acceleration
+
+    Returns
+    -------
+    list
+        Translation [dx, dy] or [dx, dy, dz] of vol2 relative to vol1
+    float
+        Cross-correlation score
+    """
+    if use_gpu and GPU_AVAILABLE:
+        return _phase_correlation_gpu(vol1, vol2, n_peaks)
+    else:
+        return _phase_correlation_cpu(vol1, vol2, n_peaks)
+
+
+def _phase_correlation_gpu(vol1: Any, vol2: Any, n_peaks: Any = 8) -> Any:
+    """GPU implementation of phase correlation."""
+    import cupy as cp
+
+    vol_shape = vol1.shape
+    ndim = vol1.ndim
+
+    # Transfer to GPU
+    vol1_gpu = cp.asarray(vol1, dtype=cp.float32)
+    vol2_gpu = cp.asarray(vol2, dtype=cp.float32)
+
+    # Extend images by 1/4 of their size (padding)
+    new_shape = tuple(int(s * 1.25) for s in vol_shape)
+    pad_size = tuple((int(np.ceil(0.5 * (n - s))),) * 2 for s, n in zip(vol_shape, new_shape, strict=False))
+
+    vol1_p = cp.pad(vol1_gpu, pad_size, mode="reflect")
+    vol2_p = cp.pad(vol2_gpu, pad_size, mode="reflect")
+
+    # Apply Hanning window
+    vol1_p = _apply_hanning_window_gpu(vol1_p, [p[0] for p in pad_size])
+    vol2_p = _apply_hanning_window_gpu(vol2_p, [p[0] for p in pad_size])
+
+    # Phase correlation using cuFFT
+    if ndim == 2:
+        fft_func = cp.fft.fft2
+        ifft_func = cp.fft.ifft2
+    else:
+        fft_func = cp.fft.fftn
+        ifft_func = cp.fft.ifftn
+
+    q_num = fft_func(vol2_p) * cp.conj(fft_func(vol1_p))
+    q_denum = cp.abs(q_num)
+
+    # Avoid division by zero
+    q_freq = cp.where(q_denum > 1e-10, q_num / q_denum, 0)
+    q = ifft_func(q_freq)
+    q_abs = cp.abs(q)
+
+    # Find peaks
+    from cupyx.scipy.ndimage import maximum_filter
+
+    # Local maxima detection
+    local_max = maximum_filter(q_abs, size=3)
+    _peaks_mask = q_abs == local_max
+
+    # Get top n_peaks
+    flat_indices = cp.argsort(q_abs.ravel())[-n_peaks:]
+    coordinates = cp.unravel_index(flat_indices, q_abs.shape)
+    coordinates = cp.stack(coordinates, axis=1)
+
+    # Try all translation permutations
+    best_translation = None
+    best_score = -1
+
+    coordinates_cpu = to_cpu(coordinates)
+    vol1_cpu = to_cpu(vol1_gpu)
+    vol2_cpu = to_cpu(vol2_gpu)
+
+    for indices in coordinates_cpu:
+        deltas = []
+        for idx, s in zip(indices, vol1_p.shape, strict=False):
+            deltas.append(int(-idx + s / 2))
+
+        # Check bounds
+        for ii in range(len(deltas)):
+            if abs(deltas[ii]) > vol_shape[ii]:
+                deltas[ii] -= int(np.sign(deltas[ii]) * vol_shape[ii])
+
+        # Generate candidate translations
+        if ndim == 2:
+            dx, dy = deltas
+            candidates = [
+                [dx, dy],
+                [dx - int(np.sign(dx) * vol1_p.shape[0] / 2), dy],
+                [dx, dy - int(np.sign(dy) * vol1_p.shape[1] / 2)],
+                [dx - int(np.sign(dx) * vol1_p.shape[0] / 2), dy - int(np.sign(dy) * vol1_p.shape[1] / 2)],
+            ]
+        else:
+            dx, dy, dz = deltas
+            nxp = int(np.sign(dx) * vol1_p.shape[0] / 2)
+            nyp = int(np.sign(dy) * vol1_p.shape[1] / 2)
+            nzp = int(np.sign(dz) * vol1_p.shape[2] / 2)
+            candidates = [
+                [dx, dy, dz],
+                [dx - nxp, dy, dz],
+                [dx, dy - nyp, dz],
+                [dx - nxp, dy - nyp, dz],
+                [dx, dy, dz - nzp],
+                [dx, dy - nyp, dz - nzp],
+                [dx - nxp, dy, dz - nzp],
+                [dx - nxp, dy - nyp, dz - nzp],
+            ]
+
+        for trans in candidates:
+            score = _compute_correlation_score(vol1_cpu, vol2_cpu, trans)
+            if score > best_score:
+                best_score = score
+                best_translation = trans
+
+    return best_translation, best_score
+
+
+def _apply_hanning_window_gpu(vol: Any, pad_sizes: Any) -> Any:
+    """Apply Hanning window on GPU."""
+    import cupy as cp
+
+    ndim = vol.ndim
+    result = vol.copy()
+
+    for axis, pad in enumerate(pad_sizes):
+        if pad <= 0:
+            continue
+
+        s = vol.shape[axis]
+        h = cp.hanning(pad * 2)
+        h_full = cp.ones(s)
+        h_full[:pad] = h[:pad]
+        h_full[-pad:] = h[pad:]
+
+        # Reshape for broadcasting
+        shape = [1] * ndim
+        shape[axis] = s
+        h_full = h_full.reshape(shape)
+
+        result = result * h_full
+
+    return result
+
+
+def _compute_correlation_score(vol1: Any, vol2: Any, translation: Any) -> Any:
+    """Compute normalized cross-correlation score for a translation."""
+    # Compute overlap region
+    slices1 = []
+    slices2 = []
+
+    for i, t in enumerate(translation):
+        t = int(t)
+        if t >= 0:
+            slices1.append(slice(t, None))
+            slices2.append(slice(None, vol2.shape[i] - t if t > 0 else None))
+        else:
+            slices1.append(slice(None, vol1.shape[i] + t))
+            slices2.append(slice(-t, None))
+
+    try:
+        ov1 = vol1[tuple(slices1)]
+        ov2 = vol2[tuple(slices2)]
+
+        if ov1.size == 0 or ov2.size == 0:
+            return 0
+
+        # Normalized cross-correlation
+        ov1_norm = ov1 - np.mean(ov1)
+        ov2_norm = ov2 - np.mean(ov2)
+
+        std1 = np.std(ov1_norm)
+        std2 = np.std(ov2_norm)
+
+        if std1 < 1e-10 or std2 < 1e-10:
+            return 0
+
+        return float(np.mean(ov1_norm * ov2_norm) / (std1 * std2))
+    except Exception:
+        return 0
+
+
+def _phase_correlation_cpu(vol1: Any, vol2: Any, n_peaks: Any = 8) -> Any:
+    """CPU fallback for phase correlation - calls existing implementation."""
+    from linumpy.registration.transforms import pair_wise_phase_correlation
+
+    return pair_wise_phase_correlation(vol1, vol2, n_peaks=n_peaks, return_cc=True)
+
+
+def fft2(image: np.ndarray, use_gpu: bool = True) -> np.ndarray:
+    """
+    GPU-accelerated 2D FFT.
+
+    Parameters
+    ----------
+    image : np.ndarray
+        Input 2D image
+    use_gpu : bool
+        Whether to use GPU
+
+    Returns
+    -------
+    np.ndarray
+        FFT result (complex)
+    """
+    if use_gpu and GPU_AVAILABLE:
+        import cupy as cp
+
+        img_gpu = cp.asarray(image)
+        result = cp.fft.fft2(img_gpu)
+        return to_cpu(result)
+    else:
+        return np.fft.fft2(image)
+
+
+def ifft2(spectrum: np.ndarray, use_gpu: bool = True) -> np.ndarray:
+    """
+    GPU-accelerated 2D inverse FFT.
+
+    Parameters
+    ----------
+    spectrum : np.ndarray
+        Input spectrum (complex)
+    use_gpu : bool
+        Whether to use GPU
+
+    Returns
+    -------
+    np.ndarray
+        Inverse FFT result
+    """
+    if use_gpu and GPU_AVAILABLE:
+        import cupy as cp
+
+        spec_gpu = cp.asarray(spectrum)
+        result = cp.fft.ifft2(spec_gpu)
+        return to_cpu(result)
+    else:
+        return np.fft.ifft2(spectrum)

--- a/linumpy/gpu/image_quality.py
+++ b/linumpy/gpu/image_quality.py
@@ -1,0 +1,417 @@
+#!/usr/bin/env python3
+"""
+GPU-accelerated image quality assessment functions.
+
+This module provides CuPy-accelerated versions of quality assessment functions.
+All functions automatically fall back to CPU if GPU is not available.
+
+Usage::
+
+    from linumpy.gpu.image_quality import (
+        compute_ssim_2d_gpu,
+        compute_ssim_3d_gpu,
+        compute_edge_score_gpu,
+        assess_slice_quality_gpu,
+    )
+
+    # All functions accept numpy arrays and return numpy scalars
+    ssim = compute_ssim_3d_gpu(vol1, vol2)
+"""
+
+import contextlib
+from typing import Any
+
+import numpy as np
+
+from linumpy.gpu import CUPY_AVAILABLE, GPU_AVAILABLE
+
+if CUPY_AVAILABLE:
+    import cupy as cp
+    from cupyx.scipy.ndimage import sobel as cupy_sobel
+    from cupyx.scipy.ndimage import uniform_filter as cupy_uniform_filter
+else:
+    cp = None
+    cupy_sobel = None
+    cupy_uniform_filter = None
+
+
+def _to_gpu(arr: np.ndarray) -> cp.ndarray:
+    """Transfer numpy array to GPU."""
+    return cp.asarray(arr, dtype=cp.float32)
+
+
+def _to_cpu(arr: Any) -> np.ndarray:
+    """Transfer GPU array to CPU."""
+    if hasattr(arr, "get"):
+        return arr.get()
+    return np.asarray(arr)
+
+
+def normalize_image_gpu(img: cp.ndarray) -> cp.ndarray:
+    """
+    Normalize image to [0, 1] range on GPU.
+
+    Parameters
+    ----------
+    img : cp.ndarray
+        Input image on GPU.
+
+    Returns
+    -------
+    cp.ndarray
+        Normalized image.
+    """
+    img_min = cp.min(img)
+    img_max = cp.max(img)
+    if img_max > img_min:
+        return (img - img_min) / (img_max - img_min)
+    return img
+
+
+def compute_ssim_2d_gpu(img1: np.ndarray, img2: np.ndarray, win_size: int = 7) -> float:
+    """
+    Compute SSIM between two 2D images using GPU.
+
+    Falls back to CPU if GPU is not available.
+
+    Parameters
+    ----------
+    img1, img2 : np.ndarray
+        Input images (2D).
+    win_size : int
+        Window size for SSIM computation.
+
+    Returns
+    -------
+    float
+        SSIM score (0 to 1, higher is better).
+    """
+    if not GPU_AVAILABLE or cp is None:
+        from linumpy.metrics.image_quality import compute_ssim_2d
+
+        return compute_ssim_2d(img1, img2, win_size)
+
+    if img1.shape != img2.shape:
+        min_y = min(img1.shape[0], img2.shape[0])
+        min_x = min(img1.shape[1], img2.shape[1])
+        img1 = img1[:min_y, :min_x]
+        img2 = img2[:min_y, :min_x]
+
+    try:
+        # Transfer to GPU
+        i1 = _to_gpu(img1)
+        i2 = _to_gpu(img2)
+
+        # Normalize
+        i1 = normalize_image_gpu(i1)
+        i2 = normalize_image_gpu(i2)
+
+        # SSIM constants
+        c1 = 0.01**2
+        c2 = 0.03**2
+
+        # Compute local means using uniform filter
+        mu1 = cupy_uniform_filter(i1, size=win_size)
+        mu2 = cupy_uniform_filter(i2, size=win_size)
+
+        mu1_sq = mu1 * mu1
+        mu2_sq = mu2 * mu2
+        mu1_mu2 = mu1 * mu2
+
+        sigma1_sq = cupy_uniform_filter(i1 * i1, size=win_size) - mu1_sq
+        sigma2_sq = cupy_uniform_filter(i2 * i2, size=win_size) - mu2_sq
+        sigma12 = cupy_uniform_filter(i1 * i2, size=win_size) - mu1_mu2
+
+        # SSIM formula
+        numerator = (2 * mu1_mu2 + c1) * (2 * sigma12 + c2)
+        denominator = (mu1_sq + mu2_sq + c1) * (sigma1_sq + sigma2_sq + c2)
+
+        ssim_map = numerator / denominator
+
+        return float(cp.mean(ssim_map))
+    except Exception:
+        # Fall back to CPU
+        from linumpy.metrics.image_quality import compute_ssim_2d
+
+        return compute_ssim_2d(img1, img2, win_size)
+
+
+def compute_ssim_3d_gpu(vol1: np.ndarray, vol2: np.ndarray, win_size: int = 7, sample_depth: int = 0) -> float:
+    """
+    Compute mean SSIM between two 3D volumes using GPU.
+
+    Parameters
+    ----------
+    vol1, vol2 : np.ndarray
+        Input volumes (Z, Y, X).
+    win_size : int
+        Window size for SSIM computation.
+    sample_depth : int
+        Number of z-planes to sample. 0 = all planes.
+
+    Returns
+    -------
+    float
+        Mean SSIM score (0 to 1, higher is better).
+    """
+    if not GPU_AVAILABLE:
+        from linumpy.metrics.image_quality import compute_ssim_3d
+
+        return compute_ssim_3d(vol1, vol2, win_size, sample_depth)
+
+    if vol1.shape != vol2.shape:
+        min_z = min(vol1.shape[0], vol2.shape[0])
+        min_y = min(vol1.shape[1], vol2.shape[1])
+        min_x = min(vol1.shape[2], vol2.shape[2])
+        vol1 = vol1[:min_z, :min_y, :min_x]
+        vol2 = vol2[:min_z, :min_y, :min_x]
+
+    # Sample z-planes if requested
+    if sample_depth > 0 and vol1.shape[0] > sample_depth:
+        indices = np.linspace(0, vol1.shape[0] - 1, sample_depth, dtype=int)
+    else:
+        indices = np.arange(vol1.shape[0])
+
+    ssim_scores = []
+    for z in indices:
+        score = compute_ssim_2d_gpu(vol1[z], vol2[z], win_size)
+        ssim_scores.append(score)
+
+    return float(np.mean(ssim_scores))
+
+
+def compute_edge_score_gpu(vol: np.ndarray, reference: np.ndarray, sample_z: int | None = None) -> float:
+    """
+    Compute edge preservation score using GPU.
+
+    Parameters
+    ----------
+    vol : np.ndarray
+        Input volume (Z, Y, X) or 2D image.
+    reference : np.ndarray
+        Reference volume or image.
+    sample_z : int, optional
+        Z-index to sample for 3D volumes.
+
+    Returns
+    -------
+    float
+        Edge preservation score (0 to 1, higher is better).
+    """
+    if not GPU_AVAILABLE or cp is None:
+        from linumpy.metrics.image_quality import compute_edge_score
+
+        return compute_edge_score(vol, reference, sample_z)
+
+    try:
+        # Handle 3D volumes
+        if vol.ndim == 3:
+            if sample_z is None:
+                sample_z = vol.shape[0] // 2
+            v_cpu = vol[sample_z]
+            r_cpu = reference[sample_z] if reference.ndim == 3 else reference
+        else:
+            v_cpu = vol
+            r_cpu = reference
+
+        if v_cpu.shape != r_cpu.shape:
+            min_y = min(v_cpu.shape[0], r_cpu.shape[0])
+            min_x = min(v_cpu.shape[1], r_cpu.shape[1])
+            v_cpu = v_cpu[:min_y, :min_x]
+            r_cpu = r_cpu[:min_y, :min_x]
+
+        # Transfer to GPU and normalize
+        v = normalize_image_gpu(_to_gpu(v_cpu))
+        r = normalize_image_gpu(_to_gpu(r_cpu))
+
+        # Compute edges using Sobel
+        edges_v = cp.sqrt(cupy_sobel(v, axis=0) ** 2 + cupy_sobel(v, axis=1) ** 2)
+        edges_r = cp.sqrt(cupy_sobel(r, axis=0) ** 2 + cupy_sobel(r, axis=1) ** 2)
+
+        # Normalize edges
+        if cp.max(edges_v) > 0:
+            edges_v = edges_v / cp.max(edges_v)
+        if cp.max(edges_r) > 0:
+            edges_r = edges_r / cp.max(edges_r)
+
+        # Compute correlation on GPU
+        flat_v = edges_v.flatten()
+        flat_r = edges_r.flatten()
+
+        mean_v = cp.mean(flat_v)
+        mean_r = cp.mean(flat_r)
+
+        num = cp.sum((flat_v - mean_v) * (flat_r - mean_r))
+        den = cp.sqrt(cp.sum((flat_v - mean_v) ** 2) * cp.sum((flat_r - mean_r) ** 2))
+
+        if den > 0:
+            corr = float(num / den)
+            return max(0.0, corr) if not np.isnan(corr) else 0.0
+        return 0.0
+    except Exception:
+        from linumpy.metrics.image_quality import compute_edge_score
+
+        return compute_edge_score(vol, reference, sample_z)
+
+
+def compute_variance_score_gpu(vol: np.ndarray, reference: np.ndarray) -> float:
+    """
+    Compute variance score using GPU.
+
+    Parameters
+    ----------
+    vol : np.ndarray
+        Input volume.
+    reference : np.ndarray
+        Reference volume.
+
+    Returns
+    -------
+    float
+        Variance score (0 to 1).
+    """
+    if not GPU_AVAILABLE or cp is None:
+        from linumpy.metrics.image_quality import compute_variance_score
+
+        return compute_variance_score(vol, reference)
+
+    try:
+        v = _to_gpu(vol)
+        r = _to_gpu(reference)
+
+        var_v = float(cp.var(v))
+        var_r = float(cp.var(r))
+
+        if var_r == 0:
+            return 0.0
+
+        ratio = var_v / var_r
+        score = 2.0 / (1.0 + abs(np.log(ratio + 1e-10)))
+
+        return float(min(1.0, max(0.0, score)))
+    except Exception:
+        from linumpy.metrics.image_quality import compute_variance_score
+
+        return compute_variance_score(vol, reference)
+
+
+def assess_slice_quality_gpu(
+    vol: np.ndarray,
+    vol_before: np.ndarray | None,
+    vol_after: np.ndarray | None,
+    sample_depth: int = 5,
+    weights: dict[str, float] | None = None,
+) -> tuple[float, dict[str, Any]]:
+    """
+    Assess overall quality of a slice volume using GPU acceleration.
+
+    Parameters
+    ----------
+    vol : np.ndarray
+        The slice volume (Z, Y, X).
+    vol_before : np.ndarray or None
+        The previous slice volume.
+    vol_after : np.ndarray or None
+        The next slice volume.
+    sample_depth : int
+        Number of z-planes to sample for SSIM.
+    weights : dict, optional
+        Custom weights for metrics.
+
+    Returns
+    -------
+    float
+        Overall quality score (0 to 1).
+    dict
+        Individual metric values.
+    """
+    if not GPU_AVAILABLE:
+        from linumpy.metrics.image_quality import assess_slice_quality
+
+        return assess_slice_quality(vol, vol_before, vol_after, sample_depth, weights)
+
+    if weights is None:
+        weights = {"ssim": 0.5, "edge": 0.3, "variance": 0.2}
+
+    depth = vol.shape[0] if vol.ndim == 3 else 1
+    metrics: dict[str, Any] = {
+        "ssim_before": 0.0,
+        "ssim_after": 0.0,
+        "ssim_mean": 0.0,
+        "edge_score": 0.0,
+        "variance_score": 0.0,
+        "depth": depth,
+        "has_data": True,
+    }
+
+    # Check if slice has meaningful data by sampling a single centre z-plane.
+    # zarr.Array supports integer indexing (returns numpy), so no full-volume I/O.
+    z_check = depth // 2 if vol.ndim == 3 else 0
+    check_plane = np.asarray(vol[z_check])
+    if check_plane.max() == check_plane.min() or np.std(check_plane) < 1e-6:
+        metrics["has_data"] = False
+        metrics["overall"] = 0.0
+        return 0.0, metrics
+
+    # Compute SSIM with neighbours.
+    # compute_ssim_3d_gpu internally accesses vol[z] one plane at a time, so
+    # zarr arrays are handled without loading the whole volume.
+    ssim_scores = []
+    if vol_before is not None:
+        metrics["ssim_before"] = compute_ssim_3d_gpu(vol, vol_before, sample_depth=sample_depth)
+        ssim_scores.append(metrics["ssim_before"])
+    if vol_after is not None:
+        metrics["ssim_after"] = compute_ssim_3d_gpu(vol, vol_after, sample_depth=sample_depth)
+        ssim_scores.append(metrics["ssim_after"])
+
+    if ssim_scores:
+        metrics["ssim_mean"] = float(np.mean(ssim_scores))
+
+    # Build sampled numpy arrays for edge and variance scores.
+    # Read only sample_depth z-planes via zarr integer indexing to avoid loading
+    # the full volume (compute_variance_score_gpu would otherwise call
+    # cp.asarray on the whole array).
+    n_planes = max(1, min(sample_depth, depth) if sample_depth > 0 else depth)
+    z_indices = np.linspace(0, depth - 1, n_planes, dtype=int)
+    vol_s = np.stack([np.asarray(vol[int(z)], dtype=np.float32) for z in z_indices])
+
+    ref_s = None
+    if vol_before is not None and vol_after is not None:
+        min_y = min(vol_before.shape[1], vol_after.shape[1])
+        min_x = min(vol_before.shape[2], vol_after.shape[2])
+        max_z_b = vol_before.shape[0] - 1
+        max_z_a = vol_after.shape[0] - 1
+        ref_s = 0.5 * np.stack(
+            [np.asarray(vol_before[min(int(z), max_z_b)], dtype=np.float32)[:min_y, :min_x] for z in z_indices]
+        ) + 0.5 * np.stack([np.asarray(vol_after[min(int(z), max_z_a)], dtype=np.float32)[:min_y, :min_x] for z in z_indices])
+    elif vol_before is not None:
+        max_z_b = vol_before.shape[0] - 1
+        ref_s = np.stack([np.asarray(vol_before[min(int(z), max_z_b)], dtype=np.float32) for z in z_indices])
+    elif vol_after is not None:
+        max_z_a = vol_after.shape[0] - 1
+        ref_s = np.stack([np.asarray(vol_after[min(int(z), max_z_a)], dtype=np.float32) for z in z_indices])
+
+    # Compute edge preservation score
+    if ref_s is not None:
+        metrics["edge_score"] = compute_edge_score_gpu(vol_s, ref_s)
+
+    # Compute variance consistency
+    if ref_s is not None:
+        metrics["variance_score"] = compute_variance_score_gpu(vol_s, ref_s)
+
+    # Compute overall score
+    overall = (
+        weights["ssim"] * metrics["ssim_mean"]
+        + weights["edge"] * metrics["edge_score"]
+        + weights["variance"] * metrics["variance_score"]
+    )
+    metrics["overall"] = float(overall)
+
+    return float(overall), metrics
+
+
+def clear_gpu_memory() -> None:
+    """Clear GPU memory pools."""
+    if GPU_AVAILABLE and cp is not None:
+        with contextlib.suppress(Exception):
+            cp.get_default_memory_pool().free_all_blocks()

--- a/linumpy/gpu/interface.py
+++ b/linumpy/gpu/interface.py
@@ -1,0 +1,48 @@
+"""GPU implementation of tissue interface detection.
+
+Mirrors the CPU path in :func:`linumpy.geometry.interface.find_tissue_interface`
+but routes the heavy filters through ``cupyx.scipy.ndimage`` to avoid
+host-device round trips when the caller already holds GPU data or when
+the volume is large enough that the transfer cost is amortised.
+"""
+
+import numpy as np
+
+from . import to_cpu
+
+
+def find_tissue_interface_gpu(
+    vol: np.ndarray,
+    s_xy: int = 15,
+    s_z: int = 2,
+    use_log: bool = True,
+    order: int = 1,
+    detect_cutting_errors: bool = False,
+) -> np.ndarray:
+    """GPU equivalent of ``find_tissue_interface`` (no mask path).
+
+    Always returns a NumPy array of integer depths so callers do not need
+    to be aware of the device.
+    """
+    import cupy as cp
+    from cupyx.scipy.ndimage import gaussian_filter1d, uniform_filter
+
+    vol_gpu = cp.asarray(vol)
+    if use_log:
+        vol_p = vol_gpu.astype(cp.float32, copy=True)
+        positive = vol_gpu > 0
+        vol_p[positive] = cp.log(vol_gpu[positive])
+    else:
+        vol_p = vol_gpu
+
+    vol_p = uniform_filter(vol_p, (s_xy, s_xy, 0))
+    vol_g = gaussian_filter1d(vol_p, s_z, axis=2, order=order)
+    z0 = cp.ceil(vol_g.argmax(axis=2) + s_z * 0.5).astype(cp.int64)
+
+    if detect_cutting_errors:
+        vol_p = gaussian_filter1d(vol_p, s_z, axis=2, order=0)
+        z0_p = cp.abs(vol_p).argmax(axis=2)
+        mask_max = z0_p < z0
+        z0 = cp.where(mask_max, z0_p, z0)
+
+    return to_cpu(z0)

--- a/linumpy/gpu/interpolation.py
+++ b/linumpy/gpu/interpolation.py
@@ -1,0 +1,254 @@
+"""
+GPU-accelerated interpolation and resampling operations for linumpy.
+
+Provides GPU versions of image resampling, affine transforms, and
+coordinate mapping operations.
+"""
+
+from typing import Any
+
+import numpy as np
+
+from . import GPU_AVAILABLE, is_cupy_array, to_cpu
+
+
+def affine_transform(image: Any, matrix: Any, output_shape: Any = None, order: Any = 1, use_gpu: Any = True) -> Any:
+    """
+    GPU-accelerated affine transformation.
+
+    Parameters
+    ----------
+    image : np.ndarray
+        Input image (2D or 3D)
+    matrix : np.ndarray
+        Affine transformation matrix
+    output_shape : tuple, optional
+        Shape of output image. If None, uses input shape.
+    order : int
+        Interpolation order (0=nearest, 1=linear, 3=cubic)
+    use_gpu : bool
+        Whether to use GPU acceleration
+
+    Returns
+    -------
+    np.ndarray
+        Transformed image
+    """
+    if output_shape is None:
+        output_shape = image.shape
+
+    if use_gpu and GPU_AVAILABLE:
+        return _affine_transform_gpu(image, matrix, output_shape, order)
+    else:
+        return _affine_transform_cpu(image, matrix, output_shape, order)
+
+
+def _affine_transform_gpu(image: Any, matrix: Any, output_shape: Any, order: Any) -> Any:
+    """GPU implementation of affine transform. Device-preserving."""
+    import cupy as cp
+    from cupyx.scipy.ndimage import affine_transform as cp_affine
+
+    input_was_gpu = is_cupy_array(image)
+    img_gpu = cp.asarray(image.astype(np.float32))
+    matrix_gpu = cp.asarray(matrix.astype(np.float32))
+
+    result = cp_affine(img_gpu, matrix_gpu, output_shape=output_shape, order=order)
+
+    if input_was_gpu:
+        return result
+    return to_cpu(result)
+
+
+def _affine_transform_cpu(image: Any, matrix: Any, output_shape: Any, order: Any) -> Any:
+    """CPU fallback for affine transform."""
+    from scipy.ndimage import affine_transform as scipy_affine
+
+    return scipy_affine(image, matrix, output_shape=output_shape, order=order)
+
+
+def map_coordinates(image: Any, coordinates: Any, order: Any = 1, use_gpu: Any = True) -> Any:
+    """
+    GPU-accelerated coordinate mapping (general interpolation).
+
+    Parameters
+    ----------
+    image : np.ndarray
+        Input image
+    coordinates : np.ndarray
+        Coordinates to sample at, shape (ndim, ...)
+    order : int
+        Interpolation order
+    use_gpu : bool
+        Whether to use GPU
+
+    Returns
+    -------
+    np.ndarray
+        Interpolated values
+    """
+    if use_gpu and GPU_AVAILABLE:
+        return _map_coordinates_gpu(image, coordinates, order)
+    else:
+        return _map_coordinates_cpu(image, coordinates, order)
+
+
+def _map_coordinates_gpu(image: Any, coordinates: Any, order: Any) -> Any:
+    """GPU implementation of map_coordinates. Device-preserving."""
+    import cupy as cp
+    from cupyx.scipy.ndimage import map_coordinates as cp_map
+
+    input_was_gpu = is_cupy_array(image)
+    img_gpu = cp.asarray(image.astype(np.float32))
+    coords_gpu = cp.asarray(coordinates.astype(np.float32))
+
+    result = cp_map(img_gpu, coords_gpu, order=order)
+
+    if input_was_gpu:
+        return result
+    return to_cpu(result)
+
+
+def _map_coordinates_cpu(image: Any, coordinates: Any, order: Any) -> Any:
+    """CPU fallback for map_coordinates."""
+    from scipy.ndimage import map_coordinates as scipy_map
+
+    return scipy_map(image, coordinates, order=order)
+
+
+def resize(image: Any, output_shape: Any, order: Any = 1, anti_aliasing: Any = True, use_gpu: Any = True) -> Any:
+    """
+    GPU-accelerated image resize.
+
+    Parameters
+    ----------
+    image : np.ndarray
+        Input image
+    output_shape : tuple
+        Desired output shape
+    order : int
+        Interpolation order
+    anti_aliasing : bool
+        Whether to apply anti-aliasing filter before downsampling
+    use_gpu : bool
+        Whether to use GPU
+
+    Returns
+    -------
+    np.ndarray
+        Resized image
+    """
+    if use_gpu and GPU_AVAILABLE:
+        return _resize_gpu(image, output_shape, order, anti_aliasing)
+    else:
+        return _resize_cpu(image, output_shape, order, anti_aliasing)
+
+
+def _resize_gpu(image: Any, output_shape: Any, order: Any, anti_aliasing: Any) -> Any:
+    """GPU implementation of resize using zoom.
+
+    Device-preserving: returns a CuPy array if *image* was already on device,
+    a NumPy array if *image* was on host. This avoids forcing a D->H copy when
+    callers want to keep tiles resident for downstream GPU compute / writes.
+    """
+    import cupy as cp
+    from cupyx.scipy.ndimage import gaussian_filter as cp_gaussian
+    from cupyx.scipy.ndimage import zoom as cp_zoom
+
+    input_was_gpu = is_cupy_array(image)
+    # Cast to float32 *after* H2D so PCIe carries the smaller (or unchanged) dtype.
+    # `copy=False` skips the device copy when the array is already float32.
+    img_gpu = cp.asarray(image).astype(np.float32, copy=False)
+
+    # Scale factors: input/output for Gaussian sigma, output/input for zoom.
+    scale_factors = tuple(i / o for i, o in zip(image.shape, output_shape, strict=False))
+    zoom_factors = tuple(o / i for i, o in zip(image.shape, output_shape, strict=False))
+
+    # Anti-aliasing: single fused Gaussian call with per-axis sigma vector,
+    # replacing N sequential per-axis kernel launches.
+    if anti_aliasing:
+        sigmas = [(f - 1) / 2 if f > 1 else 0.0 for f in scale_factors]
+        if any(s > 0 for s in sigmas):
+            img_gpu = cp_gaussian(img_gpu, sigma=sigmas)
+
+    result = cp_zoom(img_gpu, zoom_factors, order=order)
+
+    if input_was_gpu:
+        return result
+    return to_cpu(result)
+
+
+def _resize_cpu(image: Any, output_shape: Any, order: Any, anti_aliasing: Any) -> Any:
+    """CPU fallback for resize using zoom."""
+    from scipy.ndimage import gaussian_filter as scipy_gaussian
+    from scipy.ndimage import zoom as scipy_zoom
+
+    img = image if image.dtype == np.float32 else image.astype(np.float32)
+
+    scale_factors = tuple(i / o for i, o in zip(image.shape, output_shape, strict=False))
+    zoom_factors = tuple(o / i for i, o in zip(image.shape, output_shape, strict=False))
+
+    if anti_aliasing:
+        sigmas = [(f - 1) / 2 if f > 1 else 0.0 for f in scale_factors]
+        if any(s > 0 for s in sigmas):
+            img = scipy_gaussian(img, sigma=sigmas)
+
+    return scipy_zoom(img, zoom_factors, order=order)
+
+
+def apply_displacement_field(image: Any, displacement_field: Any, use_gpu: Any = True) -> Any:
+    """
+    Apply a displacement field to warp an image.
+
+    Parameters
+    ----------
+    image : np.ndarray
+        Input image (2D or 3D)
+    displacement_field : np.ndarray
+        Displacement field with shape ``(ndim, *image.shape)``
+    use_gpu : bool
+        Whether to use GPU
+
+    Returns
+    -------
+    np.ndarray
+        Warped image
+    """
+    _ndim = image.ndim
+
+    # Create coordinate grid
+    coords = np.meshgrid(*[np.arange(s) for s in image.shape], indexing="ij")
+    coords = np.array(coords)
+
+    # Add displacement
+    new_coords = coords + displacement_field
+
+    return map_coordinates(image, new_coords, order=1, use_gpu=use_gpu)
+
+
+def resample_volume(volume: Any, current_spacing: Any, target_spacing: Any, order: Any = 1, use_gpu: Any = True) -> Any:
+    """
+    Resample a volume to a new spacing.
+
+    Parameters
+    ----------
+    volume : np.ndarray
+        Input volume
+    current_spacing : tuple
+        Current voxel spacing
+    target_spacing : tuple
+        Target voxel spacing
+    order : int
+        Interpolation order
+    use_gpu : bool
+        Whether to use GPU
+
+    Returns
+    -------
+    np.ndarray
+        Resampled volume
+    """
+    # Compute new shape
+    scale_factors = tuple(c / t for c, t in zip(current_spacing, target_spacing, strict=False))
+    new_shape = tuple(int(s * f) for s, f in zip(volume.shape, scale_factors, strict=False))
+
+    return resize(volume, new_shape, order=order, anti_aliasing=True, use_gpu=use_gpu)

--- a/linumpy/gpu/kvikio_zarr.py
+++ b/linumpy/gpu/kvikio_zarr.py
@@ -1,0 +1,226 @@
+"""kvikio / GPUDirect Storage reader for uncompressed zarr arrays.
+
+This module implements the :func:`read_zarr_via_kvikio` backend used by
+:mod:`linumpy.gpu.zarr_io`. It reads zarr v2 *or* zarr v3 chunks directly
+into GPU memory using ``kvikio.CuFile``. The version is auto-detected from
+the on-disk metadata file (``zarr.json`` for v3, ``.zarray`` for v2).
+
+Most callers should use :func:`linumpy.gpu.zarr_io.read_zarr_to_gpu`, which
+dispatches to this backend only when GDS native mode is available and the
+array is uncompressed; otherwise it falls back to ``zarr.config.enable_gpu``.
+
+Supported on-disk formats
+-------------------------
+
+* zarr v3: ``codecs=[{"name": "bytes"}]`` only (or empty) — raw little/big-
+  endian bytes. Any compression codec (blosc, gzip, zstd, ...) is rejected
+  because GDS reads bytes verbatim and on-device decompression would require
+  nvCOMP.
+* zarr v2: ``compressor=None``, ``filters=None``, ``order='C'``.
+
+Notes
+-----
+* Requires ``kvikio`` and ``cupy``. Both are imported lazily so the rest of
+  linumpy is unaffected if they are not installed.
+* For the GDS fast path the source filesystem must support GDS natively
+  (ext4 on local NVMe, IOMMU disabled or in passthrough, and
+  ``properties.use_compat_mode=false`` in ``/etc/cufile.json``). Otherwise
+  kvikio falls back to a posix bounce-buffer path with no speed-up.
+"""
+
+import json
+import sys
+from itertools import product
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Iterator
+
+
+def _require_kvikio() -> tuple[Any, Any]:
+    """Import kvikio + cupy lazily and return (kvikio, cupy)."""
+    try:
+        import cupy
+        import kvikio
+    except ImportError as exc:  # pragma: no cover - hardware-dependent
+        raise RuntimeError(
+            "kvikio + cupy are required for the GDS prototype. Install with:\n"
+            "    pip install kvikio-cu13 cupy-cuda13x  # or matching your CUDA"
+        ) from exc
+    return kvikio, cupy
+
+
+def _parse_v3_dtype(dt: Any) -> np.dtype:
+    """Map a zarr v3 ``data_type`` field to a numpy dtype."""
+    if isinstance(dt, str):
+        return np.dtype(dt)
+    raise NotImplementedError(f"unsupported v3 data_type: {dt!r}")
+
+
+def _v3_chunk_path(array_path: Path, idx: tuple[int, ...], encoding: dict) -> Path:
+    """Build the on-disk chunk path for a zarr v3 array."""
+    name = encoding.get("name", "default")
+    sep = encoding.get("configuration", {}).get("separator", "/")
+    parts = sep.join(str(i) for i in idx)
+    if name == "default":
+        return array_path / "c" / parts if sep == "/" else array_path / f"c{sep}{parts}"
+    if name == "v2":
+        return array_path / parts
+    raise NotImplementedError(f"unsupported chunk_key_encoding: {name!r}")
+
+
+def _v2_chunk_path(array_path: Path, idx: tuple[int, ...], dim_separator: str) -> Path:
+    return array_path / dim_separator.join(str(i) for i in idx)
+
+
+class _ArraySpec:
+    """Resolved, format-agnostic view of a zarr array on disk."""
+
+    __slots__ = ("_v2_dim_sep", "_v3_encoding", "chunks", "dtype", "fill_value", "format", "path", "shape")
+
+    def __init__(
+        self,
+        *,
+        path: Path,
+        shape: tuple[int, ...],
+        chunks: tuple[int, ...],
+        dtype: np.dtype,
+        fill_value: Any,
+        format: int,
+        v3_encoding: dict | None = None,
+        v2_dim_sep: str | None = None,
+    ) -> None:
+        self.path = path
+        self.shape = shape
+        self.chunks = chunks
+        self.dtype = dtype
+        self.fill_value = fill_value
+        self.format = format
+        self._v3_encoding = v3_encoding
+        self._v2_dim_sep = v2_dim_sep
+
+    def chunk_path(self, idx: tuple[int, ...]) -> Path:
+        if self.format == 3:
+            assert self._v3_encoding is not None
+            return _v3_chunk_path(self.path, idx, self._v3_encoding)
+        assert self._v2_dim_sep is not None
+        return _v2_chunk_path(self.path, idx, self._v2_dim_sep)
+
+
+def _load_array_spec(array_path: Path) -> _ArraySpec:
+    """Inspect ``array_path`` and return a normalized spec for v2 or v3."""
+    v3_meta = array_path / "zarr.json"
+    v2_meta = array_path / ".zarray"
+
+    if v3_meta.exists():
+        meta = json.loads(v3_meta.read_text())
+        if meta.get("zarr_format") != 3:
+            raise ValueError(f"{array_path}: zarr.json has zarr_format != 3")
+        if meta.get("node_type") != "array":
+            raise ValueError(f"{array_path}: zarr.json is not an array node")
+        codecs = meta.get("codecs", [])
+        non_bytes = [c for c in codecs if c.get("name") != "bytes"]
+        if non_bytes:
+            raise NotImplementedError(
+                f"{array_path}: codecs={[c.get('name') for c in codecs]!r}; this prototype "
+                "requires raw bytes only (no compression). On-device decompression needs nvCOMP."
+            )
+        host_endian = "big" if sys.byteorder == "big" else "little"
+        for c in codecs:
+            endian = c.get("configuration", {}).get("endian", "little")
+            if endian != host_endian:
+                raise NotImplementedError(f"{array_path}: endian={endian!r} differs from host")
+        chunk_grid = meta.get("chunk_grid", {})
+        if chunk_grid.get("name") != "regular":
+            raise NotImplementedError(f"{array_path}: chunk_grid={chunk_grid.get('name')!r}")
+        return _ArraySpec(
+            path=array_path,
+            shape=tuple(meta["shape"]),
+            chunks=tuple(chunk_grid["configuration"]["chunk_shape"]),
+            dtype=_parse_v3_dtype(meta["data_type"]),
+            fill_value=meta.get("fill_value", 0),
+            format=3,
+            v3_encoding=meta.get("chunk_key_encoding", {"name": "default", "configuration": {"separator": "/"}}),
+        )
+
+    if v2_meta.exists():
+        meta = json.loads(v2_meta.read_text())
+        if meta.get("zarr_format") != 2:
+            raise ValueError(f"{array_path}: .zarray has zarr_format != 2")
+        if meta.get("compressor") is not None:
+            raise NotImplementedError(
+                f"{array_path}: compressor={meta['compressor']!r}; this prototype "
+                "requires uncompressed chunks. On-device decompression needs nvCOMP."
+            )
+        if meta.get("order", "C") != "C":
+            raise NotImplementedError(f"{array_path}: order={meta['order']!r} unsupported")
+        if meta.get("filters"):
+            raise NotImplementedError(f"{array_path}: filters unsupported in prototype")
+        return _ArraySpec(
+            path=array_path,
+            shape=tuple(meta["shape"]),
+            chunks=tuple(meta["chunks"]),
+            dtype=np.dtype(meta["dtype"]),
+            fill_value=meta.get("fill_value", 0),
+            format=2,
+            v2_dim_sep=meta.get("dimension_separator", "."),
+        )
+
+    raise FileNotFoundError(f"{array_path}: no zarr.json (v3) or .zarray (v2) found")
+
+
+def _iter_chunk_indices(shape: Iterable[int], chunks: Iterable[int]) -> Iterator[tuple[int, ...]]:
+    n = [(s + c - 1) // c for s, c in zip(shape, chunks, strict=True)]
+    yield from product(*[range(k) for k in n])
+
+
+def read_zarr_via_kvikio(array_path: str | Path) -> Any:
+    """Load a full uncompressed zarr (v2 or v3) array into a CuPy array via GDS.
+
+    Parameters
+    ----------
+    array_path
+        Path to the zarr array directory (containing ``zarr.json`` for v3 or
+        ``.zarray`` for v2).
+
+    Returns
+    -------
+    cupy.ndarray
+        Device-resident array of shape and dtype matching the zarr metadata.
+    """
+    kvikio, cupy = _require_kvikio()
+    spec = _load_array_spec(Path(array_path))
+
+    out = cupy.full(spec.shape, spec.fill_value, dtype=spec.dtype)
+    chunk_nbytes_full = int(np.prod(spec.chunks) * spec.dtype.itemsize)
+    scratch = cupy.empty(spec.chunks, dtype=spec.dtype)
+
+    for idx in _iter_chunk_indices(spec.shape, spec.chunks):
+        cf_path = spec.chunk_path(idx)
+        if not cf_path.exists():
+            continue  # zarr fill-value semantics
+
+        slices: list[slice] = []
+        edge_shape: list[int] = []
+        for k, c, s in zip(idx, spec.chunks, spec.shape, strict=True):
+            start = k * c
+            stop = min(start + c, s)
+            slices.append(slice(start, stop))
+            edge_shape.append(stop - start)
+        edge_shape_t = tuple(edge_shape)
+
+        # kvikio.CuFile.pread requires a contiguous device buffer; a slice
+        # into ``out`` is generally not contiguous, so we read into a
+        # chunk-shaped scratch and copy the valid region into ``out``.
+        with kvikio.CuFile(str(cf_path), "r") as f:
+            f.pread(scratch, chunk_nbytes_full).get()
+        if edge_shape_t == spec.chunks:
+            out[tuple(slices)] = scratch
+        else:
+            sub = tuple(slice(0, e) for e in edge_shape_t)
+            out[tuple(slices)] = scratch[sub]
+
+    return out

--- a/linumpy/gpu/morphology.py
+++ b/linumpy/gpu/morphology.py
@@ -1,0 +1,423 @@
+"""
+GPU-accelerated morphological operations for linumpy.
+
+Provides GPU versions of binary morphology, mask creation,
+and connected component operations.
+"""
+
+from typing import Any
+
+import numpy as np
+
+from . import GPU_AVAILABLE, to_cpu
+
+
+def binary_closing(mask: Any, iterations: Any = 1, structure: Any = None, use_gpu: Any = True) -> Any:
+    """
+    GPU-accelerated binary closing.
+
+    Parameters
+    ----------
+    mask : np.ndarray
+        Binary mask
+    iterations : int
+        Number of iterations
+    structure : np.ndarray, optional
+        Structuring element
+    use_gpu : bool
+        Whether to use GPU
+
+    Returns
+    -------
+    np.ndarray
+        Closed mask
+    """
+    if use_gpu and GPU_AVAILABLE:
+        import cupy as cp
+        from cupyx.scipy.ndimage import binary_closing as cp_closing
+        from cupyx.scipy.ndimage import generate_binary_structure
+
+        mask_gpu = cp.asarray(mask.astype(np.bool_))
+
+        structure = generate_binary_structure(mask.ndim, 1) if structure is None else cp.asarray(structure)
+
+        result = cp_closing(mask_gpu, structure=structure, iterations=iterations, brute_force=True)
+
+        output = to_cpu(result)
+        # Free GPU memory
+        del mask_gpu, result
+        cp.get_default_memory_pool().free_all_blocks()
+        return output
+    else:
+        from scipy.ndimage import binary_closing as scipy_closing
+        from scipy.ndimage import generate_binary_structure
+
+        if structure is None:
+            structure = generate_binary_structure(mask.ndim, 1)
+
+        return scipy_closing(mask, structure=structure, iterations=iterations)
+
+
+def binary_opening(mask: Any, iterations: Any = 1, structure: Any = None, use_gpu: Any = True) -> Any:
+    """
+    GPU-accelerated binary opening.
+
+    Parameters
+    ----------
+    mask : np.ndarray
+        Binary mask
+    iterations : int
+        Number of iterations
+    structure : np.ndarray, optional
+        Structuring element
+    use_gpu : bool
+        Whether to use GPU
+
+    Returns
+    -------
+    np.ndarray
+        Opened mask
+    """
+    if use_gpu and GPU_AVAILABLE:
+        import cupy as cp
+        from cupyx.scipy.ndimage import binary_opening as cp_opening
+        from cupyx.scipy.ndimage import generate_binary_structure
+
+        mask_gpu = cp.asarray(mask.astype(np.bool_))
+
+        structure = generate_binary_structure(mask.ndim, 1) if structure is None else cp.asarray(structure)
+
+        result = cp_opening(mask_gpu, structure=structure, iterations=iterations, brute_force=True)
+
+        output = to_cpu(result)
+        # Free GPU memory
+        del mask_gpu, result
+        cp.get_default_memory_pool().free_all_blocks()
+        return output
+    else:
+        from scipy.ndimage import binary_opening as scipy_opening
+        from scipy.ndimage import generate_binary_structure
+
+        if structure is None:
+            structure = generate_binary_structure(mask.ndim, 1)
+
+        return scipy_opening(mask, structure=structure, iterations=iterations)
+
+
+def binary_dilation(mask: Any, iterations: Any = 1, structure: Any = None, use_gpu: Any = True) -> Any:
+    """
+    GPU-accelerated binary dilation.
+
+    Parameters
+    ----------
+    mask : np.ndarray
+        Binary mask
+    iterations : int
+        Number of iterations
+    structure : np.ndarray, optional
+        Structuring element
+    use_gpu : bool
+        Whether to use GPU
+
+    Returns
+    -------
+    np.ndarray
+        Dilated mask
+    """
+    if use_gpu and GPU_AVAILABLE:
+        import cupy as cp
+        from cupyx.scipy.ndimage import binary_dilation as cp_dilation
+        from cupyx.scipy.ndimage import generate_binary_structure
+
+        mask_gpu = cp.asarray(mask.astype(np.bool_))
+
+        structure = generate_binary_structure(mask.ndim, 1) if structure is None else cp.asarray(structure)
+
+        result = cp_dilation(mask_gpu, structure=structure, iterations=iterations, brute_force=True)
+
+        output = to_cpu(result)
+        # Free GPU memory
+        del mask_gpu, result
+        cp.get_default_memory_pool().free_all_blocks()
+        return output
+    else:
+        from scipy.ndimage import binary_dilation as scipy_dilation
+        from scipy.ndimage import generate_binary_structure
+
+        if structure is None:
+            structure = generate_binary_structure(mask.ndim, 1)
+
+        return scipy_dilation(mask, structure=structure, iterations=iterations)
+
+
+def binary_erosion(mask: Any, iterations: Any = 1, structure: Any = None, use_gpu: Any = True) -> Any:
+    """
+    GPU-accelerated binary erosion.
+
+    Parameters
+    ----------
+    mask : np.ndarray
+        Binary mask
+    iterations : int
+        Number of iterations
+    structure : np.ndarray, optional
+        Structuring element
+    use_gpu : bool
+        Whether to use GPU
+
+    Returns
+    -------
+    np.ndarray
+        Eroded mask
+    """
+    if use_gpu and GPU_AVAILABLE:
+        import cupy as cp
+        from cupyx.scipy.ndimage import binary_erosion as cp_erosion
+        from cupyx.scipy.ndimage import generate_binary_structure
+
+        mask_gpu = cp.asarray(mask.astype(np.bool_))
+
+        structure = generate_binary_structure(mask.ndim, 1) if structure is None else cp.asarray(structure)
+
+        result = cp_erosion(mask_gpu, structure=structure, iterations=iterations, brute_force=True)
+
+        output = to_cpu(result)
+        # Free GPU memory
+        del mask_gpu, result
+        cp.get_default_memory_pool().free_all_blocks()
+        return output
+    else:
+        from scipy.ndimage import binary_erosion as scipy_erosion
+        from scipy.ndimage import generate_binary_structure
+
+        if structure is None:
+            structure = generate_binary_structure(mask.ndim, 1)
+
+        return scipy_erosion(mask, structure=structure, iterations=iterations)
+
+
+def binary_fill_holes(mask: Any, use_gpu: Any = True) -> Any:
+    """
+    GPU-accelerated binary hole filling.
+
+    Parameters
+    ----------
+    mask : np.ndarray
+        Binary mask
+    use_gpu : bool
+        Whether to use GPU
+
+    Returns
+    -------
+    np.ndarray
+        Mask with holes filled
+    """
+    if use_gpu and GPU_AVAILABLE:
+        import cupy as cp
+        from cupyx.scipy.ndimage import binary_fill_holes as cp_fill
+
+        mask_gpu = cp.asarray(mask.astype(np.bool_))
+        result = cp_fill(mask_gpu)
+
+        output = to_cpu(result)
+        # Free GPU memory
+        del mask_gpu, result
+        cp.get_default_memory_pool().free_all_blocks()
+        return output
+    else:
+        from scipy.ndimage import binary_fill_holes as scipy_fill
+
+        return scipy_fill(mask)
+
+
+def gaussian_filter(image: Any, sigma: Any, use_gpu: Any = True) -> Any:
+    """
+    GPU-accelerated Gaussian filter.
+
+    Parameters
+    ----------
+    image : np.ndarray
+        Input image
+    sigma : float or sequence
+        Standard deviation for Gaussian kernel
+    use_gpu : bool
+        Whether to use GPU
+
+    Returns
+    -------
+    np.ndarray
+        Filtered image
+    """
+    if use_gpu and GPU_AVAILABLE:
+        import cupy as cp
+        from cupyx.scipy.ndimage import gaussian_filter as cp_gaussian
+
+        img_gpu = cp.asarray(image.astype(np.float32))
+        result = cp_gaussian(img_gpu, sigma=sigma)
+
+        output = to_cpu(result)
+        # Free GPU memory
+        del img_gpu, result
+        cp.get_default_memory_pool().free_all_blocks()
+        return output
+    else:
+        from scipy.ndimage import gaussian_filter as scipy_gaussian
+
+        return scipy_gaussian(image, sigma=sigma)
+
+
+def median_filter(image: Any, size: Any, use_gpu: Any = True) -> Any:
+    """
+    GPU-accelerated median filter.
+
+    Parameters
+    ----------
+    image : np.ndarray
+        Input image
+    size : int or sequence
+        Filter size
+    use_gpu : bool
+        Whether to use GPU
+
+    Returns
+    -------
+    np.ndarray
+        Filtered image
+    """
+    if use_gpu and GPU_AVAILABLE:
+        import cupy as cp
+        from cupyx.scipy.ndimage import median_filter as cp_median
+
+        img_gpu = cp.asarray(image)
+        result = cp_median(img_gpu, size=size)
+
+        output = to_cpu(result)
+        # Free GPU memory
+        del img_gpu, result
+        cp.get_default_memory_pool().free_all_blocks()
+        return output
+    else:
+        from scipy.ndimage import median_filter as scipy_median
+
+        return scipy_median(image, size=size)
+
+
+def create_tissue_mask(
+    image: Any, sigma: Any = 2, threshold: Any = None, fill_holes: Any = True, min_opening: Any = 1, use_gpu: Any = True
+) -> Any:
+    """
+    GPU-accelerated tissue mask creation.
+
+    Parameters
+    ----------
+    image : np.ndarray
+        Input image
+    sigma : float
+        Gaussian smoothing sigma
+    threshold : float, optional
+        Threshold value. If None, uses Otsu
+    fill_holes : bool
+        Whether to fill holes
+    min_opening : int
+        Opening iterations for noise removal
+    use_gpu : bool
+        Whether to use GPU
+
+    Returns
+    -------
+    np.ndarray
+        Binary tissue mask
+    """
+    from .array_ops import threshold_otsu
+
+    # Smooth
+    smoothed = gaussian_filter(image, sigma, use_gpu=use_gpu)
+
+    # Threshold
+    if threshold is None:
+        threshold = threshold_otsu(smoothed, use_gpu=use_gpu)
+
+    if use_gpu and GPU_AVAILABLE:
+        import cupy as cp
+
+        smoothed_gpu = cp.asarray(smoothed)
+        mask = smoothed_gpu > threshold
+        mask = to_cpu(mask)
+    else:
+        mask = smoothed > threshold
+
+    # Clean up
+    if min_opening > 0:
+        mask = binary_opening(mask, iterations=min_opening, use_gpu=use_gpu)
+
+    if fill_holes:
+        mask = binary_fill_holes(mask, use_gpu=use_gpu)
+
+    return mask
+
+
+def label_connected_components(mask: Any, _use_gpu: Any = True) -> Any:
+    """
+    Label connected components in a binary mask.
+
+    Note: CuPy's connected components is limited. Falls back to CPU
+    for complex cases.
+
+    Parameters
+    ----------
+    mask : np.ndarray
+        Binary mask
+    use_gpu : bool
+        Whether to attempt GPU (may fall back to CPU)
+
+    Returns
+    -------
+    np.ndarray
+        Labeled array
+    int
+        Number of labels
+    """
+    # CuPy's label function is limited, use CPU for reliability
+    from scipy.ndimage import label as scipy_label
+
+    return scipy_label(mask)
+
+
+def get_largest_component(mask: Any, use_gpu: Any = True) -> Any:
+    """
+    Get the largest connected component from a mask.
+
+    Parameters
+    ----------
+    mask : np.ndarray
+        Binary mask
+    use_gpu : bool
+        Whether to use GPU for histogram
+
+    Returns
+    -------
+    np.ndarray
+        Binary mask of largest component
+    """
+    labeled, n_labels = label_connected_components(mask, False)
+
+    if n_labels == 0:
+        return mask
+
+    if use_gpu and GPU_AVAILABLE:
+        import cupy as cp
+
+        labeled_gpu = cp.asarray(labeled)
+
+        # Find largest component (excluding background 0)
+        counts = cp.bincount(labeled_gpu.ravel())
+        counts[0] = 0  # Ignore background
+        largest_label = int(cp.argmax(counts).get())
+
+        result = labeled_gpu == largest_label
+        return to_cpu(result)
+    else:
+        counts = np.bincount(labeled.ravel())
+        counts[0] = 0
+        largest_label = np.argmax(counts)
+        return labeled == largest_label

--- a/linumpy/gpu/nvcomp_zstd.py
+++ b/linumpy/gpu/nvcomp_zstd.py
@@ -1,0 +1,218 @@
+"""GPU-accelerated zstd codec for zarr-python, backed by nvCOMP.
+
+This is a vendored stand-in for upstream zarr-python PR #2863 (`zarr.codecs.gpu.NvcompZstdCodec`),
+which is approved but not yet released. The codec implementation matches that PR closely so we
+can swap to the upstream class once it lands without changing call sites.
+
+Why this exists
+---------------
+With ``zarr.config.enable_gpu()``, zarr-python (≤3.2) reads zstd-compressed chunks by:
+
+1. ``GDSStore`` (or any store) yields a CPU buffer.
+2. The default ``zarr.codecs.zstd.ZstdCodec`` decodes on the CPU (numcodecs).
+3. The decoded chunk is copied H→D into a ``cupy`` buffer.
+
+That CPU decode + H→D copy is the bottleneck for compressed tiles. This module replaces step 2:
+chunks are uploaded to the GPU and decoded with ``nvidia.nvcomp.Codec("Zstd")``, so the result
+already lives on device.
+
+Usage
+-----
+The codec is registered under the name ``"zstd"`` (same as the default), so any existing zarr
+file with zstd-compressed chunks will use it once registered. Registration happens lazily from
+:mod:`linumpy.gpu.zarr_io` whenever a GPU read path is taken, so CPU-only workflows are
+unaffected.
+
+References
+----------
+* https://github.com/zarr-developers/zarr-python/pull/2863
+* https://docs.nvidia.com/cuda/nvcomp/
+"""
+
+import asyncio
+from dataclasses import dataclass
+from functools import cached_property
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+from zarr.abc.codec import BytesBytesCodec
+from zarr.core.common import JSON, parse_named_configuration
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from typing import Self
+
+    from zarr.core.array_spec import ArraySpec
+    from zarr.core.buffer import Buffer
+
+
+def _parse_zstd_level(data: JSON) -> int:
+    if isinstance(data, int):
+        if data >= 23:
+            raise ValueError(f"Value must be less than or equal to 22. Got {data} instead.")
+        return data
+    raise TypeError(f"Got value with type {type(data)}, but expected an int.")
+
+
+def _parse_checksum(data: JSON) -> bool:
+    if isinstance(data, bool):
+        return data
+    raise TypeError(f"Expected bool. Got {type(data)}.")
+
+
+@dataclass(frozen=True)
+class NvcompZstdCodec(BytesBytesCodec):
+    """zstd codec that decodes/encodes on an NVIDIA GPU via nvCOMP."""
+
+    is_fixed_size = True
+
+    level: int = 0
+    checksum: bool = False
+
+    def __init__(self, *, level: int = 0, checksum: bool = False) -> None:
+        level_parsed = _parse_zstd_level(level)
+        checksum_parsed = _parse_checksum(checksum)
+        object.__setattr__(self, "level", level_parsed)
+        object.__setattr__(self, "checksum", checksum_parsed)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, JSON]) -> Self:
+        """Construct codec from its serialised metadata representation."""
+        _, configuration_parsed = parse_named_configuration(data, "zstd")
+        cfg: dict[str, Any] = dict(configuration_parsed)  # type: ignore[arg-type]
+        level = cfg.get("level", 0)
+        checksum = cfg.get("checksum", False)
+        if not isinstance(level, int):
+            raise TypeError(f"zstd codec level must be int, got {type(level).__name__}")
+        if not isinstance(checksum, bool):
+            raise TypeError(f"zstd codec checksum must be bool, got {type(checksum).__name__}")
+        return cls(level=level, checksum=checksum)
+
+    def to_dict(self) -> dict[str, JSON]:
+        """Return the codec's metadata dict (named ``zstd`` for on-disk compatibility)."""
+        return {
+            "name": "zstd",
+            "configuration": {"level": self.level, "checksum": self.checksum},
+        }
+
+    @cached_property
+    def _zstd_codec(self) -> Any:
+        import cupy as cp
+        from nvidia import nvcomp
+
+        device = cp.cuda.Device()
+        stream = cp.cuda.get_current_stream()
+        return nvcomp.Codec(
+            algorithm="Zstd",
+            bitstream_kind=nvcomp.BitstreamKind.RAW,
+            device_id=device.id,
+            cuda_stream=stream.ptr,
+        )
+
+    def _convert_to_nvcomp_arrays(
+        self,
+        chunks_and_specs: Iterable[tuple[Buffer | None, ArraySpec]],
+    ) -> tuple[list[Any], list[int]]:
+        from nvidia import nvcomp
+
+        none_indices = [i for i, (b, _) in enumerate(chunks_and_specs) if b is None]
+        filtered_inputs = [b.as_array_like() for b, _ in chunks_and_specs if b is not None]
+        return nvcomp.as_arrays(filtered_inputs), none_indices
+
+    def _convert_from_nvcomp_arrays(
+        self,
+        arrays: Iterable[Any],
+        chunks_and_specs: Iterable[tuple[Buffer | None, ArraySpec]],
+    ) -> Iterable[Buffer | None]:
+        import cupy as cp
+
+        result: list[Buffer | None] = []
+        for a, (_, spec) in zip(arrays, chunks_and_specs, strict=True):
+            if a is None:
+                result.append(None)
+            else:
+                a2 = cp.array(a, dtype=a.dtype, copy=False)
+                if a2.dtype != np.dtype("B"):
+                    a2 = a2.view(dtype=np.dtype("B"))
+                result.append(spec.prototype.buffer.from_array_like(a2))
+        return result
+
+    async def decode(
+        self,
+        chunks_and_specs: Iterable[tuple[Buffer | None, ArraySpec]],
+    ) -> Iterable[Buffer | None]:
+        """Decode a batch of zstd-compressed chunks on the GPU via nvCOMP."""
+        import cupy as cp
+
+        chunks_and_specs = list(chunks_and_specs)
+        filtered_inputs, none_indices = self._convert_to_nvcomp_arrays(chunks_and_specs)
+        outputs = self._zstd_codec.decode(filtered_inputs) if len(filtered_inputs) > 0 else []
+        event = cp.cuda.Event()
+        event.record()
+        await asyncio.to_thread(event.synchronize)
+        outputs = list(outputs)
+        for index in none_indices:
+            outputs.insert(index, None)
+        return self._convert_from_nvcomp_arrays(outputs, chunks_and_specs)
+
+    async def encode(
+        self,
+        chunks_and_specs: Iterable[tuple[Buffer | None, ArraySpec]],
+    ) -> Iterable[Buffer | None]:
+        """Encode a batch of chunks with zstd on the GPU via nvCOMP."""
+        import cupy as cp
+
+        chunks_and_specs = list(chunks_and_specs)
+        filtered_inputs, none_indices = self._convert_to_nvcomp_arrays(chunks_and_specs)
+        outputs = self._zstd_codec.encode(filtered_inputs) if len(filtered_inputs) > 0 else []
+        event = cp.cuda.Event()
+        event.record()
+        await asyncio.to_thread(event.synchronize)
+        outputs = list(outputs)
+        for index in none_indices:
+            outputs.insert(index, None)
+        return self._convert_from_nvcomp_arrays(outputs, chunks_and_specs)
+
+    def compute_encoded_size(self, input_byte_length: int, chunk_spec: ArraySpec) -> int:
+        """Raise NotImplementedError — encoded size is data-dependent for zstd."""
+        del input_byte_length, chunk_spec
+        raise NotImplementedError
+
+
+_REGISTERED = False
+
+
+def register_nvcomp_zstd() -> bool:
+    """Register :class:`NvcompZstdCodec` under the name ``zstd``.
+
+    Idempotent. Returns True if registration succeeded (or was already done), False if the
+    required GPU dependencies (``cupy``, ``nvidia.nvcomp``) are not importable.
+
+    Note that registration alone is not enough to make zarr use the GPU codec — zarr 3.2
+    selects the concrete class via ``zarr.config["codecs.zstd"]`` and the default points at
+    the CPU codec. Use :func:`gpu_zstd_config` (or rely on
+    :func:`linumpy.gpu.zarr_io.gpu_zarr_context`) to flip the config for a scoped block.
+    """
+    global _REGISTERED
+    if _REGISTERED:
+        return True
+    try:
+        import cupy  # noqa: F401
+        from nvidia import nvcomp  # noqa: F401
+    except ImportError:
+        return False
+    from zarr.registry import register_codec
+
+    register_codec("zstd", NvcompZstdCodec)
+    _REGISTERED = True
+    return True
+
+
+def gpu_zstd_config() -> dict[str, str]:
+    """Return the zarr config overrides that route the ``zstd`` codec through nvCOMP.
+
+    Pass the result to ``zarr.config.set(...)`` to enable GPU-side zstd decoding for the
+    duration of the ``set`` context. Caller is responsible for calling
+    :func:`register_nvcomp_zstd` first (otherwise zarr cannot resolve the class name).
+    """
+    return {"codecs.zstd": "linumpy.gpu.nvcomp_zstd.NvcompZstdCodec"}

--- a/linumpy/gpu/zarr_io.py
+++ b/linumpy/gpu/zarr_io.py
@@ -1,0 +1,200 @@
+"""High-level zarr → GPU loading with automatic backend selection.
+
+Public entry points:
+
+* :func:`read_zarr_to_gpu` — load an entire zarr array onto the GPU using the
+  fastest available path (kvikio / GDS, falling back to ``zarr.config.enable_gpu``).
+* :func:`gpu_zarr_context` — context manager that flips zarr into GPU mode for
+  its duration, so subsequent ``zarr.open_array(...)`` calls return arrays whose
+  slicing materialises directly into ``cupy.ndarray``. Use this for tile-by-tile
+  / per-slab access patterns where loading the whole volume at once is wasteful.
+
+Selection order (when ``prefer='auto'``):
+
+1. **kvikio (GPUDirect Storage, native mode)** — chunks DMA'd directly from
+   NVMe into GPU memory. Requires ``kvikio`` installed, GDS in native mode,
+   and an uncompressed zarr v2/v3.
+2. **zarr.config.enable_gpu()** — host I/O with on-host decode then a single
+   H→D copy. Works for any zarr (compressed or not). The fallback when GDS
+   is unavailable, in compat mode, or the array is compressed.
+
+Backend implementations live in their own modules:
+
+* :mod:`linumpy.gpu.kvikio_zarr` — kvikio / GDS reader.
+
+Reference numbers on a 16 GiB float32 zarr v3 (RTX A6000, ext4, GDS native)
+warm cache: kvikio ~9.9 GiB/s, zarr-gpu ~7.1 GiB/s.
+"""
+
+from contextlib import contextmanager
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Literal
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+Backend = Literal["auto", "kvikio", "zarr-gpu"]
+
+
+def _kvikio_native_mode_available() -> bool:
+    """Return True iff kvikio is importable and not stuck in compat mode.
+
+    kvikio always succeeds at import; the relevant question is whether
+    ``cufile.json`` (or env vars) allow native GDS. The API moved in kvikio
+    25.x → 26.x:
+
+    * Older: ``kvikio.defaults.compat_mode()`` → ``CompatMode`` enum
+      (``OFF``/``ON``/``AUTO``).
+    * 26.04+: ``kvikio.defaults.is_compat_mode_preferred()`` → ``bool``
+      (``True`` means kvikio will use the POSIX bounce-buffer path).
+    """
+    try:
+        import kvikio  # noqa: F401
+        from kvikio import defaults
+    except ImportError:
+        return False
+    # Newer API first.
+    is_compat_pref = getattr(defaults, "is_compat_mode_preferred", None)
+    if callable(is_compat_pref):
+        try:
+            return not bool(is_compat_pref())
+        except Exception:  # pragma: no cover - hardware-dependent
+            return False
+    # Legacy enum API.
+    compat_mode = getattr(defaults, "compat_mode", None)
+    if callable(compat_mode):
+        try:
+            mode = compat_mode()
+        except Exception:  # pragma: no cover - older kvikio variants
+            return False
+        name = getattr(mode, "name", str(mode)).upper()
+        return name in {"OFF", "AUTO"}
+    return False
+
+
+def _array_is_kvikio_compatible(array_path: Path) -> bool:
+    """Return True iff the on-disk array meets kvikio's raw-bytes constraints."""
+    from linumpy.gpu.kvikio_zarr import _load_array_spec
+
+    try:
+        _load_array_spec(array_path)
+    except NotImplementedError, FileNotFoundError, ValueError:
+        return False
+    return True
+
+
+def read_zarr_via_zarr_gpu(array_path: str | Path) -> Any:
+    """Load a zarr array onto the GPU using ``zarr.config.enable_gpu()``.
+
+    Host I/O with on-host decode, then a single H→D copy. Works for any zarr
+    array (including compressed) and is the recommended fallback when GDS is
+    unavailable or stuck in compat mode.
+
+    Parameters
+    ----------
+    array_path
+        Path to the zarr array directory.
+
+    Returns
+    -------
+    cupy.ndarray
+        Device-resident array.
+    """
+    try:
+        import cupy
+        import zarr
+    except ImportError as exc:  # pragma: no cover - hardware-dependent
+        raise RuntimeError("cupy + zarr are required for the zarr-gpu fallback path.") from exc
+
+    from linumpy.gpu.nvcomp_zstd import gpu_zstd_config, register_nvcomp_zstd
+
+    extra_cfg = gpu_zstd_config() if register_nvcomp_zstd() else {}
+
+    with zarr.config.enable_gpu(), zarr.config.set(extra_cfg):
+        z = zarr.open_array(str(array_path), mode="r")
+        dev = z[:]
+    cupy.cuda.Stream.null.synchronize()
+    return dev
+
+
+def read_zarr_to_gpu(array_path: str | Path, *, prefer: Backend = "auto") -> Any:
+    """Load a zarr array onto the GPU using the fastest available path.
+
+    Selection order (when ``prefer='auto'``):
+
+    1. kvikio / GDS — only if kvikio is in native or auto mode AND the array
+       is uncompressed v2/v3.
+    2. ``zarr.config.enable_gpu()`` — works for any zarr.
+
+    Parameters
+    ----------
+    array_path
+        Path to the zarr array directory.
+    prefer
+        ``'auto'`` (default), ``'kvikio'``, or ``'zarr-gpu'``. Forcing a path
+        will raise if that path is unavailable for this array.
+
+    Returns
+    -------
+    cupy.ndarray
+        Device-resident array of shape and dtype matching the zarr metadata.
+    """
+    path = Path(array_path)
+
+    if prefer == "kvikio":
+        from linumpy.gpu.kvikio_zarr import read_zarr_via_kvikio
+
+        return read_zarr_via_kvikio(path)
+    if prefer == "zarr-gpu":
+        return read_zarr_via_zarr_gpu(path)
+    if prefer != "auto":
+        raise ValueError(f"unknown prefer={prefer!r}; expected 'auto', 'kvikio', or 'zarr-gpu'")
+
+    if _kvikio_native_mode_available() and _array_is_kvikio_compatible(path):
+        from linumpy.gpu.kvikio_zarr import read_zarr_via_kvikio
+
+        try:
+            return read_zarr_via_kvikio(path)
+        except RuntimeError, OSError, NotImplementedError:
+            pass
+
+    return read_zarr_via_zarr_gpu(path)
+
+
+@contextmanager
+def gpu_zarr_context() -> Iterator[None]:
+    """Context manager that puts zarr into GPU mode for arbitrary slice reads.
+
+    Inside this context, any subsequent ``zarr.open_array(...)`` returns an
+    array whose slicing produces ``cupy.ndarray`` results — chunks are decoded
+    on host then transferred to device on each ``vol[slice]`` operation. This
+    is the right pattern for tile-by-tile or per-slab work where loading the
+    full volume at once is wasteful.
+
+    Outside this context, zarr falls back to its normal numpy-backed mode.
+
+    Examples
+    --------
+    >>> from linumpy.gpu.zarr_io import gpu_zarr_context
+    >>> from linumpy.io.zarr import read_omezarr
+    >>> with gpu_zarr_context():
+    ...     vol, _ = read_omezarr(path, level=0)
+    ...     for tile_region in regions:
+    ...         tile_gpu = vol[tile_region]  # already cupy
+
+    Raises
+    ------
+    RuntimeError
+        If zarr is unavailable.
+    """
+    try:
+        import zarr
+    except ImportError as exc:  # pragma: no cover - zarr is a hard dep
+        raise RuntimeError("zarr is required for gpu_zarr_context().") from exc
+
+    from linumpy.gpu.nvcomp_zstd import gpu_zstd_config, register_nvcomp_zstd
+
+    extra_cfg = gpu_zstd_config() if register_nvcomp_zstd() else {}
+
+    with zarr.config.enable_gpu(), zarr.config.set(extra_cfg):
+        yield

--- a/linumpy/tests/test_gpu_bspline.py
+++ b/linumpy/tests/test_gpu_bspline.py
@@ -1,0 +1,173 @@
+"""Tests for linumpy.gpu.bspline."""
+
+import numpy as np
+import pytest
+
+from linumpy.gpu import GPU_AVAILABLE
+from linumpy.gpu.bspline import (
+    _cubic_bspline_basis,
+    bspline_evaluate,
+    bspline_fit,
+)
+
+# ---------------------------------------------------------------------------
+# Basis function sanity
+# ---------------------------------------------------------------------------
+
+
+def test_basis_partition_of_unity():
+    """The four cubic B-spline weights must sum to 1 for any t in [0, 1)."""
+    t = np.linspace(0.0, 0.999, 50, dtype=np.float32)
+    weights = _cubic_bspline_basis(t, np)
+    assert weights.shape == (50, 4)
+    np.testing.assert_allclose(weights.sum(axis=1), 1.0, atol=1e-6)
+
+
+def test_basis_nonnegative():
+    t = np.linspace(0.0, 0.999, 50, dtype=np.float32)
+    weights = _cubic_bspline_basis(t, np)
+    assert (weights >= 0).all()
+
+
+# ---------------------------------------------------------------------------
+# bspline_fit + bspline_evaluate (CPU path)
+# ---------------------------------------------------------------------------
+
+
+def _iterative_fit(
+    vals: np.ndarray,
+    n_control_points: tuple[int, int, int],
+    *,
+    mask: np.ndarray | None = None,
+    n_iter: int = 8,
+) -> np.ndarray:
+    """Fit ``vals`` by iterative residual PSDB fitting.
+
+    A single :func:`bspline_fit` call uses the Lee-Wolberg-Shin
+    pseudo-squared-distance-based form, which regularises short-range
+    support but does **not** reproduce smooth inputs in one pass. Real
+    callers (e.g. :mod:`linumpy.gpu.n4`) recover smooth fields by fitting
+    the residual at each iteration. This helper mirrors that pattern so
+    the tests exercise the primitive in its actual usage.
+    """
+    field = np.zeros_like(vals)
+    weights = mask.astype(np.float32) if mask is not None else None
+    for _ in range(n_iter):
+        residual = vals - field
+        if mask is not None:
+            residual = np.where(mask, residual, 0.0).astype(np.float32)
+        coeffs = bspline_fit(
+            residual,
+            weights=weights,
+            mask=mask,
+            n_control_points=n_control_points,
+            use_gpu=False,
+        )
+        field = field + bspline_evaluate(coeffs, vals.shape, use_gpu=False)
+    return field
+
+
+def test_bspline_constant_field():
+    """Iterative residual fits on a constant volume must converge to the constant.
+
+    PSDB single-grid convergence is geometric but slow (squared-weight
+    regularisation shrinks each update); 8 iterations on a coarse 6x8x8
+    control grid leave a few-percent residual which is the realistic
+    envelope for the way N4 uses the primitive.
+    """
+    shape = (12, 16, 16)
+    vals = np.full(shape, 0.7, dtype=np.float32)
+    field = _iterative_fit(vals, n_control_points=(6, 8, 8))
+    assert np.max(np.abs(field - 0.7)) < 0.1
+
+
+def test_bspline_linear_gradient():
+    """A linear gradient should be reproduced (approximately) in the interior."""
+    shape = (24, 24, 24)
+    z = np.arange(shape[0], dtype=np.float32)[:, None, None]
+    vals = np.broadcast_to(0.5 + 0.1 * z, shape).astype(np.float32)
+    field = _iterative_fit(vals, n_control_points=(8, 8, 8))
+
+    # Check interior (away from boundary smoothing).  Cubic B-spline kernel
+    # regression introduces small bias near boundaries; require the slope
+    # in the central region to match within 5%.
+    interior = field[6:-6]
+    means = interior.mean(axis=(1, 2))
+    slope = float(means[-1] - means[0]) / (interior.shape[0] - 1)
+    expected_slope = 0.1
+    assert abs(slope - expected_slope) / expected_slope < 0.05
+
+
+def test_bspline_smooth_recovery():
+    """A smooth field (sum of Gaussians) should be approximated within 10% rel error."""
+    shape = (20, 32, 32)
+    zz, yy, xx = np.meshgrid(
+        np.arange(shape[0], dtype=np.float32),
+        np.arange(shape[1], dtype=np.float32),
+        np.arange(shape[2], dtype=np.float32),
+        indexing="ij",
+    )
+    centre = (10.0, 16.0, 16.0)
+    sigma = 8.0
+    vals = (
+        1.0 + 0.3 * np.exp(-((zz - centre[0]) ** 2 + (yy - centre[1]) ** 2 + (xx - centre[2]) ** 2) / (2 * sigma**2))
+    ).astype(np.float32)
+
+    field = _iterative_fit(vals, n_control_points=(8, 12, 12))
+
+    rel_err = np.max(np.abs(field - vals) / vals)
+    assert rel_err < 0.10, f"Max relative error {rel_err:.4f} exceeds 10%"
+
+
+def test_bspline_mask_respected():
+    """Masked-out voxels must not influence the fit."""
+    shape = (12, 16, 16)
+    vals = np.zeros(shape, dtype=np.float32)
+    vals[:, :8, :] = 0.4  # left half: tissue
+    vals[:, 8:, :] = 1e6  # right half: should be ignored
+
+    mask = np.zeros(shape, dtype=bool)
+    mask[:, :8, :] = True
+
+    field = _iterative_fit(vals, n_control_points=(6, 8, 8), mask=mask)
+    # In the masked region, fitted value must be near 0.4 (not contaminated by 1e6).
+    assert np.max(np.abs(field[:, :8, :] - 0.4)) < 0.1
+
+
+def test_bspline_evaluate_resampling_shape():
+    """Evaluate at a different resolution than the fit; output shape must match."""
+    coeffs = np.ones((6, 8, 8), dtype=np.float32) * 0.5
+    field = bspline_evaluate(coeffs, target_shape=(20, 32, 32), use_gpu=False)
+    assert field.shape == (20, 32, 32)
+    np.testing.assert_allclose(field, 0.5, atol=1e-5)
+
+
+def test_bspline_invalid_control_points():
+    """Fewer than 4 control points on any axis should raise."""
+    vals = np.ones((10, 10, 10), dtype=np.float32)
+    with pytest.raises(ValueError):
+        bspline_fit(vals, None, None, n_control_points=(3, 5, 5), use_gpu=False)
+
+
+# ---------------------------------------------------------------------------
+# CPU/GPU agreement
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not GPU_AVAILABLE, reason="GPU not available")
+def test_bspline_cpu_gpu_agree_fit():
+    rng = np.random.default_rng(0)
+    shape = (16, 24, 24)
+    vals = rng.random(shape, dtype=np.float32)
+    cpu = bspline_fit(vals, None, None, n_control_points=(6, 8, 8), use_gpu=False)
+    gpu = bspline_fit(vals, None, None, n_control_points=(6, 8, 8), use_gpu=True)
+    assert np.max(np.abs(cpu - gpu)) < 1e-4
+
+
+@pytest.mark.skipif(not GPU_AVAILABLE, reason="GPU not available")
+def test_bspline_cpu_gpu_agree_evaluate():
+    rng = np.random.default_rng(1)
+    coeffs = rng.random((6, 8, 8), dtype=np.float32)
+    cpu = bspline_evaluate(coeffs, target_shape=(16, 24, 24), use_gpu=False)
+    gpu = bspline_evaluate(coeffs, target_shape=(16, 24, 24), use_gpu=True)
+    assert np.max(np.abs(cpu - gpu)) < 1e-4


### PR DESCRIPTION
## Summary
Adds a new `linumpy.gpu` subpackage: GPU-accelerated implementations of the compute-heavy operations used elsewhere in the library (FFT phase correlation, affine interpolation, morphology, B-spline fitting, bias-field correction, image-quality metrics, tissue-interface detection, and Zarr I/O), all with automatic fallback to NumPy when CuPy/CUDA is unavailable.

Land after #139.

## What changed
New package `linumpy/gpu/` (13 modules, all new):

| Module | Provides |
|--------|----------|
| `__init__.py` | Device detection, multi-GPU selection (file-locked round-robin across physical devices, honouring `CUDA_VISIBLE_DEVICES`), `to_gpu`/`to_cpu`/`get_array_module` helpers, `list_gpus`/`select_gpu`/`select_best_gpu`, env-gated via `LINUMPY_USE_GPU` |
| `interface.py` | GPU tissue-interface detection (mirrors `linumpy.geometry.interface`) |
| `array_ops.py` | GPU array utilities |
| `fft_ops.py` | GPU phase correlation / FFT ops |
| `interpolation.py` | GPU affine transform + resampling |
| `morphology.py` | GPU morphological filters |
| `corrections.py` | GPU correction kernels |
| `bspline.py` | GPU B-spline fit/evaluate |
| `bias_field.py` | GPU bias-field correction |
| `image_quality.py` | GPU image-quality metrics |
| `zarr_io.py` | GPU-aware Zarr I/O |
| `kvikio_zarr.py` | GPUDirect-Storage (kvikio) Zarr reader |
| `nvcomp_zstd.py` | GPU ZSTD compression via nvCOMP |

Plus `linumpy/tests/test_gpu_bspline.py` — B-spline correctness (partition-of-unity, constant/linear recovery, mask handling) **and** CPU/GPU numerical agreement on the fit + evaluate paths.

## Design notes
- **Transparent CPU fallback.** Every public entry point returns plain `np.ndarray` / `ArrayLike`; callers stay device-agnostic. CuPy is imported lazily and gated on availability, so importing the package never requires CUDA.
- **Device selection.** On multi-GPU hosts a file-locked counter round-robins across devices to avoid the race where concurrent forks all grab the same "most-free-memory" snapshot. Single-GPU or externally-pinned (`CUDA_VISIBLE_DEVICES`) hosts short-circuit to device 0.
- **Typing.** Optional GPU deps are typed as `Any` via the `[tool.ty]` `replace-imports-with-any` list (`cupy`, `cupyx`, `numba`, `kvikio`, `nvidia`), so the type checker stays green without CUDA installed.

## Reviewer focus
- The **CPU/GPU agreement** in `test_gpu_bspline.py` is the main automated guard for numerical equivalence — worth a close read since real CUDA isn't exercised in CI.
- **Device selection** (`__init__.py`) uses a `fcntl`-locked counter file in `$TMPDIR`; check that the locking/unlocking and the single-GPU fast path match your deployment (e.g. Nextflow setting `CUDA_VISIBLE_DEVICES` per task).
- The `kvikio`/`nvcomp` paths are CUDA-only and not covered by CI; they're verified manually on the GPU server.

## How to verify
```bash
uv run ruff check linumpy/gpu/
uv run ty check linumpy/gpu/
uv run pytest linumpy/tests/test_gpu_bspline.py -x -v   # runs the CPU path without CUDA
```
