### PR TITLE
Align imaging orientation to Allen RAS+ + transform helpers + viz contrast fix

### DIFF
--- a/linumpy/imaging/orientation.py
+++ b/linumpy/imaging/orientation.py
@@ -1,18 +1,32 @@
 """
 Utilities for handling 3D volume orientation codes and transformations.
 
-Orientation convention used throughout:
+The target convention matches the Allen Atlas RAS+ template as returned by
+:func:`linumpy.reference.allen.download_template_ras_aligned`. After
+:func:`apply_orientation_transform`, the numpy array obeys:
+
   - numpy dim 0 → SITK Z → Allen S (Superior)
-  - numpy dim 1 → SITK X → Allen R (Right)
-  - numpy dim 2 → SITK Y → Allen A (Anterior)
+  - numpy dim 1 → SITK Y → Allen A (Anterior)
+  - numpy dim 2 → SITK X → Allen R (Right)
+
+When this volume is handed to
+:func:`linumpy.reference.allen.numpy_to_sitk_image` it becomes a SITK image
+with axis order ``(X=R, Y=A, Z=S)``, which directly matches the
+RAS-aligned Allen template.  Any other target ordering would force the
+rigid registration to recover an extra 90° axis swap from gradient steps,
+which routinely fails to converge.
 
 The RAS target orientation maps:
   - output dim 0  ←→  Superior (S)
-  - output dim 1  ←→  Right (R)
-  - output dim 2  ←→  Anterior (A)
+  - output dim 1  ←→  Anterior (A)
+  - output dim 2  ←→  Right (R)
 """
 
+import json
+from pathlib import Path
+
 import numpy as np
+import SimpleITK as sitk
 
 
 def parse_orientation_code(orientation: str) -> tuple[tuple[int, ...], tuple[int, ...]]:
@@ -30,10 +44,11 @@ def parse_orientation_code(orientation: str) -> tuple[tuple[int, ...], tuple[int
     axis_permutation : tuple of int
         Source indices for each target dimension, such that
         ``np.transpose(volume, axis_permutation)`` produces a volume whose axes are
-        ordered (S, R, A) — matching the numpy_to_sitk_image convention where:
+        ordered (S, A, R) -- matching the Allen RAS+ template convention where:
+
           - numpy dim 0 → SITK Z → Allen S (Superior)
-          - numpy dim 1 → SITK X → Allen R (Right)
-          - numpy dim 2 → SITK Y → Allen A (Anterior)
+          - numpy dim 1 → SITK Y → Allen A (Anterior)
+          - numpy dim 2 → SITK X → Allen R (Right)
     axis_flips : tuple of int
         Sign for each axis **after** permutation: -1 means flip that axis, +1 means keep.
 
@@ -45,10 +60,10 @@ def parse_orientation_code(orientation: str) -> tuple[tuple[int, ...], tuple[int
 
     Examples
     --------
-    >>> parse_orientation_code('SRA')  # source already in (S, R, A) order — identity
+    >>> parse_orientation_code('SAR')  # source already in (S, A, R) order -- identity
     ((0, 1, 2), (1, 1, 1))
     >>> parse_orientation_code('PIR')  # common OCT orientation
-    ((1, 2, 0), (-1, 1, -1))
+    ((1, 0, 2), (-1, -1, 1))
     """
     if len(orientation) != 3:
         raise ValueError(f"Orientation code must be 3 letters, got '{orientation}'")
@@ -56,17 +71,18 @@ def parse_orientation_code(orientation: str) -> tuple[tuple[int, ...], tuple[int
     orientation = orientation.upper()
 
     # Map each letter to the TARGET numpy dimension and the sign for that direction.
-    # Target dimensions (after permutation):
+    # Target dimensions (after permutation) match the Allen RAS+ template's numpy
+    # ordering ((S, A, R) → SITK (R, A, S)):
     #   dim 0 → S (Superior)    letter 'S' → same direction, 'I' → flipped
-    #   dim 1 → R (Right)       letter 'R' → same direction, 'L' → flipped
-    #   dim 2 → A (Anterior)    letter 'A' → same direction, 'P' → flipped
+    #   dim 1 → A (Anterior)    letter 'A' → same direction, 'P' → flipped
+    #   dim 2 → R (Right)       letter 'R' → same direction, 'L' → flipped
     letter_map = {
         "S": (0, 1),
         "I": (0, -1),  # target dim 0 (Superior)
-        "R": (1, 1),
-        "L": (1, -1),  # target dim 1 (Right)
-        "A": (2, 1),
-        "P": (2, -1),  # target dim 2 (Anterior)
+        "A": (1, 1),
+        "P": (1, -1),  # target dim 1 (Anterior)
+        "R": (2, 1),
+        "L": (2, -1),  # target dim 2 (Right)
     }
 
     source_to_target = {}
@@ -146,3 +162,143 @@ def reorder_resolution(resolution: tuple[float, ...], permutation: tuple[int, ..
         i.e. the resolution now corresponds to the target axis ordering.
     """
     return tuple(resolution[permutation[i]] for i in range(len(permutation)))
+
+
+def sitk_transform_to_affine_matrix(transform: sitk.Transform) -> np.ndarray:
+    """
+    Convert a SimpleITK transform to a 4x4 affine matrix.
+
+    Parameters
+    ----------
+    transform : sitk.Transform
+        SimpleITK Euler3DTransform or AffineTransform.
+
+    Returns
+    -------
+    np.ndarray
+        4x4 affine matrix in (Z, Y, X) coordinate ordering, matching the
+        OME-NGFF axis declaration used by the pipeline.
+    """
+    if isinstance(transform, sitk.Euler3DTransform):
+        center = np.array(transform.GetCenter())
+        params = transform.GetParameters()
+        rx, ry, rz = params[:3]
+        translation = np.array(params[3:6])
+
+        cx, cy, cz = np.cos([rx, ry, rz])
+        sx, sy, sz = np.sin([rx, ry, rz])
+
+        rotation = np.array(
+            [
+                [cz * cy, cz * sy * sx - sz * cx, cz * sy * cx + sz * sx],
+                [sz * cy, sz * sy * sx + cz * cx, sz * sy * cx - cz * sx],
+                [-sy, cy * sx, cy * cx],
+            ]
+        )
+
+        matrix = np.eye(4)
+        matrix[:3, :3] = rotation
+        matrix[:3, 3] = translation + center - rotation @ center
+    elif isinstance(transform, sitk.AffineTransform):
+        rotation = np.array(transform.GetMatrix()).reshape(3, 3)
+        translation = np.array(transform.GetTranslation())
+        center = np.array(transform.GetCenter())
+
+        matrix = np.eye(4)
+        matrix[:3, :3] = rotation
+        matrix[:3, 3] = translation + center - rotation @ center
+    else:
+        raise ValueError(f"Unsupported transform type: {type(transform)}")
+
+    permute = np.array([[0, 0, 1, 0], [0, 1, 0, 0], [1, 0, 0, 0], [0, 0, 0, 1]])
+    return permute @ matrix @ permute.T
+
+
+def store_transform_in_metadata(zarr_path: Path, transform: sitk.Transform) -> None:
+    """Store a transform in OME-Zarr metadata as an affine transform."""
+    affine_matrix = sitk_transform_to_affine_matrix(transform)
+    zattrs_path = Path(zarr_path) / ".zattrs"
+
+    if not zattrs_path.exists():
+        raise FileNotFoundError(f".zattrs not found: {zarr_path}")
+
+    with Path(zattrs_path).open(encoding="utf-8") as handle:
+        metadata = json.load(handle)
+
+    affine_transform = {"type": "affine", "affine": affine_matrix.flatten().tolist()}
+
+    multiscales = metadata.get("multiscales", [])
+    if not multiscales:
+        raise ValueError("No multiscales entry found in metadata")
+
+    for dataset in multiscales[0].get("datasets", []):
+        existing = dataset.get("coordinateTransformations", [])
+        dataset["coordinateTransformations"] = [affine_transform, *existing]
+
+    with Path(zattrs_path).open("w", encoding="utf-8") as handle:
+        json.dump(metadata, handle, indent=2)
+
+
+def compute_centered_reference_and_transform(
+    moving_sitk: sitk.Image, transform: sitk.Transform, output_spacing: tuple[float, float, float] | None = None
+) -> tuple[sitk.Image, sitk.Transform]:
+    """
+    Compute a centered reference image and the composite transform for resampling.
+
+    Parameters
+    ----------
+    moving_sitk : sitk.Image
+        The input moving image.
+    transform : sitk.Transform
+        Transform to apply (moving -> fixed/RAS space).
+    output_spacing : tuple of float, optional
+        Output voxel spacing. If None, uses the moving image spacing.
+
+    Returns
+    -------
+    tuple[sitk.Image, sitk.Transform]
+        Reference image with origin at 0 and the composite transform that maps
+        output coordinates back into the moving image.
+    """
+    if output_spacing is None:
+        output_spacing = moving_sitk.GetSpacing()
+
+    size = moving_sitk.GetSize()
+    corners = [
+        (0, 0, 0),
+        (size[0] - 1, 0, 0),
+        (0, size[1] - 1, 0),
+        (0, 0, size[2] - 1),
+        (size[0] - 1, size[1] - 1, 0),
+        (size[0] - 1, 0, size[2] - 1),
+        (0, size[1] - 1, size[2] - 1),
+        (size[0] - 1, size[1] - 1, size[2] - 1),
+    ]
+
+    inverse_transform = transform.GetInverse()
+    transformed_points = []
+    for idx in corners:
+        point = moving_sitk.TransformContinuousIndexToPhysicalPoint(idx)
+        transformed_points.append(inverse_transform.TransformPoint(point))
+
+    points = np.array(transformed_points)
+    points_min = points.min(axis=0)
+    points_max = points.max(axis=0)
+
+    spacing = np.array(output_spacing)
+    extent = points_max - points_min
+    new_size = np.ceil(extent / spacing).astype(int)
+
+    reference = sitk.Image([int(axis_size) for axis_size in new_size], moving_sitk.GetPixelIDValue())
+    reference.SetSpacing(tuple(spacing))
+    reference.SetOrigin((0.0, 0.0, 0.0))
+    reference.SetDirection((1, 0, 0, 0, 1, 0, 0, 0, 1))
+
+    shift_transform = sitk.TranslationTransform(3)
+    shift_transform.SetOffset(tuple(points_min))
+
+    composite = sitk.CompositeTransform(3)
+    composite.AddTransform(transform)
+    composite.AddTransform(shift_transform)
+
+    return reference, composite

--- a/linumpy/imaging/visualization.py
+++ b/linumpy/imaging/visualization.py
@@ -52,17 +52,17 @@ def save_orthogonal_views(
 
     width_ratio = [i.shape[1] for i in (image_z, image_x, image_y)]
 
-    allvals = np.concatenate([image_x.flatten(), image_y.flatten(), image_z.flatten()])
-    vmin = float(np.min(allvals))
-    vmax = float(np.percentile(allvals, percentile_max))
+    def _panel_vmax(arr: np.ndarray) -> float:
+        pos = arr[arr > 0]
+        return float(np.percentile(pos, percentile_max)) if pos.size > 0 else 1.0
 
     fig, ax = plt.subplots(1, 3, width_ratios=width_ratio)
     fig.set_size_inches(24, 10)
     fig.set_dpi(512)
 
-    ax[0].imshow(image_z, cmap=cmap, origin="lower", vmin=vmin, vmax=vmax)
-    ax[1].imshow(image_x, cmap=cmap, origin="lower", vmin=vmin, vmax=vmax)
-    ax[2].imshow(image_y, cmap=cmap, origin="lower", vmin=vmin, vmax=vmax)
+    ax[0].imshow(image_z, cmap=cmap, origin="lower", vmin=0, vmax=_panel_vmax(image_z))
+    ax[1].imshow(image_x, cmap=cmap, origin="lower", vmin=0, vmax=_panel_vmax(image_x))
+    ax[2].imshow(image_y, cmap=cmap, origin="lower", vmin=0, vmax=_panel_vmax(image_y))
 
     for a in ax:
         a.set_axis_off()
@@ -237,8 +237,8 @@ def _panel_labels_from_orientation(orientation: str) -> tuple | None:
     then computes panel names and axis labels from the source-dimension letters.
 
     The volume has shape (Z=dim0, Y=dim1, X=dim2).
-    Panel 1 is ``image[:, x_slice, :]`` — shows (dim0, dim2)=(Z,X), fixes dim1 (Y).
-    Panel 2 is ``image[:, :, y_slice]``  — shows (dim0, dim1)=(Z,Y), fixes dim2 (X).
+    Panel 1 is ``image[:, x_slice, :]`` -- shows (dim0, dim2)=(Z,X), fixes dim1 (Y).
+    Panel 2 is ``image[:, :, y_slice]``  -- shows (dim0, dim1)=(Z,Y), fixes dim2 (X).
 
     Parameters
     ----------
@@ -261,7 +261,7 @@ def _panel_labels_from_orientation(orientation: str) -> tuple | None:
     code = orientation.strip("'\" ").upper()
     try:
         parse_orientation_code(code)  # validation only
-    except (ValueError, KeyError):
+    except ValueError, KeyError:
         return None
 
     a0, a1, a2 = code  # anatomical letter for source dim0, dim1, dim2
@@ -415,9 +415,9 @@ def save_annotated_views(
     y_slice = y_slice if y_slice is not None else n_cols // 2
 
     # Derive panel titles and axis labels from orientation when available.
-    _orient = _panel_labels_from_orientation(orientation) if orientation else None
-    if _orient:
-        p1_name, p1_xlabel, p1_ylabel, p1_fixed, p2_name, p2_xlabel, p2_ylabel, p2_fixed = _orient
+    orient = _panel_labels_from_orientation(orientation) if orientation else None
+    if orient:
+        p1_name, p1_xlabel, p1_ylabel, p1_fixed, p2_name, p2_xlabel, p2_ylabel, p2_fixed = orient
         title1 = f"{p1_name} ({p1_ylabel}\u00d7{p1_xlabel}) view at {p1_fixed}={x_slice}"
         title2 = f"{p2_name} ({p2_ylabel}\u00d7{p2_xlabel}) view at {p2_fixed}={y_slice}"
         xlabel1, ylabel1 = p1_xlabel, p1_ylabel
@@ -453,9 +453,10 @@ def save_annotated_views(
         aspect1 = "equal"
         aspect2 = "equal"
 
-    allvals = np.concatenate([image_zy.flatten(), image_zx.flatten()])
-    vmin = float(np.min(allvals))
-    vmax = float(np.percentile(allvals, 99.9))
+    allvals = np.concatenate([image_zy.ravel(), image_zx.ravel()])
+    display_vals = allvals[np.isfinite(allvals) & (allvals > 0)]
+    vmin = 0.0
+    vmax = float(np.percentile(display_vals, 99.9)) if display_vals.size > 0 else 1.0
 
     fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(20, 12), facecolor="black")
     for ax in [ax1, ax2]:
@@ -508,8 +509,8 @@ def save_annotated_views(
         else ""
     )
     fig.suptitle(
-        f"Z-Slice Alignment View — {n_input_slices} input slices ({slice_range_str}){orient_note}\n"
-        f"Volume: {n_z_voxels} Z × {n_rows} X × {n_cols} Y voxels"
+        f"Z-Slice Alignment View -- {n_input_slices} input slices ({slice_range_str}){orient_note}\n"
+        f"Volume: {n_z_voxels} Z x {n_rows} X x {n_cols} Y voxels"
         f"  ·  NOTE: axes reflect raw acquisition geometry, NOT final neuroimaging orientation",
         color="yellow",
         fontsize=11,

--- a/linumpy/tests/test_imaging_orientation.py
+++ b/linumpy/tests/test_imaging_orientation.py
@@ -22,68 +22,64 @@ def _make_gradient_vol(shape=(4, 6, 8)):
 
 
 # ---------------------------------------------------------------------------
-# parse_orientation_code — valid codes
+# parse_orientation_code -- valid codes
 # ---------------------------------------------------------------------------
 
 
 class TestParseOrientationCodeValid:
-    def test_identity_SRA(self):
-        """SRA is the native target order → identity permutation."""
-        perm, flips = parse_orientation_code("SRA")
+    def test_identity_SAR(self):
+        """SAR is the native target order → identity permutation."""
+        perm, flips = parse_orientation_code("SAR")
         assert perm == (0, 1, 2)
         assert flips == (1, 1, 1)
 
     def test_identity_lowercase(self):
         """Input is case-insensitive."""
-        perm, flips = parse_orientation_code("sra")
+        perm, flips = parse_orientation_code("sar")
         assert perm == (0, 1, 2)
         assert flips == (1, 1, 1)
 
     def test_PIR(self):
         """PIR is a common OCT orientation."""
         perm, flips = parse_orientation_code("PIR")
-        assert perm == (1, 2, 0)
-        assert flips == (-1, 1, -1)
+        # P→target dim1 (flip), I→target dim0 (flip), R→target dim2.
+        # target_to_source: 0→(1,-1), 1→(0,-1), 2→(2,1)
+        assert perm == (1, 0, 2)
+        assert flips == (-1, -1, 1)
 
     def test_RAS(self):
-        """RAS orientation (Allen/NIfTI default, but dim0=R not S)."""
+        """RAS source orientation."""
         perm, flips = parse_orientation_code("RAS")
-        # R→target-dim1, A→target-dim2, S→target-dim0
-        # source: dim0=R, dim1=A, dim2=S
-        # target order (S, R, A): dim0←source_dim2, dim1←source_dim0, dim2←source_dim1
-        assert perm == (2, 0, 1)
+        # R→target dim2, A→target dim1, S→target dim0.
+        # target_to_source: 0→(2,1), 1→(1,1), 2→(0,1)
+        assert perm == (2, 1, 0)
         assert flips == (1, 1, 1)
 
     def test_LPS(self):
         """LPS (opposite of RAS)."""
         perm, flips = parse_orientation_code("LPS")
-        # L→target-dim1(flip), P→target-dim2(flip), S→target-dim0
-        # source: dim0=L, dim1=P, dim2=S
-        # S in dim2 → target dim0, so source_dim2 for target dim0
-        # L in dim0 → target dim1, flip; P in dim1 → target dim2, flip
-        assert perm == (2, 0, 1)
+        # L→target dim2(flip), P→target dim1(flip), S→target dim0.
+        # target_to_source: 0→(2,1), 1→(1,-1), 2→(0,-1)
+        assert perm == (2, 1, 0)
         assert flips == (1, -1, -1)
 
     def test_all_flipped_ILP(self):
         """ILP: all three axes need to be flipped (I→S, L→R, P→A)."""
         perm, flips = parse_orientation_code("ILP")
-        # I at dim0 → target dim0 (Superior), flip; L at dim1 → target dim1 (Right), flip;
-        # P at dim2 → target dim2 (Anterior), flip
+        # I→target 0(flip), L→target 2(flip), P→target 1(flip)
         assert all(f == -1 for f in flips)
         assert sorted(perm) == [0, 1, 2]
 
     def test_AIR(self):
         """AIR: A in dim0, I in dim1, R in dim2."""
         perm, flips = parse_orientation_code("AIR")
-        # A at dim0 → target dim2, sign=+1
-        # I at dim1 → target dim0, sign=-1
-        # R at dim2 → target dim1, sign=+1
-        # target_to_source: {0: (1, -1), 1: (2, 1), 2: (0, 1)}
-        assert perm == (1, 2, 0)
+        # A→target 1, I→target 0(flip), R→target 2.
+        # target_to_source: 0→(1,-1), 1→(0,1), 2→(2,1)
+        assert perm == (1, 0, 2)
         assert flips == (-1, 1, 1)
 
     def test_output_type_is_tuple(self):
-        perm, flips = parse_orientation_code("SRA")
+        perm, flips = parse_orientation_code("SAR")
         assert isinstance(perm, tuple)
         assert isinstance(flips, tuple)
 
@@ -94,19 +90,19 @@ class TestParseOrientationCodeValid:
 
     def test_perm_is_valid_permutation(self):
         """axis_permutation must be a valid permutation of (0,1,2)."""
-        for code in ("SRA", "PIR", "RAS", "LPS", "AIR", "ILP", "SAR"):
+        for code in ("SAR", "PIR", "RAS", "LPS", "AIR", "ILP", "SRA"):
             perm, _ = parse_orientation_code(code)
             assert sorted(perm) == [0, 1, 2], f"Bad permutation for {code}: {perm}"
 
     def test_flips_only_1_or_minus1(self):
-        for code in ("SRA", "PIR", "RAS", "LPS", "AIR", "ILP", "SAR"):
+        for code in ("SAR", "PIR", "RAS", "LPS", "AIR", "ILP", "SRA"):
             _, flips = parse_orientation_code(code)
             for f in flips:
                 assert f in (1, -1), f"Unexpected flip value {f} for {code}"
 
 
 # ---------------------------------------------------------------------------
-# parse_orientation_code — error cases
+# parse_orientation_code -- error cases
 # ---------------------------------------------------------------------------
 
 
@@ -129,14 +125,14 @@ class TestParseOrientationCodeErrors:
             parse_orientation_code("RRS")
 
     def test_duplicate_axis_opposite_direction(self):
-        """RLS has R=dim1 and L=dim1 — same target axis."""
+        """RLS has R=dim1 and L=dim1 -- same target axis."""
         with pytest.raises(ValueError):
             parse_orientation_code("RLS")
 
     def test_missing_axis(self):
         """SAI uses neither R nor L so target-dim1 is missing."""
-        # S→dim0, A→dim2, I→dim0 — actually duplicate! Let's use a truly missing case.
-        # SAP: S→0, A→2, P→2 — duplicate (A and P both target dim2).
+        # S→dim0, A→dim2, I→dim0 -- actually duplicate! Let's use a truly missing case.
+        # SAP: S→0, A→2, P→2 -- duplicate (A and P both target dim2).
         with pytest.raises(ValueError):
             parse_orientation_code("SAP")
 
@@ -256,13 +252,13 @@ class TestOrientationSemantics:
     output dimension.
     """
 
-    def test_SRA_dim0_is_superior(self):
-        """With 'SRA', dim0 is already Superior.  Reorientation is identity."""
+    def test_SAR_dim0_is_superior(self):
+        """With 'SAR', dim0 is already Superior.  Reorientation is identity."""
         # Volume increases only along dim0 (Superior direction)
         vol = np.zeros((10, 5, 5), dtype=np.float32)
         vol[:, 2, 2] = np.arange(10)
 
-        perm, flips = parse_orientation_code("SRA")
+        perm, flips = parse_orientation_code("SAR")
         result = apply_orientation_transform(vol, perm, flips)
 
         # After identity reorientation, variation should still be along dim0
@@ -270,15 +266,15 @@ class TestOrientationSemantics:
         col = result[:, 2, 2]
         assert col[-1] > col[0], "Superior direction should still increase along dim0"
 
-    def test_IRA_superior_flipped_to_dim0(self):
-        """With 'IRA', dim0 is Inferior → after reorientation it becomes Superior (flipped)."""
+    def test_IAR_superior_flipped_to_dim0(self):
+        """With 'IAR', dim0 is Inferior → after reorientation it becomes Superior (flipped)."""
         vol = np.zeros((10, 5, 5), dtype=np.float32)
         vol[:, 2, 2] = np.arange(10)  # value increases in Inferior direction
 
-        perm, flips = parse_orientation_code("IRA")
+        perm, flips = parse_orientation_code("IAR")
         result = apply_orientation_transform(vol, perm, flips)
 
-        # 'IRA': I at dim0 → target dim0 with flip=-1 (Inferior→Superior).
+        # 'IAR': I at dim0 → target dim0 with flip=-1 (Inferior→Superior).
         # Values increasing along Inferior (dim0 source) should decrease along dim0 output.
         slice_col = result[:, 2, 2]
         assert slice_col[0] > slice_col[-1], "After I→S flip, values should decrease along output dim0 (Superior direction)"
@@ -321,16 +317,16 @@ class TestReorderResolution:
 
     def test_matches_orientation_permutation(self):
         """reorder_resolution must be consistent with parse_orientation_code."""
-        # For 'PIR': perm=(1,2,0)
-        # Source resolution: (res_z=0.01, res_x=0.02, res_y=0.03) in (P, I, R) order
-        # After reorientation to (S, R, A):
+        # For 'PIR': perm=(1, 0, 2)
+        # Source resolution: (0.01, 0.02, 0.03) in (P, I, R) order
+        # After reorientation to (S, A, R):
         #   target_dim0 = source_dim1 (I), so resolution[target0] = 0.02
-        #   target_dim1 = source_dim2 (R), so resolution[target1] = 0.03
-        #   target_dim2 = source_dim0 (P), so resolution[target2] = 0.01
+        #   target_dim1 = source_dim0 (P), so resolution[target1] = 0.01
+        #   target_dim2 = source_dim2 (R), so resolution[target2] = 0.03
         perm, _ = parse_orientation_code("PIR")
         source_res = (0.01, 0.02, 0.03)
         result = reorder_resolution(source_res, perm)
-        assert result == (0.02, 0.03, 0.01)
+        assert result == (0.02, 0.01, 0.03)
 
     def test_reorder_preserves_len(self):
         perm, _ = parse_orientation_code("AIR")

--- a/linumpy/tests/test_imaging_orientation_ras.py
+++ b/linumpy/tests/test_imaging_orientation_ras.py
@@ -1,0 +1,103 @@
+from pathlib import Path
+
+import numpy as np
+import pytest
+import SimpleITK as sitk
+
+from linumpy.imaging.orientation import (
+    compute_centered_reference_and_transform,
+    sitk_transform_to_affine_matrix,
+    store_transform_in_metadata,
+)
+
+
+class TestSitkTransformToAffineMatrix:
+    def test_identity_transform_yields_identity_matrix(self):
+        transform = sitk.Euler3DTransform()
+        matrix = sitk_transform_to_affine_matrix(transform)
+        assert matrix.shape == (4, 4)
+        np.testing.assert_allclose(matrix, np.eye(4), atol=1e-12)
+
+    def test_affine_transform_translation_is_permuted_to_zyx(self):
+        transform = sitk.AffineTransform(3)
+        transform.SetTranslation((1.0, 2.0, 3.0))
+        matrix = sitk_transform_to_affine_matrix(transform)
+        np.testing.assert_allclose(matrix[:3, 3], [3.0, 2.0, 1.0], atol=1e-12)
+
+    def test_unsupported_transform_type_raises(self):
+        transform = sitk.TranslationTransform(3)
+        with pytest.raises(ValueError, match="Unsupported transform type"):
+            sitk_transform_to_affine_matrix(transform)
+
+
+class TestComputeCenteredReferenceAndTransform:
+    @staticmethod
+    def _make_moving(shape=(20, 20, 20), spacing=(0.1, 0.1, 0.1)):
+        z, y, x = np.indices(shape, dtype=np.float32)
+        cz, cy, cx = shape[0] / 2, shape[1] / 2, shape[2] / 2
+        rz, ry, rx = shape[0] * 0.3, shape[1] * 0.3, shape[2] * 0.3
+        mask = ((z - cz) / rz) ** 2 + ((y - cy) / ry) ** 2 + ((x - cx) / rx) ** 2 < 1
+        image = sitk.GetImageFromArray(mask.astype(np.float32))
+        image.SetSpacing((spacing[2], spacing[1], spacing[0]))
+        image.SetOrigin((0.0, 0.0, 0.0))
+        image.SetDirection((1, 0, 0, 0, 1, 0, 0, 0, 1))
+        return image, int(mask.sum())
+
+    def test_reference_origin_is_zero(self):
+        moving, _ = self._make_moving()
+        reference, _ = compute_centered_reference_and_transform(moving, sitk.Euler3DTransform())
+        assert reference.GetOrigin() == pytest.approx((0.0, 0.0, 0.0))
+
+    def test_rotation_preserves_brain_volume(self):
+        moving, brain_voxels = self._make_moving()
+        transform = sitk.Euler3DTransform()
+        transform.SetRotation(np.deg2rad(15), np.deg2rad(-10), np.deg2rad(30))
+        transform.SetTranslation((0.3, -0.2, 0.1))
+        center_mm = moving.TransformContinuousIndexToPhysicalPoint([axis / 2.0 for axis in moving.GetSize()])
+        transform.SetCenter(center_mm)
+
+        reference, composite = compute_centered_reference_and_transform(moving, transform)
+
+        resampler = sitk.ResampleImageFilter()
+        resampler.SetReferenceImage(reference)
+        resampler.SetTransform(composite)
+        resampler.SetInterpolator(sitk.sitkLinear)
+        resampler.SetDefaultPixelValue(0.0)
+        output = resampler.Execute(moving)
+        array = sitk.GetArrayFromImage(output)
+
+        nonzero = (array > 0.5).sum()
+        assert abs(int(nonzero) - brain_voxels) / brain_voxels < 0.05
+
+
+def test_store_transform_in_metadata_writes_affine_block(tmp_path: Path):
+    import json
+
+    store_path = tmp_path / "test.ome.zarr"
+    store_path.mkdir()
+    initial_attrs = {
+        "multiscales": [
+            {
+                "version": "0.4",
+                "axes": [
+                    {"name": "z", "type": "space", "unit": "millimeter"},
+                    {"name": "y", "type": "space", "unit": "millimeter"},
+                    {"name": "x", "type": "space", "unit": "millimeter"},
+                ],
+                "datasets": [{"path": "0", "coordinateTransformations": []}],
+            }
+        ]
+    }
+    (store_path / ".zattrs").write_text(json.dumps(initial_attrs))
+
+    transform = sitk.Euler3DTransform()
+    transform.SetTranslation((0.5, 1.5, 2.5))
+
+    store_transform_in_metadata(store_path, transform)
+
+    with (store_path / ".zattrs").open() as handle:
+        metadata = json.load(handle)
+
+    affine = metadata["multiscales"][0]["datasets"][0]["coordinateTransformations"][0]
+    matrix = np.array(affine["affine"]).reshape(4, 4)
+    np.testing.assert_allclose(matrix[:3, 3], [2.5, 1.5, 0.5], atol=1e-12)


### PR DESCRIPTION
## Summary
Extends `linumpy.imaging` to align 3D volumes to the **Allen RAS+ template** convention, and fixes contrast scaling in the orthogonal-view renderers. Changes the orientation target from `(S, R, A)` to `(S, A, R)` so a reoriented volume feeds directly into `numpy_to_sitk_image` as a SITK image ordered `(X=R, Y=A, Z=S)` — matching the Allen template and avoiding a spurious 90° rotation that the rigid registration was failing to recover.

Land after #140.

## What changed
- **`orientation.py` — convention change.** `parse_orientation_code` now targets `(S, A, R)` instead of `(S, R, A)`. The `letter_map` and all docstring/examples are updated. **This changes the permutation/flip output for every input code**, so any caller caching or asserting on a specific permutation needs updating.
- **`orientation.py` — new helpers** for downstream RAS alignment:
  - `sitk_transform_to_affine_matrix` — Euler3D / AffineTransform → 4×4 matrix in `(Z, Y, X)` OME-NGFF ordering.
  - `store_transform_in_metadata` — writes that affine as an OME-Zarr `coordinateTransformations` block.
  - `compute_centered_reference_and_transform` — builds a zero-origin reference grid and the composite transform for resampling a moving image into it.
- **`visualization.py` — contrast fix.** Orthogonal and annotated views now compute a per-panel `vmax` from **positive, finite** voxels only (percentile) and clamp `vmin = 0`, instead of a single global min/percentile over all panels. Fixes washed-out previews when one panel is dominated by zero/negative background.
- **Tests.** `test_imaging_orientation.py` re-targeted to the `(S, A, R)` convention (identity is now `SAR`, `PIR`/`RAS`/`LPS` expectations updated). New `test_imaging_orientation_ras.py` covers the three new helpers (identity/translation permutation, brain-volume preservation under rotation, affine-block round-trip into `.zattrs`).

## Reviewer focus
- **The convention change is load-bearing and subtle.** It exists so the output matches the Allen template handed to `register_3d_rigid_to_allen` (next PR). The rationale is in the module docstring; the updated `PIR`/`RAS`/`LPS` test expectations are the best place to confirm the new mapping is correct.
- `compute_centered_reference_and_transform` derives the output grid size from the transformed corner points — verify the rounding (`np.ceil`) matches how downstream resamplers consume it.
- `store_transform_in_metadata` **prepends** an affine to each dataset's existing `coordinateTransformations`; check the ordering is right for your reader.

## How to verify
```bash
uv run ruff check linumpy/imaging/
uv run ty check linumpy/imaging/
uv run pytest linumpy/tests/test_imaging_orientation.py linumpy/tests/test_imaging_orientation_ras.py -x -v
```
