### PR TITLE
chore(deps): source linum-basic from FIrgolitsch fork (upstream-staging)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -200,8 +200,11 @@ override-dependencies = [
 ]
 
 [tool.uv.sources]
-# linum-basic is not published on PyPI; resolve it from the lab repository.
-linum-basic = { git = "https://github.com/linum-uqam/Linum-BaSiC.git", branch = "modernisation" }
+# linum-basic is not published on PyPI.
+# Temporarily sourced from the @FIrgolitsch fork (upstream-staging branch) so the
+# main linumpy tree remains installable while linum-basic changes are staged for
+# upstream. Switch back to linum-uqam/Linum-BaSiC@modernisation once those land.
+linum-basic = { git = "https://github.com/FIrgolitsch/Linum-BaSiC.git", branch = "upstream-staging" }
 
 [tool.pytest.ini_options]
 filterwarnings = [

--- a/uv.lock
+++ b/uv.lock
@@ -1389,7 +1389,7 @@ wheels = [
 [[package]]
 name = "linum-basic"
 version = "2.0.0"
-source = { git = "https://github.com/linum-uqam/Linum-BaSiC.git?branch=modernisation#511c88c01173faaf548b4cf351901ae9bac298cc" }
+source = { git = "https://github.com/FIrgolitsch/Linum-BaSiC.git?branch=upstream-staging#65c0a92bc7f263cdd854b1133cb3591c707af430" }
 dependencies = [
     { name = "joblib" },
     { name = "numpy" },
@@ -1491,7 +1491,7 @@ requires-dist = [
     { name = "kvikio-cu12", marker = "extra == 'gds-cuda12'" },
     { name = "kvikio-cu13", marker = "extra == 'gds'" },
     { name = "linkify-it-py", marker = "extra == 'docs'", specifier = ">=2.1" },
-    { name = "linum-basic", extras = ["viz"], git = "https://github.com/linum-uqam/Linum-BaSiC.git?branch=modernisation" },
+    { name = "linum-basic", extras = ["viz"], git = "https://github.com/FIrgolitsch/Linum-BaSiC.git?branch=upstream-staging" },
     { name = "matplotlib" },
     { name = "myst-parser", marker = "extra == 'docs'", specifier = ">=5.0" },
     { name = "napari" },


### PR DESCRIPTION
## What

Redirects the `linum-basic` uv source so the main linumpy tree remains installable.

| | repo | branch |
|---|---|---|
| **before** | `linum-uqam/Linum-BaSiC` | `modernisation` |
| **after**  | `FIrgolitsch/Linum-BaSiC` | `upstream-staging` |

## Why

`linum-basic` is not published on PyPI and is currently resolved from the upstream lab repo's `modernisation` branch. Changes needed to keep linumpy installable are staged on the `FIrgolitsch/Linum-BaSiC` fork (`upstream-staging` branch) pending upstream review. Until those land in `linum-uqam/Linum-BaSiC`, this redirect is required for `uv` resolution to succeed.

## Changes

- `pyproject.toml` — `[tool.uv.sources]` `linum-basic` entry pointed at the fork + comment noting the temporary redirect
- `uv.lock` — refreshed pinned rev (`511c88c0` → `65c0a92b`)

## Scope

Intentionally minimal — one dependency source line + lockfile. No runtime code changes.

## Revert

Once the staged changes merge into `linum-uqam/Linum-BaSiC` (target: `modernisation`), flip the source line back and re-lock.

---
*This PR is opened outside the main working tree; conflicts with other in-flight dep changes can be resolved on review.*